### PR TITLE
Fix command flag

### DIFF
--- a/connector/tmux.go
+++ b/connector/tmux.go
@@ -18,7 +18,11 @@ func tmuxStrategy(c *RealConnector, name string) (model.Connection, error) {
 func connectToTmux(c *RealConnector, connection model.Connection, opts model.ConnectOpts) (string, error) {
 	if connection.New {
 		c.tmux.NewSession(connection.Session.Name, connection.Session.Path)
-		c.startup.Exec(connection.Session)
+		if opts.Command != "" {
+			c.tmux.SendKeys(connection.Session.Name, opts.Command)
+		} else {
+			c.startup.Exec(connection.Session)
+		}
 	}
 	return c.tmux.SwitchOrAttach(connection.Session.Name, opts)
 }


### PR DESCRIPTION
Fixes issue where command flags are being ignored when connecting to a session.

### Before
Running the following would connect to the session but would ignore the command flag:
```
./sesh connect "~/Downloads" --command "nvim"
```

### After
The `--command` flag is not ignored when using `sesh connect`. Running the same command above connects to the session and opens `nvim`:
```
./sesh connect "~/Downloads" --command "nvim"
```