### PR TITLE
feat(config):  include additional config files

### DIFF
--- a/cmds/clone.go
+++ b/cmds/clone.go
@@ -33,7 +33,7 @@ func Clone() *cli.Command {
 			if err != nil {
 				return cli.Exit(err, 1)
 			}
-			config := config.ParseConfigFile()
+			config := config.ParseConfigFile(&config.DefaultConfigDirectoryFetcher{})
 			return connect.Connect(c.Path, false, "", &config)
 		},
 	}

--- a/cmds/connect.go
+++ b/cmds/connect.go
@@ -32,7 +32,7 @@ func Connect() *cli.Command {
 			if session == "" {
 				return cli.Exit("No session provided", 0)
 			}
-			config := config.ParseConfigFile()
+			config := config.ParseConfigFile(&config.DefaultConfigDirectoryFetcher{})
 			return connect.Connect(session, alwaysSwitch, command, &config)
 		},
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,15 @@ type (
 	}
 )
 
-func getUserConfigDir() (string, error) {
+type ConfigDirectoryFetcher interface {
+	GetUserConfigDir() (string, error)
+}
+
+type DefaultConfigDirectoryFetcher struct{}
+
+var _ ConfigDirectoryFetcher = (*DefaultConfigDirectoryFetcher)(nil)
+
+func (d *DefaultConfigDirectoryFetcher) GetUserConfigDir() (string, error) {
 	switch runtime.GOOS {
 	case "darwin":
 		// typically ~/Library/Application Support, but we want to use ~/.config
@@ -35,9 +43,9 @@ func getUserConfigDir() (string, error) {
 	}
 }
 
-func ParseConfigFile() Config {
+func ParseConfigFile(fetcher ConfigDirectoryFetcher) Config {
 	config := Config{}
-	configDir, err := getUserConfigDir()
+	configDir, err := fetcher.GetUserConfigDir()
 	if err != nil {
 		fmt.Printf(
 			"Error determining the user config directory: %s\nUsing default config instead",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,75 @@
+package config_test
+
+import (
+	"io/fs"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/joshmedeski/sesh/config"
+)
+
+type mockConfigDirectoryFetcher struct {
+	dir string
+}
+
+func (m *mockConfigDirectoryFetcher) GetUserConfigDir() (string, error) {
+	return m.dir, nil
+}
+
+func prepareSeshConfig(t *testing.T) string {
+	userConfigPath, err := os.MkdirTemp(os.TempDir(), "config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(path.Join(userConfigPath, "sesh"), fs.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	tempConfigPath := path.Join(userConfigPath, "sesh", "sesh.toml")
+
+	err = os.WriteFile(tempConfigPath, []byte(`
+		default_startup_script = "default"
+
+		[[startup_scripts]]
+		session_path = "~/dev/first_session"
+		script_path = "~/.config/sesh/scripts/first_script"
+
+		[[startup_scripts]]
+		session_path = "~/dev/second_session"
+		script_path = "~/.config/sesh/scripts/second_script"
+		`), fs.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return userConfigPath
+}
+
+func TestParseConfigFile(t *testing.T) {
+	userConfigPath := prepareSeshConfig(t)
+	defer os.Remove(userConfigPath)
+
+	t.Run("ParseConfigFile", func(t *testing.T) {
+		fetcher := &mockConfigDirectoryFetcher{dir: userConfigPath}
+		config := config.ParseConfigFile(fetcher)
+
+		if config.DefaultStartupScript != "default" {
+			t.Errorf("Expected %s, got %s", "default", config.DefaultStartupScript)
+		}
+		if len(config.StartupScripts) != 2 {
+			t.Errorf("Expected %d, got %d", 2, len(config.StartupScripts))
+		}
+		if config.StartupScripts[0].SessionPath != "~/dev/first_session" {
+			t.Errorf("Expected %s, got %s", "~/dev/first_session", config.StartupScripts[0].SessionPath)
+		}
+		if config.StartupScripts[0].ScriptPath != "~/.config/sesh/scripts/first_script" {
+			t.Errorf("Expected %s, got %s", "~/.config/sesh/scripts/first_script", config.StartupScripts[0].ScriptPath)
+		}
+		if config.StartupScripts[1].SessionPath != "~/dev/second_session" {
+			t.Errorf("Expected %s, got %s", "~/dev/second_session", config.StartupScripts[1].SessionPath)
+		}
+		if config.StartupScripts[1].ScriptPath != "~/.config/sesh/scripts/second_script" {
+			t.Errorf("Expected %s, got %s", "~/.config/sesh/scripts/second_script", config.StartupScripts[1].ScriptPath)
+		}
+	})
+}


### PR DESCRIPTION
### Background

- I will add the sesh config file to my GitHub repository `dotfiles`, but I don't want to commit some sensitive information to the public GitHub repository. For example:
  - I have the following sesh `startup_scripts` config, but I don't want to add the sensitive info (company name) `~/code/my_compay` to my Github repository
    ```toml
    [[startup_scripts]]
    session_path = "~/code/my_compay/third_session"
    script_path = "~/.config/sesh/scripts/third_script"
    ```
- The solution is to allow the sesh config to include additional config files, and then I could exclude the additional config files from the git commit history.

### Usage
- The custom sesh config
```toml
# ~/.config/sesh/sesh.toml

default_startup_script = "default"

[[startup_scripts]]
session_path = "~/dev/first_session"
script_path = "~/.config/sesh/scripts/first_script"

[[startup_scripts]]
session_path = "~/dev/second_session"
script_path = "~/.config/sesh/scripts/second_script"

[[included_paths]]
path = "~/.config/sesh/local/sesh.toml"
```

- The following config is an additional config that will be included in the custom sesh config
```toml
# ~/.config/sesh/local/sesh.toml
[[startup_scripts]]
session_path = "~/dev/third_session"
script_path = "~/.config/sesh/scripts/third_script"
```

### Test Cases
- All of the test cases are passed.
<img width="790" alt="image" src="https://github.com/joshmedeski/sesh/assets/7600503/59f692e4-0f9d-4933-b49b-da251966d88c">
