### PR TITLE
Evaluate symbolic link real path

### DIFF
--- a/session/path.go
+++ b/session/path.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/joshmedeski/sesh/dir"
 	"github.com/joshmedeski/sesh/tmux"
@@ -19,7 +20,18 @@ func DeterminePath(choice string) (string, error) {
 		return cwd, nil
 	}
 	fullPath := dir.FullPath(choice)
-	if path.IsAbs(fullPath) {
+
+	realPath, err := filepath.EvalSymlinks(choice)
+	if err != nil {
+		fmt.Println("Couldn't evaluate symbolic link", err)
+		os.Exit(1)
+	}
+
+	if path.IsAbs(realPath) {
+		return realPath, nil
+	}
+
+	if path.IsAbs(realPath) {
 		return fullPath, nil
 	}
 


### PR DESCRIPTION
Closes #33 
Closes #39 

Evaluates symbolic links in the determine path logic to generate the session from the real path (not the symbolically linked path).