### PR TITLE
feat: add SESH_SESSION_NAME environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@ startup_command = "nvim tmux.conf"
 preview_command = "bat --color=always ~/c/dotfiles/.config/tmux/tmux.conf"
 ```
 
+### Environment Variables
+
+When creating a new tmux session, sesh now automatically sets the `SESH_SESSION_NAME` environment variable to the name of the session. This can be useful for scripts or programs that need to know the current session name.
+
 ### Listing Configurations
 
 Session configurations will load by default if no flags are provided (the return after tmux sessions and before zoxide results). If you want to explicitly list them, you can use the `-c` flag.
@@ -308,3 +312,4 @@ Made with [contrib.rocks](https://contrib.rocks).
    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=joshmedeski/sesh&type=Date" />
  </picture>
 </a>
+

--- a/tmux/tmux.go
+++ b/tmux/tmux.go
@@ -39,7 +39,7 @@ func (t *RealTmux) SendKeys(targetPane string, keys string) (string, error) {
 }
 
 func (t *RealTmux) NewSession(sessionName string, startDir string) (string, error) {
-	return t.shell.Cmd("tmux", "new-session", "-d", "-s", sessionName, "-c", startDir)
+	return t.shell.Cmd("tmux", "new-session", "-d", "-s", sessionName, "-c", startDir, "-e", "SESH_SESSION_NAME="+sessionName)
 }
 
 func (t *RealTmux) CapturePane(targetSession string) (string, error) {


### PR DESCRIPTION
When creating new tmux sessions, sesh now automatically sets the SESH_SESSION_NAME environment variable to the name of the session. This enables scripts and programs to know the current session name.

- Add -e SESH_SESSION_NAME to tmux new-session command

- Document the new feature in README.md under Environment Variables section