### PR TITLE
Add connect root flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,9 @@ bind-key x kill-pane # skip "kill-pane 1? (y/n)" prompt
 set -g detach-on-destroy off  # don't exit from tmux when closing a session
 ```
 
-## Bonus: sesh last
+## Bonus
+
+### Last
 
 The default `<prefix>+L` command will "Switch the attached client back to the last session." However, if you close a session while `detach-on-destroy off` is set, the last session will not be found. To fix this, I have a `sesh last` command that will always switch the client to the second to last session that has been attached.
 
@@ -170,6 +172,18 @@ Add the following to your `tmux.conf` to overwrite the default `last-session` co
 ```sh
 bind -N "last-session (via sesh) " L run-shell "sesh last"
 ```
+
+### Connect to root
+
+While working in a nested session, you may way to connect to the root session of a git worktree or git repository. To do this, you can use the `--root` flag with the `sesh connect` command.
+
+I recommend adding this to your `tmux.conf`:
+
+```sh
+bind -N "switch to root session (via sesh) " 9 run-shell "sesh connect --root \'$(pwd)\'"
+```
+
+**Note:** This will only work if you are in a git worktree or git repository. For now, git worktrees expect a `.bare` folder.
 
 ## Configuration
 

--- a/dir/dir.go
+++ b/dir/dir.go
@@ -1,21 +1,26 @@
 package dir
 
 import (
+	"strings"
+
+	"github.com/joshmedeski/sesh/git"
 	"github.com/joshmedeski/sesh/oswrap"
 	"github.com/joshmedeski/sesh/pathwrap"
 )
 
 type Dir interface {
 	Dir(name string) (isDir bool, absPath string)
+	RootDir(name string) (hasRootDir bool, absPath string)
 }
 
 type RealDir struct {
 	os   oswrap.Os
+	git  git.Git
 	path pathwrap.Path
 }
 
-func NewDir(os oswrap.Os, path pathwrap.Path) Dir {
-	return &RealDir{os, path}
+func NewDir(os oswrap.Os, git git.Git, path pathwrap.Path) Dir {
+	return &RealDir{os, git, path}
 }
 
 func (d *RealDir) Dir(path string) (isDir bool, absPath string) {
@@ -33,4 +38,20 @@ func (d *RealDir) Dir(path string) (isDir bool, absPath string) {
 	}
 
 	return true, absPath
+}
+
+func (d *RealDir) RootDir(path string) (hasRootDir bool, absPath string) {
+	isGit, commonDir, _ := d.git.GitCommonDir(path)
+	if isGit && strings.HasSuffix(commonDir, "/.bare") {
+		topLevelDir := strings.TrimSuffix(commonDir, "/.bare")
+		relativePath := strings.TrimPrefix(path, topLevelDir)
+		firstDir := strings.Split(relativePath, string("/"))[1]
+		name, err := d.path.Abs(topLevelDir + "/" + firstDir)
+		if err != nil {
+			return false, ""
+		}
+		return true, name
+	} else {
+		return false, ""
+	}
 }

--- a/dir/mock_Dir.go
+++ b/dir/mock_Dir.go
@@ -73,6 +73,62 @@ func (_c *MockDir_Dir_Call) RunAndReturn(run func(string) (bool, string)) *MockD
 	return _c
 }
 
+// RootDir provides a mock function with given fields: name
+func (_m *MockDir) RootDir(name string) (bool, string) {
+	ret := _m.Called(name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RootDir")
+	}
+
+	var r0 bool
+	var r1 string
+	if rf, ok := ret.Get(0).(func(string) (bool, string)); ok {
+		return rf(name)
+	}
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(name)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) string); ok {
+		r1 = rf(name)
+	} else {
+		r1 = ret.Get(1).(string)
+	}
+
+	return r0, r1
+}
+
+// MockDir_RootDir_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RootDir'
+type MockDir_RootDir_Call struct {
+	*mock.Call
+}
+
+// RootDir is a helper method to define mock.On call
+//   - name string
+func (_e *MockDir_Expecter) RootDir(name interface{}) *MockDir_RootDir_Call {
+	return &MockDir_RootDir_Call{Call: _e.mock.On("RootDir", name)}
+}
+
+func (_c *MockDir_RootDir_Call) Run(run func(name string)) *MockDir_RootDir_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockDir_RootDir_Call) Return(hasRootDir bool, absPath string) *MockDir_RootDir_Call {
+	_c.Call.Return(hasRootDir, absPath)
+	return _c
+}
+
+func (_c *MockDir_RootDir_Call) RunAndReturn(run func(string) (bool, string)) *MockDir_RootDir_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockDir creates a new instance of MockDir. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockDir(t interface {

--- a/seshcli/connect.go
+++ b/seshcli/connect.go
@@ -5,12 +5,13 @@ import (
 	"strings"
 
 	"github.com/joshmedeski/sesh/connector"
+	"github.com/joshmedeski/sesh/dir"
 	"github.com/joshmedeski/sesh/icon"
 	"github.com/joshmedeski/sesh/model"
 	cli "github.com/urfave/cli/v2"
 )
 
-func Connect(c connector.Connector, i icon.Icon) *cli.Command {
+func Connect(c connector.Connector, i icon.Icon, d dir.Dir) *cli.Command {
 	return &cli.Command{
 		Name:                   "connect",
 		Aliases:                []string{"cn"},
@@ -32,6 +33,11 @@ func Connect(c connector.Connector, i icon.Icon) *cli.Command {
 				Aliases: []string{"T"},
 				Usage:   "Use tmuxinator to start session if it doesnt exist",
 			},
+			&cli.BoolFlag{
+				Name:    "root",
+				Aliases: []string{"r"},
+				Usage:   "Switches to the root of the current session",
+			},
 		},
 		Action: func(cCtx *cli.Context) error {
 			if cCtx.NArg() == 0 {
@@ -41,6 +47,14 @@ func Connect(c connector.Connector, i icon.Icon) *cli.Command {
 			if name == "" {
 				return nil
 			}
+
+			if cCtx.Bool("root") {
+				hasRootDir, rootDir := d.RootDir(name)
+				if hasRootDir {
+					name = rootDir
+				}
+			}
+
 			opts := model.ConnectOpts{Switch: cCtx.Bool("switch"), Command: cCtx.String("command"), Tmuxinator: cCtx.Bool("tmuxinator")}
 			trimmedName := i.RemoveIcon(name)
 			if _, err := c.Connect(trimmedName, opts); err != nil {

--- a/seshcli/seshcli.go
+++ b/seshcli/seshcli.go
@@ -30,13 +30,13 @@ func App(version string) cli.App {
 	runtime := runtimewrap.NewRunTime()
 
 	// base dependencies
-	dir := dir.NewDir(os, path)
 	shell := shell.NewShell(exec)
 	home := home.NewHome(os)
 	json := json.NewJson()
 
 	// resource dependencies
 	git := git.NewGit(shell)
+	dir := dir.NewDir(os, git, path)
 	tmux := tmux.NewTmux(os, shell)
 	zoxide := zoxide.NewZoxide(shell)
 	tmuxinator := tmuxinator.NewTmuxinator(shell)
@@ -62,7 +62,7 @@ func App(version string) cli.App {
 		Commands: []*cli.Command{
 			List(icon, json, lister),
 			Last(lister, tmux),
-			Connect(connector, icon),
+			Connect(connector, icon, dir),
 			Clone(),
 		},
 	}


### PR DESCRIPTION
For https://github.com/joshmedeski/sesh/issues/130

Adds a `--root` flag that connects you to the root of a `.bare` worktree or git root, and ignored if not found.

This makes it easy to jump from `~/c/dotfiles/.config/neovim` to `~/c/dotfiles` with a single command. I have bound it to `<prefix>+9` in tmux by adding this to my `tmux.conf`:

```sh
bind -N "switch to root session (via sesh) " 9 run-shell "sesh connect --root \'$(pwd)\'"
```