### PR TITLE
Defer hiding the attached session until after duplicates have been hidden

### DIFF
--- a/lister/list.go
+++ b/lister/list.go
@@ -2,6 +2,7 @@ package lister
 
 import (
 	"github.com/joshmedeski/sesh/v2/model"
+	"slices"
 )
 
 type (
@@ -41,8 +42,7 @@ func (l *RealLister) List(opts ListOptions) (model.SeshSessions, error) {
 			sessionsCopy := sessions.OrderedIndex
 			for i, ses := range sessionsCopy {
 				if attachedSession.Name == sessions.Directory[ses].Name {
-					sessions.OrderedIndex = append(sessions.OrderedIndex[:i],
-						sessions.OrderedIndex[i+1:]...)
+					sessions.OrderedIndex = slices.Delete(sessions.OrderedIndex, i, i+1)
 				}
 			}
 		}

--- a/lister/list.go
+++ b/lister/list.go
@@ -37,15 +37,6 @@ func (l *RealLister) List(opts ListOptions) (model.SeshSessions, error) {
 		if err != nil {
 			return model.SeshSessions{}, err
 		}
-		if opts.HideAttached {
-			attachedSession, _ := GetAttachedTmuxSession(l)
-			sessionsCopy := sessions.OrderedIndex
-			for i, ses := range sessionsCopy {
-				if attachedSession.Name == sessions.Directory[ses].Name {
-					sessions.OrderedIndex = slices.Delete(sessions.OrderedIndex, i, i+1)
-				}
-			}
-		}
 		fullOrderedIndex = append(fullOrderedIndex, sessions.OrderedIndex...)
 		for _, i := range sessions.OrderedIndex {
 			fullDirectory[i] = sessions.Directory[i]
@@ -64,6 +55,16 @@ func (l *RealLister) List(opts ListOptions) (model.SeshSessions, error) {
 			}
 		}
 		fullOrderedIndex = fullOrderedIndex[:destIndex]
+	}
+
+	if opts.HideAttached {
+		attachedSession, _ := GetAttachedTmuxSession(l)
+		for i, index := range fullOrderedIndex {
+			if fullDirectory[index].Name == attachedSession.Name {
+				fullOrderedIndex = slices.Delete(fullOrderedIndex, i, i+1)
+				break
+			}
+		}
 	}
 
 	return model.SeshSessions{


### PR DESCRIPTION
fixes #249

>[!Warning]
> Be gentle: this is the first Go code I've written

>[!Note]
> Using `slices.Delete` was recommended by the linter as the modern way, versus slicing around the range you want to delete, so I went with that.