### PR TITLE
feat: add flag to hide the currently attached session

### DIFF
--- a/cmds/choose.go
+++ b/cmds/choose.go
@@ -30,6 +30,11 @@ func Choose() *cli.Command {
 				Aliases: []string{"z"},
 				Usage:   "show zoxide results",
 			},
+			&cli.BoolFlag{
+				Name:    "hide-attached",
+				Aliases: []string{"H"},
+				Usage:   "don't show currently attached sessions",
+			},
 		},
 		Action: func(cCtx *cli.Context) error {
 			cmd := exec.Command("fzf")
@@ -47,7 +52,10 @@ func Choose() *cli.Command {
 				return err
 			}
 
-			sessions := session.List(session.Srcs{
+			o := session.Options{
+				HideAttached: cCtx.Bool("hide-attached"),
+			}
+			sessions := session.List(o, session.Srcs{
 				Tmux:   cCtx.Bool("tmux"),
 				Zoxide: cCtx.Bool("zoxide"),
 			})

--- a/cmds/list.go
+++ b/cmds/list.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/joshmedeski/sesh/session"
+	cli "github.com/urfave/cli/v2"
 
-	"github.com/urfave/cli/v2"
+	"github.com/joshmedeski/sesh/session"
 )
 
 func List() *cli.Command {
@@ -26,9 +26,17 @@ func List() *cli.Command {
 				Aliases: []string{"z"},
 				Usage:   "show zoxide results",
 			},
+			&cli.BoolFlag{
+				Name:    "hide-attached",
+				Aliases: []string{"H"},
+				Usage:   "don't show currently attached sessions",
+			},
 		},
 		Action: func(cCtx *cli.Context) error {
-			sessions := session.List(session.Srcs{
+			o := session.Options{
+				HideAttached: cCtx.Bool("hide-attached"),
+			}
+			sessions := session.List(o, session.Srcs{
 				Tmux:   cCtx.Bool("tmux"),
 				Zoxide: cCtx.Bool("zoxide"),
 			})

--- a/session/list.go
+++ b/session/list.go
@@ -8,13 +8,19 @@ import (
 	"github.com/joshmedeski/sesh/zoxide"
 )
 
-func List(srcs Srcs) []string {
+type Options struct {
+	HideAttached bool
+}
+
+func List(o Options, srcs Srcs) []string {
 	var sessions []string
 	anySrcs := checkAnyTrue(srcs)
 
 	tmuxSessions := make([]*tmux.TmuxSession, 0)
 	if !anySrcs || srcs.Tmux {
-		tmuxList, err := tmux.List()
+		tmuxList, err := tmux.List(tmux.Options{
+			HideAttached: o.HideAttached,
+		})
 		tmuxSessions = append(tmuxSessions, tmuxList...)
 		if err != nil {
 			fmt.Println("Error:", err)

--- a/tmux/list.go
+++ b/tmux/list.go
@@ -101,12 +101,19 @@ func format() string {
 	return strings.Join(variables, " ")
 }
 
-func processSessions(sessionList []string) []*TmuxSession {
+type Options struct {
+	HideAttached bool
+}
+
+func processSessions(o Options, sessionList []string) []*TmuxSession {
 	sessions := make([]*TmuxSession, 0, len(sessionList))
 	for _, line := range sessionList {
 		fields := strings.Split(line, " ") // Strings split by single space
 
 		if len(fields) != 21 {
+			continue
+		}
+		if o.HideAttached && fields[2] == "1" {
 			continue
 		}
 
@@ -147,7 +154,7 @@ func sortSessions(sessions []*TmuxSession) []*TmuxSession {
 	return sessions
 }
 
-func List() ([]*TmuxSession, error) {
+func List(o Options) ([]*TmuxSession, error) {
 	format := format()
 	output, err := tmuxCmd([]string{"list-sessions", "-F", format})
 	cleanOutput := strings.TrimSpace(output)
@@ -156,7 +163,7 @@ func List() ([]*TmuxSession, error) {
 	}
 	sessionList := strings.TrimSpace(string(output))
 	lines := strings.Split(sessionList, "\n")
-	sessions := processSessions(lines)
+	sessions := processSessions(o, lines)
 
 	return sortSessions(sessions), nil
 }

--- a/tmux/list_test.go
+++ b/tmux/list_test.go
@@ -28,6 +28,7 @@ func BenchmarkFormat(i *testing.B) {
 func TestProcessSessions(t *testing.T) {
 	testCases := map[string]struct {
 		Input    []string
+		Options  Options
 		Expected []*TmuxSession
 	}{
 		"Single active session": {
@@ -35,6 +36,15 @@ func TestProcessSessions(t *testing.T) {
 				"1705879337  1 /dev/ttys000 1705878987 1       0 $2 1705879328 0 0 session-1 /some/test/path 1 1",
 			},
 			Expected: make([]*TmuxSession, 1),
+		},
+		"Hide single active session": {
+			Input: []string{
+				"1705879337  1 /dev/ttys000 1705878987 1       0 $2 1705879328 0 0 session-1 /some/test/path 1 1",
+			},
+			Options: Options{
+				HideAttached: true,
+			},
+			Expected: make([]*TmuxSession, 0),
 		},
 		"Single inactive session": {
 			Input: []string{
@@ -70,7 +80,7 @@ func TestProcessSessions(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			got := processSessions(tc.Input)
+			got := processSessions(tc.Options, tc.Input)
 			require.Equal(t, len(tc.Expected), len(got))
 		})
 	}
@@ -78,7 +88,7 @@ func TestProcessSessions(t *testing.T) {
 
 func BenchmarkProcessSessions(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		processSessions([]string{
+		processSessions(Options{}, []string{
 			"1705879337  1 /dev/ttys000 1705878987 1       0 $2 1705879328 0 0 session-1 /some/test/path 1 1",
 			"1705879337  1 /dev/ttys000 1705878987 1       0 $2 1705879328 0 0 session-1 /some/test/path 1 1",
 		})

--- a/tmux/tmux.go
+++ b/tmux/tmux.go
@@ -37,7 +37,7 @@ func isAttached() bool {
 }
 
 func IsSession(session string) (bool, string) {
-	sessions, err := List()
+	sessions, err := List(Options{})
 	if err != nil {
 		return false, ""
 	}

--- a/tmux/tmux_test.go
+++ b/tmux/tmux_test.go
@@ -1,5 +1,5 @@
 package tmux
 
 func SessionsList() {
-	List()
+	List(Options{})
 }


### PR DESCRIPTION
Add a flag to the `list` and `choose` commands to provide a means of excluding currently attached sessions when generting a list of current tmux sessions.
 
closes #50 


<details>
<summary>help output</summary>
<p>

```
❯ go run *.go list --help
NAME:
   sesh list - List sessions

USAGE:
   sesh list [command options] [arguments...]

OPTIONS:
   --tmux, -t           show tmux sessions (default: false)
   --zoxide, -z         show zoxide results (default: false)
   --hide-attached, -H  don't show currently attached sessions (default: false)
   --help, -h           show help
```

```
❯ go run *.go choose -h              
NAME:
   sesh choose - Select session

USAGE:
   sesh choose [command options] [arguments...]

OPTIONS:
   --tmux, -t           show tmux sessions (default: false)
   --zoxide, -z         show zoxide results (default: false)
   --hide-attached, -H  don't show currently attached sessions (default: false)
   --help, -h           show help
```
</p>
</details>

<details>
<summary>show attached</summary>
<p>

```
❯ go run *.go list       
default
```

</p>
</details>

<details>
<summary>hide attached</summary>
<p>

```
❯ go run *.go list --hide-attached

❯
```
```
❯ go run *.go list -H             

❯
```

</p>
</details>