### PR TITLE
fix: tmuxinator list parsing

### DIFF
--- a/tmuxinator/list.go
+++ b/tmuxinator/list.go
@@ -17,7 +17,7 @@ func (t *RealTmuxinator) List() ([]*model.TmuxinatorConfig, error) {
 
 func parseTmuxinatorConfigsOutput(rawList []string) ([]*model.TmuxinatorConfig, error) {
 	cleanedList := slices.Delete(rawList, 0, 1)
-	cleanedList = slices.Delete(cleanedList, 8, 8)
+	cleanedList = cleanedList[:len(cleanedList)-1]
 	sessions := make([]*model.TmuxinatorConfig, 0, len(cleanedList))
 	for _, line := range cleanedList {
 		if len(line) > 0 {

--- a/tmuxinator/list.go
+++ b/tmuxinator/list.go
@@ -1,13 +1,13 @@
 package tmuxinator
 
 import (
-	"strings"
+	"slices"
 
 	"github.com/joshmedeski/sesh/model"
 )
 
 func (t *RealTmuxinator) List() ([]*model.TmuxinatorConfig, error) {
-	res, err := t.shell.ListCmd("tmuxinator", "list")
+	res, err := t.shell.ListCmd("tmuxinator", "list", "-n")
 	if err != nil {
 		// NOTE: return empty list if error
 		return []*model.TmuxinatorConfig{}, nil
@@ -16,12 +16,13 @@ func (t *RealTmuxinator) List() ([]*model.TmuxinatorConfig, error) {
 }
 
 func parseTmuxinatorConfigsOutput(rawList []string) ([]*model.TmuxinatorConfig, error) {
-	cleanedList := strings.Split(rawList[1], "  ")
+	cleanedList := slices.Delete(rawList, 0, 1)
+	cleanedList = slices.Delete(cleanedList, 8, 8)
 	sessions := make([]*model.TmuxinatorConfig, 0, len(cleanedList))
 	for _, line := range cleanedList {
 		if len(line) > 0 {
 			session := &model.TmuxinatorConfig{
-				Name: strings.TrimSpace(line),
+				Name: line,
 			}
 			sessions = append(sessions, session)
 		}

--- a/tmuxinator/list_test.go
+++ b/tmuxinator/list_test.go
@@ -12,9 +12,12 @@ func TestListConfigs(t *testing.T) {
 	t.Run("List Tmuxinator Configs", func(t *testing.T) {
 		mockShell := new(shell.MockShell)
 		tmuxinator := &RealTmuxinator{shell: mockShell}
-		mockShell.EXPECT().ListCmd("tmuxinator", "list").Return([]string{
+		mockShell.EXPECT().ListCmd("tmuxinator", "list", "-n").Return([]string{
 			"tmuxinator projects:",
-			"dotfiles  sesh  home",
+			"dotfiles",
+			"sesh",
+			"home",
+			"",
 		}, nil)
 		expected := []*model.TmuxinatorConfig{
 			{Name: "dotfiles"},


### PR DESCRIPTION
Changed the tmuxinator list command to use the -n flag to seperate configs onto new lines to make cleaning the response easier