### PR TITLE
fix: fzf-tmux ANSI rendering example

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ In order to integrate with tmux, you can add a binding to your tmux config (`tmu
 ```sh
 bind-key "T" run-shell "sesh connect \"$(
 	sesh list | fzf-tmux -p 55%,60% \
-		--no-sort --border-label ' sesh ' --prompt '⚡  ' \
+		--no-sort --ansi --border-label ' sesh ' --prompt '⚡  ' \
 		--header '  ^a all ^t tmux ^g configs ^x zoxide ^d tmux kill ^f find' \
 		--bind 'tab:down,btab:up' \
 		--bind 'ctrl-a:change-prompt(⚡  )+reload(sesh list)' \


### PR DESCRIPTION
I've copied and used your example fzf-tmux script from your README.md (below)

```bash
bind-key "T" run-shell "sesh connect \"$(
	sesh list | fzf-tmux -p 55%,60% \
		--no-sort --border-label ' sesh ' --prompt '⚡  ' \
		--header '  ^a all ^t tmux ^g configs ^x zoxide ^d tmux kill ^f find' \
		--bind 'tab:down,btab:up' \
		--bind 'ctrl-a:change-prompt(⚡  )+reload(sesh list)' \
		--bind 'ctrl-t:change-prompt(🪟  )+reload(sesh list -t)' \
		--bind 'ctrl-g:change-prompt(⚙️  )+reload(sesh list -c)' \
		--bind 'ctrl-x:change-prompt(📁  )+reload(sesh list -z)' \
		--bind 'ctrl-f:change-prompt(🔎  )+reload(fd -H -d 2 -t d -E .Trash . ~)' \
		--bind 'ctrl-d:execute(tmux kill-session -t {})+change-prompt(⚡  )+reload(sesh list)'
)\""
```

It's great, but I've had a problem with how the row symbols are rendered... see image below:

<img width="490" alt="image" src="https://github.com/joshmedeski/sesh/assets/68929760/538ee433-d39d-4054-9ee8-1525b934ac86">

However, without piping the text from `sesh` to `fzf-tmux`, the symbols render just fine:

<img width="253" alt="image" src="https://github.com/joshmedeski/sesh/assets/68929760/a65ef103-f39f-48e5-a45b-dc58fc3fbb72">


I can't see that anyone else has had this issue yet, but I've found that, contrary to `gum`, `fzf`, and therefore `fzf-tmux`, don't seem to support ANSI escape codes by default - at least in my case.

Therefore, passing the `--ansi` flag expliticly allows for `fzf-tmux` to correctly handle the ANSI codes. In this PR, I've simply added the flag to the README example. With the flag set, my sesh list looks like this:

<img width="317" alt="image" src="https://github.com/joshmedeski/sesh/assets/68929760/96d6b7ba-9c40-4114-a717-9ef5a344b1bf">


