### PR TITLE
Strict toml marshalling

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,10 +301,4 @@ Made with [contrib.rocks](https://contrib.rocks).
 
 ## Star History
 
-<a href="https://star-history.com/#joshmedeski/sesh&Date">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=joshmedeski/sesh&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=joshmedeski/sesh&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=joshmedeski/sesh&type=Date" />
- </picture>
-</a>
+[![Star History Chart](https://api.star-history.com/svg?repos=joshmedeski/sesh&type=Date)](https://www.star-history.com/#joshmedeski/sesh&Date)

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -13,13 +13,27 @@ import (
 )
 
 type Configurator interface {
-	GetConfig() (model.Config, string, error)
+	GetConfig() (model.Config, error) // Since error is an interface, we use it here to return a single variable instead of multiple variables (configError holds 2 strings, human and err)
 }
 
 type RealConfigurator struct {
 	os      oswrap.Os
 	path    pathwrap.Path
 	runtime runtimewrap.Runtime
+}
+
+// Helper for consolidation of error into a single structure
+type ConfigError struct {
+	Err          string // Load the (DecodeError/StrictMissingError).Error() into this
+	HumanDetails string // Load the (DecodeError/StrictMissingError).String() into this
+}
+
+func (ce *ConfigError) Error() string {
+	return ce.Err // Return the error
+}
+
+func (ce *ConfigError) Human() string {
+	return ce.HumanDetails // Return the string
 }
 
 func NewConfigurator(os oswrap.Os, path pathwrap.Path, runtime runtimewrap.Runtime) Configurator {
@@ -38,39 +52,39 @@ func (c *RealConfigurator) fullImportPath(homeDir, importPath string) (string, e
 	return c.path.Join(homeDir, importPath[1:]), nil
 }
 
-func (c *RealConfigurator) getConfigFileFromUserConfigDir() (model.Config, string, error) {
+func (c *RealConfigurator) getConfigFileFromUserConfigDir() (model.Config, error) {
 	config := model.Config{}
 	evaluation := model.Evaluation{}
 	userHomeDir, err := c.os.UserHomeDir()
 	if err != nil {
-		return config, "", fmt.Errorf("couldn't get user config dir: %q", err)
+		return config, fmt.Errorf("couldn't get user config dir: %q", err)
 	}
 	userConfigDir := c.path.Join(userHomeDir, ".config")
 	configFilePath := c.configFilePath(userConfigDir)
 	file, _ := c.os.ReadFile(configFilePath)
-	// TODO: add to debugging logs
+	// TODO: add to debugging logs (Update, added details string)
 	// if err != nil {
-	// 	return config, fmt.Errorf("couldn't read config file: %q", err)
+	// 	return config, "", fmt.Errorf("couldn't read config file: %q", err)
 	// }
 	_ = toml.Unmarshal(file, &evaluation)
 	if evaluation.StrictMode {
 		reader := strings.NewReader(string(file))
 		d := toml.NewDecoder(reader)
-		d.DisallowUnknownFields()
+		d.DisallowUnknownFields() // enable the strict mode
 		err = d.Decode(&config)
 		if err != nil {
 			var details *toml.StrictMissingError
 			if errors.As(err, &details) {
-				return config, details.String(), err
+				return config, &ConfigError{Err: err.Error(), HumanDetails: details.String()}
 			}
-			return config, "", err
+			return config, err
 		}
 	} else {
 		err = toml.Unmarshal(file, &config)
 		if err != nil {
 			var derr *toml.DecodeError
 			if errors.As(err, &derr) {
-				return config, derr.String(), err
+				return config, &ConfigError{Err: err.Error(), HumanDetails: derr.String()}
 			}
 		}
 	}
@@ -78,29 +92,29 @@ func (c *RealConfigurator) getConfigFileFromUserConfigDir() (model.Config, strin
 	for _, importPath := range config.ImportPaths {
 		importFilePath, err := c.fullImportPath(userHomeDir, importPath)
 		if err != nil {
-			return config, "", fmt.Errorf("couldn't get full import path: %q", err)
+			return config, fmt.Errorf("couldn't get full import path: %q", err)
 		}
 
 		importFile, err := c.os.ReadFile(importFilePath)
 		if err != nil {
-			return config, "", fmt.Errorf("couldn't read import file %s: %q", importFilePath, err)
+			return config, fmt.Errorf("couldn't read import file %s: %q", importFilePath, err)
 		}
 
 		importConfig := model.Config{}
 		if err := toml.Unmarshal(importFile, &importConfig); err != nil {
-			return config, "", fmt.Errorf("couldn't unmarshal import file %s: %q", importFilePath, err)
+			return config, fmt.Errorf("couldn't unmarshal import file %s: %q", importFilePath, err)
 		}
 
 		config.SessionConfigs = append(config.SessionConfigs, importConfig.SessionConfigs...)
 	}
 
-	return config, "", nil
+	return config, nil
 }
 
-func (c *RealConfigurator) GetConfig() (model.Config, string, error) {
-	config, details, err := c.getConfigFileFromUserConfigDir()
+func (c *RealConfigurator) GetConfig() (model.Config, error) {
+	config, err := c.getConfigFileFromUserConfigDir()
 	if err != nil {
-		return model.Config{}, details, err
+		return model.Config{}, err
 	}
-	return config, "", nil
+	return config, nil
 }

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -40,7 +40,7 @@ func (c *RealConfigurator) fullImportPath(homeDir, importPath string) (string, e
 
 func (c *RealConfigurator) getConfigFileFromUserConfigDir() (model.Config, string, error) {
 	config := model.Config{}
-	evaluation := model.EvalSettings{}
+	evaluation := model.Evaluation{}
 	userHomeDir, err := c.os.UserHomeDir()
 	if err != nil {
 		return config, "", fmt.Errorf("couldn't get user config dir: %q", err)
@@ -53,7 +53,7 @@ func (c *RealConfigurator) getConfigFileFromUserConfigDir() (model.Config, strin
 	// 	return config, fmt.Errorf("couldn't read config file: %q", err)
 	// }
 	_ = toml.Unmarshal(file, &evaluation)
-	if evaluation.EvalConfig.Strict {
+	if evaluation.StrictMode {
 		reader := strings.NewReader(string(file))
 		d := toml.NewDecoder(reader)
 		d.DisallowUnknownFields()

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -40,6 +40,7 @@ func (c *RealConfigurator) fullImportPath(homeDir, importPath string) (string, e
 
 func (c *RealConfigurator) getConfigFileFromUserConfigDir() (model.Config, string, error) {
 	config := model.Config{}
+	evaluation := model.EvalSettings{}
 	userHomeDir, err := c.os.UserHomeDir()
 	if err != nil {
 		return config, "", fmt.Errorf("couldn't get user config dir: %q", err)
@@ -51,8 +52,8 @@ func (c *RealConfigurator) getConfigFileFromUserConfigDir() (model.Config, strin
 	// if err != nil {
 	// 	return config, fmt.Errorf("couldn't read config file: %q", err)
 	// }
-	_ = toml.Unmarshal(file, &config)
-	if config.EvalSettings.Strict {
+	_ = toml.Unmarshal(file, &evaluation)
+	if evaluation.EvalConfig.Strict {
 		reader := strings.NewReader(string(file))
 		d := toml.NewDecoder(reader)
 		d.DisallowUnknownFields()

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -56,8 +56,11 @@ func (c *RealConfigurator) getConfigFileFromUserConfigDir() (model.Config, *stri
 	d.DisallowUnknownFields()
 	err = d.Decode(&config)
 	var details *toml.StrictMissingError
-	string_details := details.String()
-	if !errors.As(err, &details) {
+	var string_details string
+	if errors.As(err, &details) {
+		string_details = details.String()
+	}
+	if err != nil {
 		return config, &string_details, fmt.Errorf("couldn't unmarshal config file: %q", err)
 	}
 

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -58,15 +58,12 @@ func (c *RealConfigurator) getConfigFileFromUserConfigDir() (model.Config, strin
 		d := toml.NewDecoder(reader)
 		d.DisallowUnknownFields()
 		err = d.Decode(&config)
-		var details *toml.StrictMissingError
 		if err != nil {
-			if !errors.As(err, &details) {
-				fmt.Printf("err: %v\n", err)
+			var details *toml.StrictMissingError
+			if errors.As(err, &details) {
+				return config, details.String(), err
 			}
-			fmt.Println(details.String())
-		}
-		if details != nil {
-			return config, details.String(), err
+			return config, "", err
 		}
 	} else {
 		err = toml.Unmarshal(file, &config)

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -52,7 +52,7 @@ func (c *RealConfigurator) getConfigFileFromUserConfigDir() (model.Config, strin
 	// 	return config, fmt.Errorf("couldn't read config file: %q", err)
 	// }
 	_ = toml.Unmarshal(file, &config)
-	if config.EvalSettings.Strict == "yes" {
+	if config.EvalSettings.Strict {
 		reader := strings.NewReader(string(file))
 		d := toml.NewDecoder(reader)
 		d.DisallowUnknownFields()
@@ -60,7 +60,7 @@ func (c *RealConfigurator) getConfigFileFromUserConfigDir() (model.Config, strin
 		var details *toml.StrictMissingError
 		if err != nil {
 			if !errors.As(err, &details) {
-				panic(fmt.Sprintf("err should have been a *toml.StrictMissingError, but got %s (%T)", err, err))
+				fmt.Printf("err: %v\n", err)
 			}
 			fmt.Println(details.String())
 		}

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -13,7 +13,7 @@ import (
 )
 
 type Configurator interface {
-	GetConfig() (model.Config, *string, error)
+	GetConfig() (model.Config, string, error)
 }
 
 type RealConfigurator struct {
@@ -38,11 +38,11 @@ func (c *RealConfigurator) fullImportPath(homeDir, importPath string) (string, e
 	return c.path.Join(homeDir, importPath[1:]), nil
 }
 
-func (c *RealConfigurator) getConfigFileFromUserConfigDir() (model.Config, *string, error) {
+func (c *RealConfigurator) getConfigFileFromUserConfigDir() (model.Config, string, error) {
 	config := model.Config{}
 	userHomeDir, err := c.os.UserHomeDir()
 	if err != nil {
-		return config, nil, fmt.Errorf("couldn't get user config dir: %q", err)
+		return config, "", fmt.Errorf("couldn't get user config dir: %q", err)
 	}
 	userConfigDir := c.path.Join(userHomeDir, ".config")
 	configFilePath := c.configFilePath(userConfigDir)
@@ -51,45 +51,59 @@ func (c *RealConfigurator) getConfigFileFromUserConfigDir() (model.Config, *stri
 	// if err != nil {
 	// 	return config, fmt.Errorf("couldn't read config file: %q", err)
 	// }
-	reader := strings.NewReader(string(file))
-	d := toml.NewDecoder(reader)
-	d.DisallowUnknownFields()
-	err = d.Decode(&config)
-	var details *toml.StrictMissingError
-	var string_details string
-	if errors.As(err, &details) {
-		string_details = details.String()
+	if err := toml.Unmarshal(file, &config); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		var derr *toml.DecodeError
+		if errors.As(err, &derr) {
+			return config, derr.String(), err
+		}
 	}
+	if config.EvalSettings.Strict != "yes" {
+		reader := strings.NewReader(string(file))
+		d := toml.NewDecoder(reader)
+		d.DisallowUnknownFields()
+		err = d.Decode(&config)
+		if err != nil {
+			var derr *toml.DecodeError
+			if errors.As(err, &derr) {
+				return config, derr.String(), err
+			}
+		}
+	}
+	err = toml.Unmarshal(file, &config)
 	if err != nil {
-		return config, &string_details, fmt.Errorf("couldn't unmarshal config file: %q", err)
+		var derr *toml.DecodeError
+		if errors.As(err, &derr) {
+			return config, derr.String(), err
+		}
 	}
 
 	for _, importPath := range config.ImportPaths {
 		importFilePath, err := c.fullImportPath(userHomeDir, importPath)
 		if err != nil {
-			return config, nil, fmt.Errorf("couldn't get full import path: %q", err)
+			return config, "", fmt.Errorf("couldn't get full import path: %q", err)
 		}
 
 		importFile, err := c.os.ReadFile(importFilePath)
 		if err != nil {
-			return config, nil, fmt.Errorf("couldn't read import file %s: %q", importFilePath, err)
+			return config, "", fmt.Errorf("couldn't read import file %s: %q", importFilePath, err)
 		}
 
 		importConfig := model.Config{}
 		if err := toml.Unmarshal(importFile, &importConfig); err != nil {
-			return config, nil, fmt.Errorf("couldn't unmarshal import file %s: %q", importFilePath, err)
+			return config, "", fmt.Errorf("couldn't unmarshal import file %s: %q", importFilePath, err)
 		}
 
 		config.SessionConfigs = append(config.SessionConfigs, importConfig.SessionConfigs...)
 	}
 
-	return config, nil, nil
+	return config, "", nil
 }
 
-func (c *RealConfigurator) GetConfig() (model.Config, *string, error) {
+func (c *RealConfigurator) GetConfig() (model.Config, string, error) {
 	config, details, err := c.getConfigFileFromUserConfigDir()
 	if err != nil {
 		return model.Config{}, details, err
 	}
-	return config, nil, nil
+	return config, "", nil
 }

--- a/main.go
+++ b/main.go
@@ -88,12 +88,12 @@ func createLoggerFile(userTempDir string) (*os.File, error) {
 	now := time.Now()
 	date := fmt.Sprintf("%s.log", now.Format("2006-01-02"))
 
-	if err := os.MkdirAll(path.Join(userTempDir, ".seshtmp"), 0755); err != nil {
+	if err := os.MkdirAll(path.Join(userTempDir, ".seshtmp"), 0o755); err != nil {
 		return nil, err
 	}
 
 	fileFullPath := path.Join(userTempDir, ".seshtmp", date)
-	file, err := os.OpenFile(fileFullPath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	file, err := os.OpenFile(fileFullPath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o666)
 	if err != nil {
 		return nil, err
 	}

--- a/model/config.go
+++ b/model/config.go
@@ -2,10 +2,11 @@ package model
 
 type (
 	Config struct {
-		ImportPaths          []string             `toml:"import"`
-		DefaultSessionConfig DefaultSessionConfig `toml:"default_session"`
-		Blacklist            []string             `toml:"blacklist"`
-		SessionConfigs       []SessionConfig      `toml:"session"`
+		EvalSettings         EvaluationConfigSettings `toml:"evaluation"`
+		ImportPaths          []string                 `toml:"import"`
+		DefaultSessionConfig DefaultSessionConfig     `toml:"default_session"`
+		Blacklist            []string                 `toml:"blacklist"`
+		SessionConfigs       []SessionConfig          `toml:"session"`
 	}
 
 	DefaultSessionConfig struct {
@@ -22,5 +23,9 @@ type (
 		Path                string `toml:"path"`
 		DisableStartCommand bool   `toml:"disable_startup_command"`
 		DefaultSessionConfig
+	}
+
+	EvaluationConfigSettings struct {
+		Strict string `toml:"strict"`
 	}
 )

--- a/model/config.go
+++ b/model/config.go
@@ -2,13 +2,13 @@ package model
 
 type (
 	Config struct {
-		EvalSettings         EvaluationConfigSettings `toml:"evaluation"`
-		ImportPaths          []string                 `toml:"import"`
-		DefaultSessionConfig DefaultSessionConfig     `toml:"default_session"`
-		Blacklist            []string                 `toml:"blacklist"`
-		SessionConfigs       []SessionConfig          `toml:"session"`
-		SortOrder            []string                 `toml:"sort_order"`
-		WindowConfigs        []WindowConfig           `toml:"window"`
+		EvalSettings         evalConfig           `toml:"evaluation"`
+		ImportPaths          []string             `toml:"import"`
+		DefaultSessionConfig DefaultSessionConfig `toml:"default_session"`
+		Blacklist            []string             `toml:"blacklist"`
+		SessionConfigs       []SessionConfig      `toml:"session"`
+		SortOrder            []string             `toml:"sort_order"`
+		WindowConfigs        []WindowConfig       `toml:"window"`
 	}
 
 	DefaultSessionConfig struct {
@@ -28,8 +28,13 @@ type (
 		DefaultSessionConfig
 	}
 
-	EvaluationConfigSettings struct {
+	// NOTE: Making all evaluation structs public is a BAD idea because it makes way too many structs
+	// for _just_ configuration public
+	evalConfig struct {
 		Strict bool `toml:"strict"`
+	}
+	EvalSettings struct {
+		EvalConfig evalConfig `toml:"evaluation"`
 	}
 
 	WindowConfig struct {

--- a/model/config.go
+++ b/model/config.go
@@ -2,13 +2,16 @@ package model
 
 type (
 	Config struct {
-		EvalSettings         evalConfig           `toml:"evaluation"`
+		StrictMode           bool                 `toml:"strict_mode"`
 		ImportPaths          []string             `toml:"import"`
 		DefaultSessionConfig DefaultSessionConfig `toml:"default_session"`
 		Blacklist            []string             `toml:"blacklist"`
 		SessionConfigs       []SessionConfig      `toml:"session"`
 		SortOrder            []string             `toml:"sort_order"`
 		WindowConfigs        []WindowConfig       `toml:"window"`
+	}
+	Evaluation struct {
+		StrictMode bool `toml:"strict_mode"`
 	}
 
 	DefaultSessionConfig struct {
@@ -26,15 +29,6 @@ type (
 		Path                string `toml:"path"`
 		DisableStartCommand bool   `toml:"disable_startup_command"`
 		DefaultSessionConfig
-	}
-
-	// NOTE: Making all evaluation structs public is a BAD idea because it makes way too many structs
-	// for _just_ configuration public
-	evalConfig struct {
-		Strict bool `toml:"strict"`
-	}
-	EvalSettings struct {
-		EvalConfig evalConfig `toml:"evaluation"`
 	}
 
 	WindowConfig struct {

--- a/model/config.go
+++ b/model/config.go
@@ -7,13 +7,8 @@ type (
 		DefaultSessionConfig DefaultSessionConfig     `toml:"default_session"`
 		Blacklist            []string                 `toml:"blacklist"`
 		SessionConfigs       []SessionConfig          `toml:"session"`
-
-		ImportPaths          []string             `toml:"import"`
-		DefaultSessionConfig DefaultSessionConfig `toml:"default_session"`
-		Blacklist            []string             `toml:"blacklist"`
-		SessionConfigs       []SessionConfig      `toml:"session"`
-		SortOrder            []string             `toml:"sort_order"`
-		WindowConfigs        []WindowConfig       `toml:"window"`
+		SortOrder            []string                 `toml:"sort_order"`
+		WindowConfigs        []WindowConfig           `toml:"window"`
 	}
 
 	DefaultSessionConfig struct {
@@ -34,8 +29,9 @@ type (
 	}
 
 	EvaluationConfigSettings struct {
-		Strict string `toml:"strict"`
+		Strict bool `toml:"strict"`
 	}
+
 	WindowConfig struct {
 		Name          string `toml:"name"`
 		StartupScript string `toml:"startup_script"`

--- a/seshcli/seshcli.go
+++ b/seshcli/seshcli.go
@@ -51,7 +51,7 @@ func App(version string) cli.App {
 	// config
 	config, err, details := configurator.NewConfigurator(os, path, runtime).GetConfig()
 	// TODO: make sure to ignore the error if the config doesn't exist
-	if err != nil {
+	if err != "" {
 		if details != nil {
 			fmt.Println(details)
 			panic(details.Error())

--- a/seshcli/seshcli.go
+++ b/seshcli/seshcli.go
@@ -1,6 +1,7 @@
 package seshcli
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/urfave/cli/v2"
@@ -48,9 +49,13 @@ func App(version string) cli.App {
 	tmuxinator := tmuxinator.NewTmuxinator(shell)
 
 	// config
-	config, err := configurator.NewConfigurator(os, path, runtime).GetConfig()
+	config, err, details := configurator.NewConfigurator(os, path, runtime).GetConfig()
 	// TODO: make sure to ignore the error if the config doesn't exist
 	if err != nil {
+		if details != nil {
+			fmt.Println(details)
+			panic(details.Error())
+		}
 		slog.Error("seshcli/seshcli.go: App", "error", err)
 		panic(err)
 	}

--- a/seshcli/seshcli.go
+++ b/seshcli/seshcli.go
@@ -1,7 +1,6 @@
 package seshcli
 
 import (
-	"fmt"
 	"log/slog"
 
 	"github.com/urfave/cli/v2"
@@ -49,12 +48,11 @@ func App(version string) cli.App {
 	tmuxinator := tmuxinator.NewTmuxinator(shell)
 
 	// config
-	config, err, details := configurator.NewConfigurator(os, path, runtime).GetConfig()
+	config, details, err := configurator.NewConfigurator(os, path, runtime).GetConfig()
 	// TODO: make sure to ignore the error if the config doesn't exist
-	if err != "" {
-		if details != nil {
-			fmt.Println(details)
-			panic(details.Error())
+	if err != nil {
+		if details != "" {
+			slog.Error("seshcli/seshcli.go: App", "version", version, "error", details)
 		}
 		slog.Error("seshcli/seshcli.go: App", "error", err)
 		panic(err)

--- a/seshcli/seshcli.go
+++ b/seshcli/seshcli.go
@@ -31,7 +31,7 @@ import (
 	"github.com/joshmedeski/sesh/v2/zoxide"
 )
 
-func App(version string) *cli.App {
+func App(version string) cli.App {
 	// wrapper dependencies
 	exec := execwrap.NewExec()
 	os := oswrap.NewOs()
@@ -76,7 +76,7 @@ func App(version string) *cli.App {
 	previewer := previewer.NewPreviewer(lister, tmux, icon, dir, home, ls, config, shell)
 	cloner := cloner.NewCloner(connector, git)
 
-	return &cli.App{
+	return cli.App{
 		Name:    "sesh",
 		Version: version,
 		Usage:   "Smart session manager for the terminal",


### PR DESCRIPTION
This prevents users from putting in invalid keys. I also made it print details of the error if the error doesn't result to nil and same with the details. This was done by not using the `toml.Unmarshal` alias and creating a Decoder manually with a strings.reader(file) 
as the argument and enabling strict marshalling to the Decoder, 