### PR TITLE
feat: improve session logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ sesh connect $(sesh list | fzf)
 In order to integrate with tmux, you can add a binding to your tmux config (`tmux.conf`). For example, the following will bind `ctrl-a T` to open a fzf prompt as a tmux popup (using `fzf-tmux`) and using different commands to list sessions (`sesh list -t`), zoxide directories (`sesh list -z`), and find directories (`fd...`).
 
 ```sh
- bind-key "T" run-shell "sesh connect $(
+bind-key "T" run-shell "sesh connect \"$(
 	sesh list -tz | fzf-tmux -p 55%,60% \
 		--no-sort --border-label ' sesh ' --prompt '⚡  ' \
 		--header '  ^a all ^t tmux ^x zoxide ^f find' \
@@ -85,7 +85,7 @@ In order to integrate with tmux, you can add a binding to your tmux config (`tmu
 		--bind 'ctrl-t:change-prompt(🪟  )+reload(sesh list -t)' \
 		--bind 'ctrl-x:change-prompt(📁  )+reload(sesh list -z)' \
 		--bind 'ctrl-f:change-prompt(🔎  )+reload(fd -H -d 2 -t d -E .Trash . ~)'
-)"
+)\""
 ```
 
 You can customize this however you want, see `man fzf` for more info on the different options.

--- a/name/name.go
+++ b/name/name.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/joshmedeski/sesh/git"
+	"github.com/joshmedeski/sesh/tmux"
 )
 
 func convertToValidName(name string) string {
@@ -47,12 +48,17 @@ func nameFromGit(result string) string {
 	return nameFromGit
 }
 
-func DetermineName(result string) string {
-	name := result
-	// TODO: parent directory config option detection
-	pathName := nameFromPath(result)
-	if pathName != "" {
-		name = pathName
+func DetermineName(choice string, path string) string {
+	session, _ := tmux.FindSession(choice)
+	if session != nil {
+		return session.Name
 	}
-	return convertToValidName(name)
+
+	// TODO: parent directory config option detection
+	pathName := nameFromPath(path)
+	if pathName != "" {
+		return convertToValidName(pathName)
+	}
+
+	return convertToValidName(choice)
 }

--- a/session/determine.go
+++ b/session/determine.go
@@ -19,7 +19,7 @@ func Determine(choice string, config *config.Config) (s Session, err error) {
 	}
 	s.Path = path
 
-	sessionName := name.DetermineName(path)
+	sessionName := name.DetermineName(choice, path)
 	if sessionName == "" {
 		log.Fatal("Couldn't determine the session name", err)
 		return s, fmt.Errorf(

--- a/session/path.go
+++ b/session/path.go
@@ -30,9 +30,16 @@ func DeterminePath(choice string) (string, error) {
 		return fullPath, nil
 	}
 
-	isSession, sessionPath := tmux.IsSession(fullPath)
-	if isSession && sessionPath != "" {
-		return sessionPath, nil
+	session, err := tmux.FindSession(fullPath)
+	if err != nil {
+		return "", fmt.Errorf(
+			"couldn't determine the path for %q: %w",
+			choice,
+			err,
+		)
+	}
+	if session != nil {
+		return session.Path, nil
 	}
 
 	zoxideResult, err := zoxide.Query(fullPath)

--- a/tmux/list.go
+++ b/tmux/list.go
@@ -32,6 +32,8 @@ type TmuxSession struct {
 	Marked            bool       // 1 if this session contains the marked pane
 }
 
+var separator = "::"
+
 func format() string {
 	variables := []string{
 		"#{session_activity}",
@@ -57,7 +59,7 @@ func format() string {
 		"#{session_windows}",
 	}
 
-	return strings.Join(variables, " ")
+	return strings.Join(variables, separator)
 }
 
 type Options struct {
@@ -67,7 +69,7 @@ type Options struct {
 func processSessions(o Options, sessionList []string) []*TmuxSession {
 	sessions := make([]*TmuxSession, 0, len(sessionList))
 	for _, line := range sessionList {
-		fields := strings.Split(line, " ") // Strings split by single space
+		fields := strings.Split(line, separator) // Strings split by single space
 
 		if len(fields) != 21 {
 			continue

--- a/tmux/list_test.go
+++ b/tmux/list_test.go
@@ -33,13 +33,13 @@ func TestProcessSessions(t *testing.T) {
 	}{
 		"Single active session": {
 			Input: []string{
-				"1705879337  1 /dev/ttys000 1705878987 1       0 $2 1705879328 0 0 session-1 /some/test/path 1 1",
+				"1705879337::::1::/dev/ttys000::1705878987::1::::::::::::::0::$2::1705879328::0::0::session-1::/some/test/path::1::1",
 			},
 			Expected: make([]*TmuxSession, 1),
 		},
 		"Hide single active session": {
 			Input: []string{
-				"1705879337  1 /dev/ttys000 1705878987 1       0 $2 1705879328 0 0 session-1 /some/test/path 1 1",
+				"1705879337::::1::/dev/ttys000::1705878987::1::::::::::::::0::$2::1705879328::0::0::session-1::/some/test/path::1::1",
 			},
 			Options: Options{
 				HideAttached: true,
@@ -48,21 +48,21 @@ func TestProcessSessions(t *testing.T) {
 		},
 		"Single inactive session": {
 			Input: []string{
-				"1705879002  0  1705878987 1       0 $2 1705878987 0 0 session-1 /some/test/path 1 1",
+				"1705879002::::0::::1705878987::1::::::::::::::0::$2::1705878987::0::0::session-1::/some/test/path::1::1",
 			},
 			Expected: make([]*TmuxSession, 1),
 		},
 		"Two inactive session": {
 			Input: []string{
-				"1705879002  0  1705878987 1       0 $2 1705878987 0 0 session-1 /some/test/path 1 1",
-				"1705879063  0  1705879002 1       0 $3 1705879002 0 0 session-2 /some/other/test/path 1 1",
+				"1705879002::::0::::1705878987::1::::::::::::::0::$2::1705878987::0::0::session-1::/some/test/path::1::1",
+				"1705879063::::0::::1705879002::1::::::::::::::0::$3::1705879002::0::0::session-2::/some/other/test/path::1::1",
 			},
 			Expected: make([]*TmuxSession, 2),
 		},
 		"Two active session": {
 			Input: []string{
-				"1705879337  1 /dev/ttys000 1705878987 1       0 $2 1705879328 0 0 session-1 /some/test/path 1 1",
-				"1705879337  1 /dev/ttys000 1705878987 1       0 $2 1705879328 0 0 session-1 /some/test/path 1 1",
+				"1705879337::::1::/dev/ttys000::1705878987::1::::::::::::::0::$2::1705879328::0::0::session-1::/some/test/path::1::1",
+				"1705879337::::1::/dev/ttys000::1705878987::1::::::::::::::0::$2::1705879328::0::0::session-1::/some/test/path::1::1",
 			},
 			Expected: make([]*TmuxSession, 2),
 		},
@@ -71,8 +71,8 @@ func TestProcessSessions(t *testing.T) {
 		},
 		"Invalid LastAttached (Issue 34)": {
 			Input: []string{
-				"1705879002  0  1705878987 1       0 $2 1705878987 0 0 session-1 /some/test/path 1 1",
-				"1705879063  0  1705879002 1       0 $3  0 0 session-2 /some/other/test/path 1 1",
+				"1705879002::::0::::1705878987::1::::::::::::::0::$2::1705878987::0::0::session-1::/some/test/path::1::1",
+				"1705879063::::0::::1705879002::1::::::::::::::0::$3::::0::0::session-2::/some/other/test/path::1::1",
 			},
 			Expected: make([]*TmuxSession, 2),
 		},
@@ -89,8 +89,8 @@ func TestProcessSessions(t *testing.T) {
 func BenchmarkProcessSessions(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		processSessions(Options{}, []string{
-			"1705879337  1 /dev/ttys000 1705878987 1       0 $2 1705879328 0 0 session-1 /some/test/path 1 1",
-			"1705879337  1 /dev/ttys000 1705878987 1       0 $2 1705879328 0 0 session-1 /some/test/path 1 1",
+			"1705879337::::1::/dev/ttys000::1705878987::1::::::::::::::0::$2::1705879328::0::0::session-1::/some/test/path::1::1",
+			"1705879337::::1::/dev/ttys000::1705878987::1::::::::::::::0::$2::1705879328::0::0::session-1::/some/test/path::1::1",
 		})
 	}
 }

--- a/tmux/list_test.go
+++ b/tmux/list_test.go
@@ -7,14 +7,14 @@ import (
 )
 
 func TestFormat(t *testing.T) {
-	want := "#{session_activity} #{session_alerts} #{session_attached}" +
-		" #{session_attached_list} #{session_created} #{session_format} " +
-		"#{session_group} #{session_group_attached} " +
-		"#{session_group_attached_list} #{session_group_list} " +
-		"#{session_group_many_attached} #{session_group_size} " +
-		"#{session_grouped} #{session_id} #{session_last_attached} " +
-		"#{session_many_attached} #{session_marked} #{session_name} " +
-		"#{session_path} #{session_stack} #{session_windows}"
+	want := "#{session_activity}::#{session_alerts}::#{session_attached}::" +
+		"#{session_attached_list}::#{session_created}::#{session_format}::" +
+		"#{session_group}::#{session_group_attached}::" +
+		"#{session_group_attached_list}::#{session_group_list}::" +
+		"#{session_group_many_attached}::#{session_group_size}::" +
+		"#{session_grouped}::#{session_id}::#{session_last_attached}::" +
+		"#{session_many_attached}::#{session_marked}::#{session_name}::" +
+		"#{session_path}::#{session_stack}::#{session_windows}"
 	got := format()
 	require.Equal(t, want, got)
 }

--- a/tmux/tmux.go
+++ b/tmux/tmux.go
@@ -68,18 +68,18 @@ func isAttached() bool {
 	return len(os.Getenv("TMUX")) > 0
 }
 
-func IsSession(session string) (bool, string) {
+func FindSession(session string) (*TmuxSession, error) {
 	sessions, err := List(Options{})
 	if err != nil {
-		return false, ""
+		return nil, err
 	}
 
 	for _, s := range sessions {
 		if s.Name == session {
-			return true, s.Path
+			return s, nil
 		}
 	}
-	return false, ""
+	return nil, nil
 }
 
 func attachSession(session string) error {
@@ -146,8 +146,8 @@ func Connect(
 	sessionPath string,
 	config *config.Config,
 ) error {
-	isSession, _ := IsSession(s.Name)
-	if !isSession {
+	session, _ := FindSession(s.Name)
+	if session == nil {
 		_, err := NewSession(s)
 		if err != nil {
 			return fmt.Errorf(


### PR DESCRIPTION
Closes #77 

Support custom session names by updating the determine logic.

- Switch isSession to FindSession and return nil if not found
- Determine name logic now returns the session name if it exists

Closes #75 

Use "::" as a separator in the tmux list to support spaces in tmux path or name variables.