### PR TITLE
Add Yay package manager

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -62,3 +62,19 @@ brews:
     dependencies:
       - tmux
       - zoxide
+
+aurs:
+  - name: sesh-bin
+    description: "Smart session manager for the terminal"
+    maintainers: "Josh Medeski"
+    license: "MIT"
+    git_url: "https://github.com/joshmedeski/sesh"
+    depends:
+      - zoxide
+        tmux
+    package: |-
+      # bin
+      install -Dm755 $_pkgname "$pkgdir/usr/bin/$_pkgname"
+      
+      # license
+      install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ To install sesh, run the following [homebrew](https://brew.sh/) command:
 brew install joshmedeski/sesh/sesh
 ```
 
+### ArchLinux AUR
+
+To install sesh using, run the following [yay](https://aur.archlinux.org/packages/yay) command:
+
+```sh
+yay -S sesh-bin
+```
+
 ### Go
 
 Alternatively, you can install Sesh using Go's go install command:


### PR DESCRIPTION
After a search of the AUR packages, I found that goreleaser already have published sesh to the AUR, but uses `sesh-bin` as the package name.

So I just added to the README the information on how to install it using the yay package manager.

This PR will close issue #173 