### PR TITLE
Fix reference to sesh-dev in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The default `<prefix>+L` command will "Switch the attached client back to the la
 Add the following to your `tmux.conf` to overwrite the default `last-session` command:
 
 ```sh
-bind -N "last-session (via sesh) " L run-shell "sesh-dev last"
+bind -N "last-session (via sesh)" L run-shell "sesh last"
 ```
 
 ````


### PR DESCRIPTION
btw regarding running out of characters for tmux keybinds… you can extend into Ctrl + char.

So I kept the built-in tmux last-session as `<prefix> + l` and instead used `<prefix> + Ctrl + l`.

:)