### PR TITLE
Add path list to create windows in custom session

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -20,8 +20,9 @@ type (
 	}
 
 	SessionConfig struct {
-		Name string `toml:"name"`
-		Path string `toml:"path"`
+		Name     string   `toml:"name"`
+		Path     string   `toml:"path"`
+		PathList []string `toml:"path_list"`
 		DefaultSessionConfig
 	}
 

--- a/connect/connect.go
+++ b/connect/connect.go
@@ -30,7 +30,8 @@ func Connect(
 		return fmt.Errorf("unable to connect to %q: %w", choice, err)
 	}
 	return tmux.Connect(tmux.TmuxSession{
-		Name: session.Name,
-		Path: session.Path,
+		Name:     session.Name,
+		Path:     session.Path,
+		PathList: session.PathList,
 	}, alwaysSwitch, command, session.Path, config)
 }

--- a/session/determine.go
+++ b/session/determine.go
@@ -14,9 +14,10 @@ func isConfigSession(choice string) *Session {
 	for _, sessionConfig := range config.SessionConfigs {
 		if sessionConfig.Name == choice {
 			return &Session{
-				Src:  "config",
-				Name: sessionConfig.Name,
-				Path: dir.AlternatePath(sessionConfig.Path),
+				Src:      "config",
+				Name:     sessionConfig.Name,
+				Path:     dir.AlternatePath(sessionConfig.Path),
+				PathList: sessionConfig.PathList,
 			}
 		}
 	}

--- a/session/session.go
+++ b/session/session.go
@@ -1,12 +1,13 @@
 package session
 
 type Session struct {
-	Src      string  // tmux or zoxide
-	Name     string  // The display name
-	Path     string  // The absolute directory path
-	Score    float64 // The score of the session (from Zoxide)
-	Attached int     // Whether the session is currently attached
-	Windows  int     // The number of windows in the session
+	Src      string   // tmux or zoxide
+	Name     string   // The display name
+	Path     string   // The absolute directory path
+	PathList []string // A list of directory paths to create windows in the session
+	Score    float64  // The score of the session (from Zoxide)
+	Attached int      // Whether the session is currently attached
+	Windows  int      // The number of windows in the session
 }
 
 type Srcs struct {

--- a/tmux/connect.go
+++ b/tmux/connect.go
@@ -20,7 +20,7 @@ func Connect(
 		_, err := NewSession(s)
 		if err != nil {
 			return fmt.Errorf(
-				"unable to connect to tmux session %q: %w",
+				"error when creating new tmux session %q: %w",
 				s.Name,
 				err,
 			)

--- a/tmux/list.go
+++ b/tmux/list.go
@@ -21,6 +21,7 @@ type TmuxSession struct {
 	ID                string     // Unique session ID
 	Name              string     // Name of session
 	Path              string     // Working directory of session
+	PathList          []string   // List of additional window paths in session
 	Attached          int        // Number of clients session is attached to
 	GroupAttached     int        // Number of clients sessions in group are attached to
 	GroupSize         int        // Size of session group
@@ -57,6 +58,7 @@ func format() string {
 		"#{session_path}",
 		"#{session_stack}",
 		"#{session_windows}",
+		"#{session_path_list}",
 	}
 
 	return strings.Join(variables, separator)
@@ -71,7 +73,7 @@ func processSessions(o Options, sessionList []string) []*TmuxSession {
 	for _, line := range sessionList {
 		fields := strings.Split(line, separator) // Strings split by single space
 
-		if len(fields) != 21 {
+		if len(fields) != 22 {
 			continue
 		}
 		if o.HideAttached && fields[2] == "1" {
@@ -100,6 +102,7 @@ func processSessions(o Options, sessionList []string) []*TmuxSession {
 			Path:              fields[18],
 			Stack:             convert.StringToIntSlice(fields[19]),
 			Windows:           convert.StringToInt(fields[20]),
+			PathList:          strings.Split(fields[21], ","),
 		}
 		sessions = append(sessions, session)
 	}


### PR DESCRIPTION
First, thanks a lot for this project. Actually, I have been using a modified version of your `t` script when you first released it, added a bunch of things to it and modified to what I needed. So basically, your `t` script really improved my Tmux workflow in a big and positive way, and was a huge inspiration for managing my tmux sessions.

Now, this version written in Go is really nice and I just started using it, specially due to the possibility of defining custom sessions in `~/.config/sesh/sesh.toml`. So to make it similar to the `t` script(s) I have been using so far in which I also define custom sessions, I added the option to define additional directory paths in `path_list` and create windows based on those paths in the current session.

I think you do prefer to have one window per session, but maybe some other users like me would also like the idea to have a few other windows in the same session.

So this pull request implements that basically. If you like the idea, do let me know to adjust it based on your own preferences, suggestions, and naming conventions.

At this point, it is working for me without disrupting any other commands or features (to the best of my knowledge). So basically, if I have this in my sesh config, it will create a first window with cwd as in `path`, and additional windows based on the paths in `path_list`. For example:

```toml
[[session]]
name = "Config  "
path = "~/.config/nvim"
path_list = ["~/dotfiles", "~/.config/wezterm"]
startup_command = "nvim"
```

This will create three windows in total, and the `startup_command` will still be applied but only to the first window defined by `path`. `path_list` is optional so a custom session just with `path` works as expected. If any path in `path_list` is not a valid directory, the window is not created.

I hope you like the idea and thanks again!
