### PR TITLE
refactor: error handling in connect.Connect

### DIFF
--- a/cmds/choose.go
+++ b/cmds/choose.go
@@ -7,10 +7,10 @@ import (
 	"os/exec"
 	"strings"
 
+	cli "github.com/urfave/cli/v2"
+
 	"github.com/joshmedeski/sesh/connect"
 	"github.com/joshmedeski/sesh/session"
-
-	"github.com/urfave/cli/v2"
 )
 
 func Choose() *cli.Command {
@@ -65,8 +65,7 @@ func Choose() *cli.Command {
 			}
 			choice := strings.TrimSpace(cmdOutput.String())
 			// TODO: get choice from Session structs array
-			connect.Connect(choice, false, "")
-			return nil
+			return connect.Connect(choice, false, "")
 		},
 	}
 }

--- a/cmds/clone.go
+++ b/cmds/clone.go
@@ -1,10 +1,10 @@
 package cmds
 
 import (
+	cli "github.com/urfave/cli/v2"
+
 	"github.com/joshmedeski/sesh/connect"
 	"github.com/joshmedeski/sesh/git"
-
-	"github.com/urfave/cli/v2"
 )
 
 func Clone() *cli.Command {
@@ -32,8 +32,8 @@ func Clone() *cli.Command {
 			if err != nil {
 				return cli.Exit(err, 1)
 			}
-			connect.Connect(c.Path, false, "")
-			return nil
+
+			return connect.Connect(c.Path, false, "")
 		},
 	}
 }

--- a/cmds/connect.go
+++ b/cmds/connect.go
@@ -1,9 +1,9 @@
 package cmds
 
 import (
-	"github.com/joshmedeski/sesh/connect"
+	cli "github.com/urfave/cli/v2"
 
-	"github.com/urfave/cli/v2"
+	"github.com/joshmedeski/sesh/connect"
 )
 
 func Connect() *cli.Command {
@@ -31,8 +31,7 @@ func Connect() *cli.Command {
 			if session == "" {
 				return cli.Exit("No session provided", 0)
 			}
-			connect.Connect(session, alwaysSwitch, command)
-			return nil
+			return connect.Connect(session, alwaysSwitch, command)
 		},
 	}
 }

--- a/connect/connect.go
+++ b/connect/connect.go
@@ -1,17 +1,26 @@
 package connect
 
 import (
+	"fmt"
+
 	"github.com/joshmedeski/sesh/session"
 	"github.com/joshmedeski/sesh/tmux"
 	"github.com/joshmedeski/sesh/zoxide"
 )
 
 func Connect(choice string, alwaysSwitch bool, command string) error {
-	session := session.Determine(choice)
-	zoxide.Add(session.Path)
-	tmux.Connect(tmux.TmuxSession{
-		Name: session.Name,
-		Path: session.Path,
-	}, alwaysSwitch, command)
-	return nil
+	session, err := session.Determine(choice)
+	if err != nil {
+		return fmt.Errorf("unable to connect to %q: %w", choice, err)
+	}
+
+	if err := zoxide.Add(session.Path); err != nil {
+		return fmt.Errorf("unable to connect to %q: %w", choice, err)
+	}
+
+	return tmux.Connect(
+		tmux.TmuxSession{Name: session.Name, Path: session.Path},
+		alwaysSwitch,
+		command,
+	)
 }

--- a/session/determine.go
+++ b/session/determine.go
@@ -1,22 +1,30 @@
 package session
 
 import (
+	"fmt"
 	"log"
 )
 
-func Determine(choice string) Session {
+func Determine(choice string) (s Session, err error) {
 	path, err := DeterminePath(choice)
 	if err != nil {
-		log.Fatal("Couldn't determine the session path", err)
+		return s, fmt.Errorf(
+			"couldn't determine the path for %q: %w",
+			choice,
+			err,
+		)
 	}
+	s.Path = path
 
 	name := DetermineName(path)
 	if name == "" {
 		log.Fatal("Couldn't determine the session name", err)
+		return s, fmt.Errorf(
+			"couldn't determine the session name for %q",
+			choice,
+		)
 	}
+	s.Name = name
 
-	return Session{
-		Name: name,
-		Path: path,
-	}
+	return s, nil
 }

--- a/tmux/tmux.go
+++ b/tmux/tmux.go
@@ -2,7 +2,7 @@ package tmux
 
 import (
 	"bytes"
-	"log"
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -73,7 +73,9 @@ func runPersistentCommand(session string, command string) error {
 }
 
 func NewSession(s TmuxSession) (string, error) {
-	out, err := tmuxCmd([]string{"new-session", "-d", "-s", s.Name, "-c", s.Path})
+	out, err := tmuxCmd(
+		[]string{"new-session", "-d", "-s", s.Name, "-c", s.Path},
+	)
 	if err != nil {
 		return "", err
 	}
@@ -85,7 +87,7 @@ func Connect(s TmuxSession, alwaysSwitch bool, command string) error {
 	if !isSession {
 		_, err := NewSession(s)
 		if err != nil {
-			log.Fatal(err)
+			fmt.Errorf("unable to connect to tmux session %q: %w", s.Name, err)
 		}
 		if command != "" {
 			runPersistentCommand(s.Name, command)
@@ -97,5 +99,6 @@ func Connect(s TmuxSession, alwaysSwitch bool, command string) error {
 	} else {
 		attachSession(s.Name)
 	}
+
 	return nil
 }

--- a/zoxide/add.go
+++ b/zoxide/add.go
@@ -2,19 +2,20 @@ package zoxide
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"path"
 )
 
-func Add(result string) {
+func Add(result string) error {
 	if !path.IsAbs(result) {
-		return
+		return fmt.Errorf("can't add relative %q path to zoxide", result)
 	}
+
 	cmd := exec.Command("zoxide", "add", result)
 	_, err := cmd.Output()
 	if err != nil {
-		fmt.Println("Error:", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to add %q to zoxide: %w", result, err)
 	}
+
+	return nil
 }


### PR DESCRIPTION
Restructure the code around the connect.Connect method to return errors up the stack for centralized handling. 

fixes: #31 