### PR TITLE
feat: Support regex in blacklist

### DIFF
--- a/lister/blacklist.go
+++ b/lister/blacklist.go
@@ -1,20 +1,12 @@
 package lister
 
-import "strings"
+import "regexp"
 
 func isBlacklisted(blacklist []string, name string) bool {
 	for _, blacklistedName := range blacklist {
-		if strings.EqualFold(blacklistedName, name) {
+		if regexp.MustCompile(blacklistedName).MatchString(name) {
 			return true
 		}
 	}
 	return false
-}
-
-func createBlacklistSet(blacklist []string) map[string]struct{} {
-	blacklistSet := make(map[string]struct{}, len(blacklist))
-	for _, name := range blacklist {
-		blacklistSet[name] = struct{}{}
-	}
-	return blacklistSet
 }

--- a/lister/tmux.go
+++ b/lister/tmux.go
@@ -16,12 +16,11 @@ func listTmux(l *RealLister) (model.SeshSessions, error) {
 		return model.SeshSessions{}, fmt.Errorf("couldn't list tmux sessions: %q", err)
 	}
 
-	blacklistSet := createBlacklistSet(l.config.Blacklist)
 	directory := make(map[string]model.SeshSession)
 	orderedIndex := []string{}
 
 	for _, session := range tmuxSessions {
-		if _, blacklisted := blacklistSet[session.Name]; !blacklisted {
+		if !isBlacklisted(l.config.Blacklist, session.Name) {
 			key := tmuxKey(session.Name)
 			orderedIndex = append(orderedIndex, key)
 			directory[key] = model.SeshSession{


### PR DESCRIPTION
My go fu is not that high, but this works and I really have a use-case for using regex (or at least some wild-card) matching in the blacklist.

e.g.

blacklist = [
"^scratch$",
"^__"
]

I have quite some temporary popup sessions that start with __