### PR TITLE
Fix bare wortree to ignore errors

### DIFF
--- a/namer/git_bare.go
+++ b/namer/git_bare.go
@@ -31,14 +31,14 @@ func determineBareWorktreePath(out string) string {
 func getBareWorktreePath(n *RealNamer, path string) (bool, string, error) {
 	isGit, list, err := n.git.WorktreeList(path)
 	if err != nil {
-		return false, "", err
+		return false, "", nil
 	}
 	if !isGit {
 		return false, "", nil
 	}
 	barePath := determineBareWorktreePath(list)
 	if barePath == "" {
-		return false, "", err
+		return false, "", nil
 	}
 	return true, barePath, nil
 }


### PR DESCRIPTION
Fixes #289

The new bare worktree namer was returning an error when it should simple be returning `nil` any time it couldn't determine a git bare name.