### PR TITLE
Update go.mod module path to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/joshmedeski/sesh
+module github.com/joshmedeski/sesh/v2
 
 go 1.21
 


### PR DESCRIPTION
The module path needs to contain `/v2` to indicate it is on the major version 2.

Then a request to https://proxy.golang.org/github.com/joshmedeski/sesh/v2/@v/v2.7.0.info can be made and the version should eventually update on https://pkg.go.dev/github.com/joshmedeski/sesh