### PR TITLE
Improve Git Bare Repo Naming

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -8,6 +8,7 @@ type Git interface {
 	ShowTopLevel(name string) (bool, string, error)
 	GitCommonDir(name string) (bool, string, error)
 	Clone(url string, cmdDir string, dir string) (string, error)
+	WorktreeList(name string) (bool, string, error)
 }
 
 type RealGit struct {
@@ -51,4 +52,12 @@ func (g *RealGit) Clone(url string, cmdDir string, dir string) (string, error) {
 		return "", err
 	}
 	return out, nil
+}
+
+func (g *RealGit) WorktreeList(path string) (bool, string, error) {
+	out, err := g.shell.Cmd("git", "-C", path, "worktree", "list")
+	if err != nil {
+		return false, "", err
+	}
+	return true, out, nil
 }

--- a/namer/git.go
+++ b/namer/git.go
@@ -1,51 +1,8 @@
 package namer
 
 import (
-	"fmt"
 	"strings"
 )
-
-func gitBareRootName(n *RealNamer, path string) (string, error) {
-	isGit, commonDir, _ := n.git.GitCommonDir(path)
-	if isGit && strings.HasSuffix(commonDir, "/.bare") {
-		topLevelDir := strings.TrimSuffix(commonDir, "/.bare")
-		name, err := n.home.ShortenHome(topLevelDir)
-		if err != nil {
-			return "", fmt.Errorf("couldn't shorten path: %q", err)
-		}
-		return name, nil
-	} else {
-		return "", nil
-	}
-}
-
-// Gets the name from a git bare repository
-func gitBareName(n *RealNamer, path string) (string, error) {
-	var name string
-	isGit, commonDir, _ := n.git.GitCommonDir(path)
-	if isGit && strings.HasSuffix(commonDir, "/.bare") {
-		topLevelDir := strings.TrimSuffix(commonDir, "/.bare")
-		relativePath := strings.TrimPrefix(path, topLevelDir)
-		baseDir := n.pathwrap.Base(topLevelDir)
-		name = baseDir + relativePath
-		return name, nil
-	} else {
-		return "", nil
-	}
-}
-
-func gitRootName(n *RealNamer, path string) (string, error) {
-	isGit, topLevelDir, _ := n.git.ShowTopLevel(path)
-	if isGit && topLevelDir != "" {
-		name, err := n.home.ShortenHome(topLevelDir)
-		if err != nil {
-			return "", fmt.Errorf("couldn't shorten path: %q", err)
-		}
-		return name, nil
-	} else {
-		return "", nil
-	}
-}
 
 // Gets the name from a git repository
 func gitName(n *RealNamer, path string) (string, error) {

--- a/namer/git_bare.go
+++ b/namer/git_bare.go
@@ -1,0 +1,59 @@
+package namer
+
+import (
+	"strings"
+)
+
+func determineBareWorktreePath(out string) string {
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			return ""
+		}
+
+		if strings.Contains(line, "(bare)") {
+			parts := strings.Fields(line)
+			if len(parts) >= 2 && parts[1] == "(bare)" {
+				path := parts[0]
+				// TODO: move `.bare` folder naming convention to configuration?
+				if strings.HasSuffix(path, "/.bare") {
+					trimmedPath := strings.TrimSuffix(path, "/.bare")
+					return trimmedPath
+				} else {
+					return parts[0]
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func getBareWorktreePath(n *RealNamer, path string) (bool, string, error) {
+	isGit, list, err := n.git.WorktreeList(path)
+	if err != nil {
+		return false, "", err
+	}
+	if !isGit {
+		return false, "", nil
+	}
+	barePath := determineBareWorktreePath(list)
+	if barePath == "" {
+		return false, "", err
+	}
+	return true, barePath, nil
+}
+
+// Gets the name from a git bare repository
+func gitBareName(n *RealNamer, path string) (string, error) {
+	isGit, barePath, err := getBareWorktreePath(n, path)
+	if err != nil {
+		return "", err
+	}
+	if isGit && barePath != "" {
+		relativePath := strings.TrimPrefix(path, barePath)
+		baseDir := n.pathwrap.Base(barePath)
+		name := baseDir + relativePath
+		return name, nil
+	}
+	return "", nil
+}

--- a/namer/git_bare_test.go
+++ b/namer/git_bare_test.go
@@ -1,0 +1,73 @@
+package namer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetermineBareWorktreePath(t *testing.T) {
+	t.Run("should find the bare path for standard bare clone", func(t *testing.T) {
+		out := `
+/Users/hansolo/code/project/sesh             (bare)
+/Users/hansolo/code/project/sesh/main        ba04ca494 [5.x]
+`
+		barePath := determineBareWorktreePath(out)
+		assert.Equal(t, "/Users/hansolo/code/project/sesh", barePath)
+	})
+
+	t.Run("should find the bare path for bare clone to .bare folder and trim .bare suffix", func(t *testing.T) {
+		out := `
+/Users/hansolo/code/project/sesh/.bare             (bare)
+/Users/hansolo/code/project/sesh/main        ba04ca494 [5.x]
+`
+		barePath := determineBareWorktreePath(out)
+		assert.Equal(t, "/Users/hansolo/code/project/sesh", barePath)
+	})
+
+	t.Run("should return empty string when no bare repository exists", func(t *testing.T) {
+		out := `
+/Users/hansolo/code/project/sesh/main        ba04ca494 [5.x]
+/Users/hansolo/code/project/sesh/feature     c1d2e3f45 [feature-branch]
+`
+		barePath := determineBareWorktreePath(out)
+		assert.Equal(t, "", barePath)
+	})
+
+	t.Run("should handle empty output", func(t *testing.T) {
+		out := ""
+		barePath := determineBareWorktreePath(out)
+		assert.Equal(t, "", barePath)
+	})
+
+	t.Run("should handle whitespace-only output", func(t *testing.T) {
+		out := "   \n  \n   "
+		barePath := determineBareWorktreePath(out)
+		assert.Equal(t, "", barePath)
+	})
+
+	t.Run("should find bare when it's the only entry", func(t *testing.T) {
+		out := "/Users/hansolo/code/project/repo.git (bare)"
+		barePath := determineBareWorktreePath(out)
+		assert.Equal(t, "/Users/hansolo/code/project/repo.git", barePath)
+	})
+
+	t.Run("should handle multiple lines with bare on second line", func(t *testing.T) {
+		out := `
+/Users/hansolo/code/project/sesh/main        ba04ca494 [5.x]
+/Users/hansolo/code/project/sesh             (bare)
+`
+		barePath := determineBareWorktreePath(out)
+		assert.Equal(t, "/Users/hansolo/code/project/sesh", barePath)
+	})
+
+	t.Run("should ignore malformed lines that don't match expected format", func(t *testing.T) {
+		out := `
+/Users/hansolo/code/project/sesh             (bare)
+some malformed line without proper format
+/Users/hansolo/code/project/sesh/main        ba04ca494 [5.x]
+`
+		barePath := determineBareWorktreePath(out)
+		assert.Equal(t, "/Users/hansolo/code/project/sesh", barePath)
+	})
+}

--- a/namer/git_test.go
+++ b/namer/git_test.go
@@ -1,0 +1,47 @@
+package namer
+
+import (
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/git"
+	"github.com/joshmedeski/sesh/v2/home"
+	"github.com/joshmedeski/sesh/v2/pathwrap"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGitNamer(t *testing.T) {
+	t.Run("should find git name when on top level", func(t *testing.T) {
+		mockPathwrap := new(pathwrap.MockPath)
+		mockGit := new(git.MockGit)
+		mockHome := new(home.MockHome)
+		n := NewNamer(mockPathwrap, mockGit, mockHome)
+		mockGit.On("ShowTopLevel", "/Users/hansolo/code/project/sesh").Return(true, "/Users/hansolo/code/project/sesh", nil)
+		mockPathwrap.On("Base", "/Users/hansolo/code/project/sesh").Return("sesh")
+		name, err := gitName(n.(*RealNamer), "/Users/hansolo/code/project/sesh")
+		assert.NoError(t, err)
+		assert.Equal(t, "sesh", name)
+	})
+
+	t.Run("should find git name when nested in git repo", func(t *testing.T) {
+		mockPathwrap := new(pathwrap.MockPath)
+		mockGit := new(git.MockGit)
+		mockHome := new(home.MockHome)
+		n := NewNamer(mockPathwrap, mockGit, mockHome)
+		mockGit.On("ShowTopLevel", "/Users/hansolo/code/project/sesh/namer").Return(true, "/Users/hansolo/code/project/sesh", nil)
+		mockPathwrap.On("Base", "/Users/hansolo/code/project/sesh").Return("sesh")
+		name, err := gitName(n.(*RealNamer), "/Users/hansolo/code/project/sesh/namer")
+		assert.NoError(t, err)
+		assert.Equal(t, "sesh/namer", name)
+	})
+
+	t.Run("should return empty string when not in a git repo", func(t *testing.T) {
+		mockPathwrap := new(pathwrap.MockPath)
+		mockGit := new(git.MockGit)
+		mockHome := new(home.MockHome)
+		n := NewNamer(mockPathwrap, mockGit, mockHome)
+		mockGit.On("ShowTopLevel", "/Users/hansolo/code/project/sesh").Return(false, "", nil)
+		name, err := gitName(n.(*RealNamer), "/Users/hansolo/code/project/sesh")
+		assert.NoError(t, err)
+		assert.Equal(t, "", name)
+	})
+}

--- a/namer/namer.go
+++ b/namer/namer.go
@@ -11,6 +11,7 @@ import (
 type Namer interface {
 	// Names a sesh session from a given path
 	Name(path string) (string, error)
+	// Names a sesh session from the root of a given path
 	RootName(path string) (string, error)
 }
 

--- a/namer/namer_test.go
+++ b/namer/namer_test.go
@@ -17,10 +17,6 @@ func TestFromPath(t *testing.T) {
 		mockHome := new(home.MockHome)
 		n := NewNamer(mockPathwrap, mockGit, mockHome)
 
-		// TODO: test namer for git bare repo (using bare root)
-		// TODO: test namer for git repo (using top level)
-		// TODO: test namer for non-git dir (using base dir)
-
 		t.Run("name for git repo", func(t *testing.T) {
 			mockPathwrap.On("EvalSymlinks", "/Users/josh/config/dotfiles/.config/neovim").Return("/Users/josh/config/dotfiles/.config/neovim", nil)
 			mockGit.On("WorktreeList", "/Users/josh/config/dotfiles/.config/neovim").Return(false, "", nil)

--- a/namer/namer_test.go
+++ b/namer/namer_test.go
@@ -17,8 +17,13 @@ func TestFromPath(t *testing.T) {
 		mockHome := new(home.MockHome)
 		n := NewNamer(mockPathwrap, mockGit, mockHome)
 
+		// TODO: test namer for git bare repo (using bare root)
+		// TODO: test namer for git repo (using top level)
+		// TODO: test namer for non-git dir (using base dir)
+
 		t.Run("name for git repo", func(t *testing.T) {
 			mockPathwrap.On("EvalSymlinks", "/Users/josh/config/dotfiles/.config/neovim").Return("/Users/josh/config/dotfiles/.config/neovim", nil)
+			mockGit.On("WorktreeList", "/Users/josh/config/dotfiles/.config/neovim").Return(false, "", nil)
 			mockGit.On("ShowTopLevel", "/Users/josh/config/dotfiles/.config/neovim").Return(true, "/Users/josh/config/dotfiles", nil)
 			mockGit.On("GitCommonDir", "/Users/josh/config/dotfiles/.config/neovim").Return(true, "", nil)
 			mockPathwrap.On("Base", "/Users/josh/config/dotfiles").Return("dotfiles")
@@ -26,17 +31,9 @@ func TestFromPath(t *testing.T) {
 			assert.Equal(t, "dotfiles/_config/neovim", name)
 		})
 
-		t.Run("name for git worktree", func(t *testing.T) {
-			mockPathwrap.On("EvalSymlinks", "/Users/josh/config/sesh/main").Return("/Users/josh/config/sesh/main", nil)
-			mockGit.On("ShowTopLevel", "/Users/josh/config/sesh/main").Return(true, "/Users/josh/config/sesh/main", nil)
-			mockGit.On("GitCommonDir", "/Users/josh/config/sesh/main").Return(true, "/Users/josh/config/sesh/.bare", nil)
-			mockPathwrap.On("Base", "/Users/josh/config/sesh").Return("sesh")
-			name, _ := n.Name("/Users/josh/config/sesh/main")
-			assert.Equal(t, "sesh/main", name)
-		})
-
 		t.Run("returns base on non-git dir", func(t *testing.T) {
 			mockPathwrap.On("EvalSymlinks", "/Users/josh/.config/neovim").Return("/Users/josh/.config/neovim", nil)
+			mockGit.On("WorktreeList", "/Users/josh/.config/neovim").Return(false, "", nil)
 			mockGit.On("ShowTopLevel", "/Users/josh/.config/neovim").Return(false, "", fmt.Errorf("not a git repository (or any of the parent"))
 			mockGit.On("GitCommonDir", "/Users/josh/.config/neovim").Return(false, "", fmt.Errorf("not a git repository (or any of the parent"))
 			mockPathwrap.On("Base", "/Users/josh/.config/neovim").Return("neovim")

--- a/namer/root_git.go
+++ b/namer/root_git.go
@@ -1,0 +1,16 @@
+package namer
+
+import "fmt"
+
+func gitRootName(n *RealNamer, path string) (string, error) {
+	isGit, topLevelDir, _ := n.git.ShowTopLevel(path)
+	if isGit && topLevelDir != "" {
+		name, err := n.home.ShortenHome(topLevelDir)
+		if err != nil {
+			return "", fmt.Errorf("couldn't shorten path: %q", err)
+		}
+		return name, nil
+	} else {
+		return "", nil
+	}
+}


### PR DESCRIPTION
Adds logic to use the git worktrees to detect bare repos and improve the namer.
- Ensure backwards compatability by manually trimming `./.bare` from bare worktree paths
- Adds support for simple `git clone --bare` repos (that don't use the `.bare` convention)
- Adds additional unit tests for git namer
- Breaks apart the namer package into additional files for better organization and  testing