### PR TITLE
Zoxide fallback

### DIFF
--- a/session/path.go
+++ b/session/path.go
@@ -1,10 +1,13 @@
 package session
 
 import (
+	"fmt"
+	"os"
 	"path"
 
 	"github.com/joshmedeski/sesh/dir"
 	"github.com/joshmedeski/sesh/tmux"
+	"github.com/joshmedeski/sesh/zoxide"
 )
 
 func DeterminePath(choice string) (string, error) {
@@ -16,7 +19,15 @@ func DeterminePath(choice string) (string, error) {
 	if tmux.IsSession(fullPath) {
 		return fullPath, nil
 	}
-	// TODO: if not absolute path, get zoxide results
-	// TODO: get zoxide result if not path and tmux session doesn't exist
+
+	zoxideResult, err := zoxide.Query(fullPath)
+	if err != nil {
+		fmt.Println("Couldn't query zoxide", err)
+		os.Exit(1)
+	}
+	if zoxideResult != nil {
+		return zoxideResult.Path, nil
+	}
+
 	return fullPath, nil
 }

--- a/zoxide/add.go
+++ b/zoxide/add.go
@@ -1,0 +1,20 @@
+package zoxide
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+)
+
+func Add(result string) {
+	if !path.IsAbs(result) {
+		return
+	}
+	cmd := exec.Command("zoxide", "add", result)
+	_, err := cmd.Output()
+	if err != nil {
+		fmt.Println("Error:", err)
+		os.Exit(1)
+	}
+}

--- a/zoxide/query.go
+++ b/zoxide/query.go
@@ -1,0 +1,42 @@
+package zoxide
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/joshmedeski/sesh/convert"
+)
+
+func Query(dir string) (*ZoxideResult, error) {
+	output, err := zoxideCmd([]string{"query", "-s", dir})
+	if err != nil {
+		return nil, nil
+	}
+	cleanOutput := strings.TrimSpace(string(output))
+	list := strings.Split(cleanOutput, "\n")
+	listLen := len(list)
+	if listLen == 1 && list[0] == "" {
+		return nil, nil
+	}
+	results := make([]*ZoxideResult, 0, listLen)
+	for _, line := range list {
+		trimmed := strings.Trim(line, "[]")
+		trimmed = strings.Trim(trimmed, " ")
+		fields := strings.SplitN(trimmed, " ", 2)
+		if len(fields) != 2 {
+			fmt.Println("Zoxide entry has invalid number of fields (expected 2)")
+			os.Exit(1)
+		}
+		path := fields[1]
+		results = append(results, &ZoxideResult{
+			Score: convert.StringToFloat(fields[0]),
+			Name:  convert.PathToPretty(path),
+			Path:  path,
+		})
+	}
+	if len(results) == 0 {
+		return nil, nil
+	}
+	return results[0], nil
+}

--- a/zoxide/zoxide.go
+++ b/zoxide/zoxide.go
@@ -1,10 +1,7 @@
 package zoxide
 
 import (
-	"fmt"
-	"os"
 	"os/exec"
-	"path"
 )
 
 func zoxideCmd(args []string) ([]byte, error) {
@@ -18,16 +15,4 @@ func zoxideCmd(args []string) ([]byte, error) {
 		return nil, err
 	}
 	return output, nil
-}
-
-func Add(result string) {
-	if !path.IsAbs(result) {
-		return
-	}
-	cmd := exec.Command("zoxide", "add", result)
-	_, err := cmd.Output()
-	if err != nil {
-		fmt.Println("Error:", err)
-		os.Exit(1)
-	}
 }


### PR DESCRIPTION
Closes #9 

Adds the ability to query zoxide and use the result to generate the session if the connect command's argument is not a path or active session.