### PR TITLE
docs(readme): reset zsh prompt after calling sesh-sessions script

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ function sesh-sessions() {
     exec <&1
     local session
     session=$(sesh list -t -c | fzf --height 40% --reverse --border-label ' sesh ' --border --prompt '⚡  ')
+    zle reset-prompt > /dev/null 2>&1 || true
     [[ -z "$session" ]] && return
     sesh connect $session
   }


### PR DESCRIPTION
When in a Zsh shell and pressing `Alt-s`, the session list opens with FZF, thanks to the script provided in the `README`.

Pressing `Esc` or `Ctrl-C` goes back to the shell, but we need to press `Enter` again before we're given another Zsh prompt. The same issue appears when entering a tmux session: after detaching from tmux, we need to press `Enter` again before we're given another Zsh prompt.

Calling the function by typing in `sesh-session` at the Zsh prompt and pressing `Enter`, and then closing FZF already does what we want - we're given another Zsh prompt. This PR aims to replicate the same behavior through the `Alt-s` shortcut.