### PR TITLE
Concatenate args to avoid out of bound issues

### DIFF
--- a/seshcli/connect.go
+++ b/seshcli/connect.go
@@ -3,6 +3,7 @@ package seshcli
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/joshmedeski/sesh/connector"
 	"github.com/joshmedeski/sesh/icon"
@@ -62,7 +63,7 @@ func Connect(c connector.Connector, i icon.Icon) *cli.Command {
 			if cCtx.NArg() == 0 {
 				return errors.New("please provide a session name")
 			}
-			name := cCtx.Args().First()
+			name := strings.Join(cCtx.Args().Slice(), " ")
 			if name == "" {
 				return nil
 			}


### PR DESCRIPTION
fixes: https://github.com/joshmedeski/sesh/issues/114


```
 sesh connect $(sesh list -i | gum filter --limit 1 --placeholder 'Pick a session' --height 60 --prompt='⚡')
panic: runtime error: slice bounds out of range [4:3]

goroutine 1 [running]:
github.com/joshmedeski/sesh/icon.(*RealIcon).RemoveIcon(0x140001288c0?, {0x16f916fad, 0x3})
        /home/runner/work/sesh/sesh/icon/icon.go:55 +0x128
github.com/joshmedeski/sesh/seshcli.App.Connect.func1(0x1400018f958?)
        /home/runner/work/sesh/sesh/seshcli/connect.go:70 +0xb4
github.com/urfave/cli/v2.(*Command).Run(0x140001be2c0, 0x140001288c0, {0x14000111350, 0x3, 0x3})
        /home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.27.1/command.go:279 +0x754
github.com/urfave/cli/v2.(*Command).Run(0x140001be6e0, 0x14000128780, {0x14000128040, 0x4, 0x4})
        /home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.27.1/command.go:272 +0x964
github.com/urfave/cli/v2.(*App).RunContext(0x1400016a200, {0x1008088b8?, 0x100a05320}, {0x14000128040, 0x4, 0x4})
        /home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.27.1/app.go:337 +0x534
github.com/urfave/cli/v2.(*App).Run(0x10070cec7?, {0x14000128040?, 0x0?, 0x0?})
        /home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.27.1/app.go:311 +0x3c
main.main()
        /home/runner/work/sesh/sesh/main.go:14 +0xb0
```

Tested solution locally:
```
bin/sesh-dev connect $(sesh list -i | gum filter --limit 1 --placeholder 'Pick a session' --height 60 --prompt='⚡')
payments-service
switching to tmux session: payments-service
```

```
bin/sesh-dev connect "$(sesh list -i | gum filter --limit 1 --placeholder 'Pick a session' --height 60 --prompt='⚡')"
payments-service
switching to tmux session: payments-service
```