### PR TITLE
feat: allow replacements in startup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,17 @@ startup_command = "nvim tmux.conf"
 preview_command = "bat --color=always ~/c/dotfiles/.config/tmux/tmux.conf"
 ```
 
+### Path substitution
+If you want to use the path of the selected session in your startup or preview command, you can use the `{}` placeholder.  
+This will be replaced with the session's path when the command is run.
+
+An example of this in use is the following, where the `tmuxinator` default_project uses the path as key/value pair using [ERB syntax](https://github.com/tmuxinator/tmuxinator?tab=readme-ov-file#erb):
+```toml
+[default_session]
+startup_command = "tmuxinator start default_project path={}"
+preview_command = "eza --all --git --icons --color=always {}"
+```
+
 ### Multiple windows
 
 If you want your session to have multiple windows you can define windows in your configuration. You can then use these window layouts in your sessions. These windows can be reused as many times as you want and you can add as many windows to each session as you want.

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.1
+	github.com/petar-dambovaliev/aho-corasick v0.0.0-20250424160509-463d218d4745
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v2 v2.27.1
 )

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pelletier/go-toml/v2 v2.2.1 h1:9TA9+T8+8CUCO2+WYnDLCgrYi9+omqKXyjDtosvtEhg=
 github.com/pelletier/go-toml/v2 v2.2.1/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
+github.com/petar-dambovaliev/aho-corasick v0.0.0-20250424160509-463d218d4745 h1:Vpr4VgAizEgEZsaMohpw6JYDP+i9Of9dmdY4ufNP6HI=
+github.com/petar-dambovaliev/aho-corasick v0.0.0-20250424160509-463d218d4745/go.mod h1:EHPiTAKtiFmrMldLUNswFwfZ2eJIYBHktdaUTZxYWRw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=

--- a/replacer/replacer.go
+++ b/replacer/replacer.go
@@ -1,0 +1,38 @@
+package replacer
+
+import (
+	ahocorasick "github.com/petar-dambovaliev/aho-corasick"
+)
+
+type Replacer interface {
+	Replace(command string, replacements map[string]string) string
+}
+
+type RealReplacer struct{}
+
+func NewReplacer() Replacer {
+	return &RealReplacer{}
+}
+
+func (r *RealReplacer) Replace(command string, replacements map[string]string) string {
+	dict := make([]string, 0, len(replacements))
+	replacementArray := make([]string, 0, len(replacements))
+	for k, v := range replacements {
+		dict = append(dict, k)
+		replacementArray = append(replacementArray, v)
+	}
+	ac := getAhoCorasick(dict)
+	replacer := ahocorasick.NewReplacer(ac)
+	return replacer.ReplaceAll(command, replacementArray)
+}
+
+func getAhoCorasick(dictionary []string) ahocorasick.AhoCorasick {
+	builder := ahocorasick.NewAhoCorasickBuilder(ahocorasick.Opts{
+		AsciiCaseInsensitive: true,
+		MatchOnlyWholeWords:  true,
+		MatchKind:            ahocorasick.LeftMostFirstMatch,
+		DFA:                  true,
+	})
+
+	return builder.Build(dictionary)
+}

--- a/replacer/replacer_test.go
+++ b/replacer/replacer_test.go
@@ -1,0 +1,44 @@
+package replacer
+
+import (
+	"testing"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func TestReplace(t *testing.T) {
+	defaultReplacements := map[string]string{
+		"{}": "hello",
+		"~":  "/home/test",
+	}
+
+	testCases := map[string]testCase{
+		"multiple replacements": {
+			"~/.local/bin/rat {}{}",
+			"/home/test/.local/bin/rat hellohello",
+		},
+		"single replacement": {
+			"/bin/rat {}",
+			"/bin/rat hello",
+		},
+		"no replacement": {
+			"/bin/rat",
+			"/bin/rat",
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			replacer := NewReplacer()
+			result := replacer.Replace(test.input, defaultReplacements)
+			if result != test.expected {
+				t.Errorf("expected %s, got %s", test.expected, result)
+			}
+		})
+	}
+	t.Run("", func(t *testing.T) {
+	})
+}

--- a/seshcli/seshcli.go
+++ b/seshcli/seshcli.go
@@ -20,6 +20,7 @@ import (
 	"github.com/joshmedeski/sesh/v2/oswrap"
 	"github.com/joshmedeski/sesh/v2/pathwrap"
 	"github.com/joshmedeski/sesh/v2/previewer"
+	"github.com/joshmedeski/sesh/v2/replacer"
 	"github.com/joshmedeski/sesh/v2/runtimewrap"
 	"github.com/joshmedeski/sesh/v2/shell"
 	"github.com/joshmedeski/sesh/v2/startup"
@@ -39,6 +40,7 @@ func App(version string) cli.App {
 	home := home.NewHome(os)
 	shell := shell.NewShell(exec, home)
 	json := json.NewJson()
+	replacer := replacer.NewReplacer()
 
 	// resource dependencies
 	git := git.NewGit(shell)
@@ -60,7 +62,7 @@ func App(version string) cli.App {
 	// core dependencies
 	ls := ls.NewLs(config, shell)
 	lister := lister.NewLister(config, home, tmux, zoxide, tmuxinator)
-	startup := startup.NewStartup(config, lister, tmux, home)
+	startup := startup.NewStartup(config, lister, tmux, home, replacer)
 	namer := namer.NewNamer(path, git, home)
 	connector := connector.NewConnector(config, dir, home, lister, namer, startup, tmux, zoxide, tmuxinator)
 	icon := icon.NewIcon(config)

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -55,4 +55,14 @@ func TestShellPrepareCmd(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, []string{"/home/test/.local/bin/rat", "hello"}, cmdParts)
 	})
+
+	// This test case asserts the existing behaviour when the desired replacement is not separated by spaces
+	t.Run("should not use a partial match", func(t *testing.T) {
+		mockHome := new(home.MockHome)
+		shell := &RealShell{home: mockHome}
+		mockHome.On("ExpandHome", "~/.local/bin/rat").Return("/home/test/.local/bin/rat", nil)
+		cmdParts, err := shell.PrepareCmd("~/.local/bin/rat localVar={}", map[string]string{"{}": "hello"})
+		assert.Nil(t, err)
+		assert.Equal(t, []string{"/home/test/.local/bin/rat", "localVar={}"}, cmdParts)
+	})
 }

--- a/startup/config.go
+++ b/startup/config.go
@@ -10,7 +10,11 @@ func configStrategy(s *RealStartup, session model.SeshSession) (string, error) {
 	}
 
 	if exists && config.StartupCommand != "" {
-		return config.StartupCommand, nil
+		replacements := map[string]string{
+			"{}": session.Path,
+		}
+
+		return s.replacer.Replace(config.StartupCommand, replacements), nil
 	}
 	return "", nil
 }

--- a/startup/defaultconfig.go
+++ b/startup/defaultconfig.go
@@ -9,7 +9,11 @@ func defaultConfigStrategy(s *RealStartup, session model.SeshSession) (string, e
 
 	defaultConfig := s.config.DefaultSessionConfig
 	if defaultConfig.StartupCommand != "" {
-		return defaultConfig.StartupCommand, nil
+		replacements := map[string]string{
+			"{}": session.Path,
+		}
+
+		return s.replacer.Replace(defaultConfig.StartupCommand, replacements), nil
 	}
 
 	return "", nil

--- a/startup/startup.go
+++ b/startup/startup.go
@@ -6,6 +6,7 @@ import (
 	"github.com/joshmedeski/sesh/v2/home"
 	"github.com/joshmedeski/sesh/v2/lister"
 	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/replacer"
 	"github.com/joshmedeski/sesh/v2/tmux"
 )
 
@@ -14,14 +15,17 @@ type Startup interface {
 }
 
 type RealStartup struct {
-	lister lister.Lister
-	tmux   tmux.Tmux
-	config model.Config
-	home   home.Home
+	lister   lister.Lister
+	tmux     tmux.Tmux
+	config   model.Config
+	home     home.Home
+	replacer replacer.Replacer
 }
 
-func NewStartup(config model.Config, lister lister.Lister, tmux tmux.Tmux, home home.Home) Startup {
-	return &RealStartup{lister, tmux, config, home}
+func NewStartup(
+	config model.Config, lister lister.Lister, tmux tmux.Tmux, home home.Home, replacer replacer.Replacer,
+) Startup {
+	return &RealStartup{lister, tmux, config, home, replacer}
 }
 
 func (s *RealStartup) Exec(session model.SeshSession) (string, error) {


### PR DESCRIPTION
Currently, when you use the replacement syntax `{}` in the startup command, it isn't replaced. Since I was hoping to use this as an argument that can't be passed with a space delimiting it, I needed to introduce a separate `replacer` which uses the `aho-corasick` algorithm to replace instances of the string. I included tests for the replacer and another test to assert the existing behaviour for preview commands.

This PR was made specifically to introduce the least change, but my preference (if you're happy with it) is to instead use the new `Replacer` to complete replacements in `PrepareCmd` _before_ splitting and substituting the home directory. This way we have a consistent replacement mechanism. I'm also open to the replacement mechanism being used for home directory substitution as well, with `PrepareCmd` only being used to split into a string array. This would change behaviour, however, which I wasn't 100% on!