### PR TITLE
Add "command" flag to "connect" command

### DIFF
--- a/cmds/choose.go
+++ b/cmds/choose.go
@@ -65,7 +65,7 @@ func Choose() *cli.Command {
 			}
 			choice := strings.TrimSpace(cmdOutput.String())
 			// TODO: get choice from Session structs array
-			connect.Connect(choice, false)
+			connect.Connect(choice, false, "")
 			return nil
 		},
 	}

--- a/cmds/connect.go
+++ b/cmds/connect.go
@@ -21,7 +21,7 @@ func Connect() *cli.Command {
 			&cli.StringFlag{
 				Name:    "command",
 				Aliases: []string{"c"},
-				Usage:   "Execute a command when connecting to a new session.",
+				Usage:   "Execute a command when connecting to a new session. Will be ignored if the session exists.",
 			},
 		},
 		Action: func(cCtx *cli.Context) error {

--- a/cmds/connect.go
+++ b/cmds/connect.go
@@ -18,14 +18,20 @@ func Connect() *cli.Command {
 				Aliases: []string{"s"},
 				Usage:   "Always switch the session (and never attach). This is useful for third-party tools like Raycast.",
 			},
+			&cli.StringFlag{
+				Name:    "command",
+				Aliases: []string{"c"},
+				Usage:   "Execute a command when connecting to a new session.",
+			},
 		},
 		Action: func(cCtx *cli.Context) error {
 			session := cCtx.Args().First()
 			alwaysSwitch := cCtx.Bool("switch")
+			command := cCtx.String("command")
 			if session == "" {
 				return cli.Exit("No session provided", 0)
 			}
-			connect.Connect(session, alwaysSwitch)
+			connect.Connect(session, alwaysSwitch, command)
 			return nil
 		},
 	}

--- a/connect/connect.go
+++ b/connect/connect.go
@@ -6,12 +6,12 @@ import (
 	"github.com/joshmedeski/sesh/zoxide"
 )
 
-func Connect(choice string, alwaysSwitch bool) error {
+func Connect(choice string, alwaysSwitch bool, command string) error {
 	session := session.Determine(choice)
 	zoxide.Add(session.Path)
 	tmux.Connect(tmux.TmuxSession{
 		Name: session.Name,
 		Path: session.Path,
-	}, alwaysSwitch)
+	}, alwaysSwitch, command)
 	return nil
 }

--- a/session/determine.go
+++ b/session/determine.go
@@ -1,21 +1,18 @@
 package session
 
 import (
-	"fmt"
-	"os"
+	"log"
 )
 
 func Determine(choice string) Session {
-	path, err := DeterminPath(choice)
+	path, err := DeterminePath(choice)
 	if err != nil {
-		fmt.Println("Couldn't determine the session path", err)
-		os.Exit(1)
+		log.Fatal("Couldn't determine the session path", err)
 	}
 
 	name := DetermineName(path)
 	if name == "" {
-		fmt.Println("Couldn't determine the session name", err)
-		os.Exit(1)
+		log.Fatal("Couldn't determine the session name", err)
 	}
 
 	return Session{

--- a/session/determine.go
+++ b/session/determine.go
@@ -8,13 +8,13 @@ import (
 func Determine(choice string) Session {
 	path, err := DeterminPath(choice)
 	if err != nil {
-		fmt.Println("Could't determine the session path", err)
+		fmt.Println("Couldn't determine the session path", err)
 		os.Exit(1)
 	}
 
 	name := DetermineName(path)
 	if name == "" {
-		fmt.Println("Could't determine the session name", err)
+		fmt.Println("Couldn't determine the session name", err)
 		os.Exit(1)
 	}
 

--- a/session/path.go
+++ b/session/path.go
@@ -7,7 +7,7 @@ import (
 	"github.com/joshmedeski/sesh/tmux"
 )
 
-func DeterminPath(choice string) (string, error) {
+func DeterminePath(choice string) (string, error) {
 	fullPath := dir.FullPath(choice)
 	if path.IsAbs(fullPath) {
 		return fullPath, nil

--- a/tmux/tmux.go
+++ b/tmux/tmux.go
@@ -2,7 +2,7 @@ package tmux
 
 import (
 	"bytes"
-	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"strings"
@@ -85,9 +85,9 @@ func Connect(s TmuxSession, alwaysSwitch bool, command string) error {
 	if !isSession {
 		_, err := NewSession(s)
 		if err != nil {
-			fmt.Println(err)
+			log.Fatal(err)
 		}
-		if command != "" && err == nil {
+		if command != "" {
 			runPersistentCommand(s.Name, command)
 		}
 	}

--- a/tmux/tmux.go
+++ b/tmux/tmux.go
@@ -64,6 +64,14 @@ func switchSession(session string) error {
 	return nil
 }
 
+func runPersistentCommand(session string, command string) error {
+	finalCmd := []string{"send-keys", "-t", session, command, "Enter"}
+	if _, err := tmuxCmd(finalCmd); err != nil {
+		return err
+	}
+	return nil
+}
+
 func NewSession(s TmuxSession) (string, error) {
 	out, err := tmuxCmd([]string{"new-session", "-d", "-s", s.Name, "-c", s.Path})
 	if err != nil {
@@ -72,12 +80,15 @@ func NewSession(s TmuxSession) (string, error) {
 	return out, nil
 }
 
-func Connect(s TmuxSession, alwaysSwitch bool) error {
+func Connect(s TmuxSession, alwaysSwitch bool, command string) error {
 	isSession := IsSession(s.Name)
 	if !isSession {
 		_, err := NewSession(s)
 		if err != nil {
 			fmt.Println(err)
+		}
+		if command != "" && err == nil {
+			runPersistentCommand(s.Name, command)
 		}
 	}
 	isAttached := isAttached()


### PR DESCRIPTION
- Adds the `command` flag to the `connect` command
- Decreases verbosity by substituting `fmt.Println(text)` followed by `os.Exit(1)` with `log.Fatal(text)` (only in edited files)
- Fixes a couple typos (only in edited files)