### PR TITLE
docs:go install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ To install sesh, run the following [homebrew](https://brew.sh/) command:
 brew install joshmedeski/sesh/sesh
 ```
 
+### Using Go
+
+Alternatively, you can install Sesh using Go's go install command:
+
+```sh
+go install github.com/joshmedeski/sesh@latest
+```
+
+This will download and install the latest version of Sesh. Make sure that your Go environment is properly set up.
+
 **Note:** Do you want this on another package manager? [Create an issue](https://github.com/joshmedeski/sesh/issues/new) and let me know!
 
 ## How to use


### PR DESCRIPTION
add the go install command to install the binary with a single command without needing to clone and build by yourself