### PR TITLE
Improve `sesh root` logic

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -1,12 +1,15 @@
 package git
 
 import (
+	"strings"
+
 	"github.com/joshmedeski/sesh/shell"
 )
 
 type Git interface {
 	ShowTopLevel(name string) (bool, string, error)
 	GitCommonDir(name string) (bool, string, error)
+	GitMainWorktree(name string) (bool, string, error)
 	Clone(name string) (string, error)
 }
 
@@ -32,6 +35,16 @@ func (g *RealGit) GitCommonDir(path string) (bool, string, error) {
 		return false, "", err
 	}
 	return true, out, nil
+}
+
+func (g *RealGit) GitMainWorktree(path string) (bool, string, error) {
+	out, err := g.shell.CmdFromDir(path, "git", "worktree", "list")
+	if err != nil {
+		return false, "", err
+	}
+	main := strings.Fields(out)[0]
+	// TODO: does strings.Fields need err handling too?
+	return true, main, nil
 }
 
 func (g *RealGit) Clone(name string) (string, error) {

--- a/seshcli/root.go
+++ b/seshcli/root.go
@@ -5,10 +5,11 @@ import (
 
 	"github.com/joshmedeski/sesh/lister"
 	"github.com/joshmedeski/sesh/namer"
+	"github.com/joshmedeski/sesh/git"
 	cli "github.com/urfave/cli/v2"
 )
 
-func Root(l lister.Lister, n namer.Namer) *cli.Command {
+func Root(l lister.Lister, n namer.Namer, git git.Git) *cli.Command {
 	return &cli.Command{
 		Name:                   "root",
 		Aliases:                []string{"r"},
@@ -20,7 +21,8 @@ func Root(l lister.Lister, n namer.Namer) *cli.Command {
 			if !exists {
 				return cli.Exit("No root found for session", 1)
 			}
-			root, err := n.RootName(session.Path)
+			_, path, err := git.GitMainWorktree(session.Path)
+			root, err := n.RootName(path)
 			if err != nil {
 				return cli.Exit(err, 1)
 			}

--- a/seshcli/seshcli.go
+++ b/seshcli/seshcli.go
@@ -70,7 +70,7 @@ func App(version string) cli.App {
 			Last(lister, tmux),
 			Connect(connector, icon, dir),
 			Clone(),
-			Root(lister, namer),
+			Root(lister, namer, git),
 		},
 	}
 }


### PR DESCRIPTION
Still WIP, but here's the gist of what I'm trying to solve...

# The problem:

The sesh README say that `sesh root` assumes existence of a `.bare` folder...

> Note: This will only work if you are in a git worktree or git repository. For now, git worktrees expect a .bare folder.

Not everyone uses git worktrees this way. For example, many prefer the conventional `git clone --bare [repo] project`, which leaves you with a messy project folder, but this is still very common nonetheless.

I on the other hand, prefer to run `git clone --bare [repo] project/.git`, which stores all of the git meta in `.git` folder, but still creates a bare repo. This leaves me with a really clean project folder when using worktrees...

![CleanShot 2024-11-03 at 13 12 18](https://github.com/user-attachments/assets/596796ac-3cf0-4bf8-bec1-8b2455c894e7)

The `.bare` convention is cool too, but again would require different pathing logic for each situation.

# A possible solution:

My proposition is to use the output of `git worktree list`, since git knows where the main worktree / bare repo lives...

![CleanShot 2024-11-03 at 13 13 09](https://github.com/user-attachments/assets/15b63d93-c247-43af-825f-548f8e365293)

^ As you can see, the main worktree is always listed first, no matter how you roll with git worktrees (whether that be using `.git`, or `.bare`, or doing it the messier default way.

For example, this is what you see when running `git worktree list`...

![CleanShot 2024-11-03 at 13 16 30](https://github.com/user-attachments/assets/b82fb527-3038-4ede-9c4e-af95173b192b)

This PR attempts to grab that first (bare) item, for the basis of `sesh root`.

# Todo:

- [x] Proof of concept
- [ ] Output root path instead of root sesh name?
- [ ] Add test coverage?
    - Help me out @joshmedeski? I'm sorry I'm quite the Go newb over here 😅

# Thanks!

PS. Just a quick thank you, for all your awesome work on sesh! It's a game changer for me ❤️