### PR TITLE
Fix zoxide no results

### DIFF
--- a/zoxide/list.go
+++ b/zoxide/list.go
@@ -18,7 +18,7 @@ type ZoxideResult struct {
 func List(tmuxSessions []*tmux.TmuxSession) ([]*ZoxideResult, error) {
 	output, err := zoxideCmd([]string{"query", "-ls"})
 	if err != nil {
-		return nil, err
+		return []*ZoxideResult{}, nil
 	}
 	cleanOutput := strings.TrimSpace(string(output))
 	list := strings.Split(cleanOutput, "\n")

--- a/zoxide/list.go
+++ b/zoxide/list.go
@@ -22,8 +22,12 @@ func List(tmuxSessions []*tmux.TmuxSession) ([]*ZoxideResult, error) {
 	}
 	cleanOutput := strings.TrimSpace(string(output))
 	list := strings.Split(cleanOutput, "\n")
+	listLen := len(list)
+	if listLen == 1 && list[0] == "" {
+		return []*ZoxideResult{}, nil
+	}
 
-	results := make([]*ZoxideResult, 0, len(list))
+	results := make([]*ZoxideResult, 0, listLen)
 	tmuxSessionPaths := make(map[string]struct{})
 	for _, session := range tmuxSessions {
 		tmuxSessionPaths[session.Path] = struct{}{}


### PR DESCRIPTION
Fix #11 

When zoxide isn't installed or doesn't return any results, the zoxide.List command will just return an empty slice