### PR TITLE
ci: run benchmark tests and print a coverage summary

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           go-version: "1.21"
       - name: Run tests
-        run: go test -race ./...
+        run: go test -cover -bench=. -benchmem -race ./...
 
   goreleaser:
     name: Build and Publish


### PR DESCRIPTION
This change will add coverage summary and benchmark results to the output of the ci test run.