### PR TITLE
fix: allow config sessions w/ duplicate paths

### DIFF
--- a/session/determine.go
+++ b/session/determine.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"github.com/joshmedeski/sesh/config"
-	"github.com/joshmedeski/sesh/dir"
 	"github.com/joshmedeski/sesh/name"
 )
 
@@ -16,7 +15,7 @@ func isConfigSession(choice string) *Session {
 			return &Session{
 				Src:  "config",
 				Name: sessionConfig.Name,
-				Path: dir.AlternatePath(sessionConfig.Path),
+				Path: sessionConfig.Path,
 			}
 		}
 	}

--- a/session/list_test.go
+++ b/session/list_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path"
@@ -17,7 +18,13 @@ func (m *mockConfigDirectoryFetcher) GetUserConfigDir() (string, error) {
 	return m.dir, nil
 }
 
-func prepareSeshConfig(t *testing.T) string {
+type MockSeshConfig struct {
+	Name     string
+	Contents string
+	Imports  string
+}
+
+func prepareSeshConfig(t *testing.T, mockSeshConfigs []MockSeshConfig) string {
 	userConfigPath, err := os.MkdirTemp(os.TempDir(), "config")
 	if err != nil {
 		t.Fatal(err)
@@ -25,42 +32,73 @@ func prepareSeshConfig(t *testing.T) string {
 	if err := os.MkdirAll(path.Join(userConfigPath, "sesh"), fs.ModePerm); err != nil {
 		t.Fatal(err)
 	}
-	tempConfigPath := path.Join(userConfigPath, "sesh", "sesh.toml")
 
-	err = os.WriteFile(tempConfigPath, []byte(`
-		[[session]]
-		name = "test-session"
-		path = "~/dev/duplicate_session"
-		`,
-	), fs.ModePerm)
-	if err != nil {
-		t.Fatal(err)
+	// create a temp config file for each supplied config
+	for _, mockSesh := range mockSeshConfigs {
+		tempConfigPath := path.Join(userConfigPath, "sesh", mockSesh.Name)
+
+		var contents string
+		if mockSesh.Imports != "" {
+			contents = fmt.Sprintf("import = [\"%s\"]\n%s", path.Join(userConfigPath, "sesh", mockSesh.Imports), mockSesh.Contents)
+		} else {
+			contents = mockSesh.Contents
+		}
+		err = os.WriteFile(tempConfigPath, []byte(contents), fs.ModePerm)
+
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	return userConfigPath
 }
 
-func mockCfg(t *testing.T) config.Config {
-	cfgDir := prepareSeshConfig(t)
-	fetcher := &mockConfigDirectoryFetcher{dir: cfgDir}
-	defer os.Remove(cfgDir)
-	cfg := config.ParseConfigFile(fetcher)
-	return cfg
-}
-
 // Verify that custom sessions defined in config with a path
-// equal to a tmux session is still added to the session list
+// equal to a tmux session is still added to the session list.
+//
+// Only tmux sessions created from custom config sessions directly
+// should overwrite config sessions
 func TestListConfigSessionsShouldAddConfigSessionWithDuplicatePath(t *testing.T) {
-	cfg := mockCfg(t)
-	sessions := []Session{
-		{Src: "tmux", Name: "some-other-name", Path: "~/dev/duplicate_session"},
+	mockCfg := []MockSeshConfig{
+		{
+			Name: "sesh.toml",
+			Contents: `
+			[[session]]
+			name = "test-session"
+			path = "~/dev/duplicate_session"
+		
+			[[session]] 
+			name = "test-session-2"
+			path = "~/dev/duplicate_session"
+		`},
 	}
+	cfgDir := prepareSeshConfig(t, mockCfg)
+	defer os.Remove(cfgDir)
+
+	fetcher := &mockConfigDirectoryFetcher{dir: cfgDir}
+	cfg := config.ParseConfigFile(fetcher)
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal("unable to get user home directory")
+	}
+
+	sessions := []Session{
+		// session has been created from config session
+		// include it, but not the one from the config
+		{Src: "tmux", Name: "test-session", Path: home + "/dev/duplicate_session"},
+	}
+
 	configSessions, err := listConfigSessions(&cfg, sessions)
 	if err != nil {
 		t.Fatalf("error: %v", err.Error())
 	}
 
-	if len(configSessions) != 2 {
-		t.Fatal("error: Expected config session with duplicate path to be added to tmux session")
+	if len(configSessions) != 1 {
+		t.Fatalf("Expected created configSessions to be %d, got %d", 1, len(configSessions))
+	}
+
+	if configSessions[0].Name != "test-session-2" {
+		t.Fatalf("Expected created configSession to be %s, got %s", "test-session-2", configSessions[0].Name)
 	}
 }

--- a/session/list_test.go
+++ b/session/list_test.go
@@ -1,0 +1,66 @@
+package session
+
+import (
+	"io/fs"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/joshmedeski/sesh/config"
+)
+
+type mockConfigDirectoryFetcher struct {
+	dir string
+}
+
+func (m *mockConfigDirectoryFetcher) GetUserConfigDir() (string, error) {
+	return m.dir, nil
+}
+
+func prepareSeshConfig(t *testing.T) string {
+	userConfigPath, err := os.MkdirTemp(os.TempDir(), "config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(path.Join(userConfigPath, "sesh"), fs.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	tempConfigPath := path.Join(userConfigPath, "sesh", "sesh.toml")
+
+	err = os.WriteFile(tempConfigPath, []byte(`
+		[[session]]
+		name = "test-session"
+		path = "~/dev/duplicate_session"
+		`,
+	), fs.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return userConfigPath
+}
+
+func mockCfg(t *testing.T) config.Config {
+	cfgDir := prepareSeshConfig(t)
+	fetcher := &mockConfigDirectoryFetcher{dir: cfgDir}
+	defer os.Remove(cfgDir)
+	cfg := config.ParseConfigFile(fetcher)
+	return cfg
+}
+
+// Verify that custom sessions defined in config with a path
+// equal to a tmux session is still added to the session list
+func TestListConfigSessionsShouldAddConfigSessionWithDuplicatePath(t *testing.T) {
+	cfg := mockCfg(t)
+	sessions := []Session{
+		{Src: "tmux", Name: "some-other-name", Path: "~/dev/duplicate_session"},
+	}
+	configSessions, err := listConfigSessions(&cfg, sessions)
+	if err != nil {
+		t.Fatalf("error: %v", err.Error())
+	}
+
+	if len(configSessions) != 2 {
+		t.Fatal("error: Expected config session with duplicate path to be added to tmux session")
+	}
+}


### PR DESCRIPTION
If config sessions defined in sesh.toml have a path equal to an existing tmux session, they are currently not added to a sesh List (when calling `sesh list`.

This PR adds config sessions, which are explicitly defined by the user, no independent of the user's existing tmux sessions.