### PR TITLE
Ensure tmuxinator switches or attaches on connect

### DIFF
--- a/connector/tmuxinator.go
+++ b/connector/tmuxinator.go
@@ -19,5 +19,6 @@ func tmuxinatorStrategy(c *RealConnector, name string) (model.Connection, error)
 }
 
 func connectToTmuxinator(c *RealConnector, connection model.Connection, opts model.ConnectOpts) (string, error) {
-	return c.tmuxinator.Start(connection.Session.Name)
+	c.tmuxinator.Start(connection.Session.Name)
+	return c.tmux.SwitchOrAttach(connection.Session.Name, opts)
 }


### PR DESCRIPTION
For https://github.com/raycast/extensions/issues/20732#issuecomment-3315231427

- When running sesh from the terminal, tmuxinator commands will automatically switch to the session
- In the Raycast isolated environment, connecting to a tmuxinator session throws an exit code.

Now, the tmux SwitchOrAttach command is always called when connecting to a tmuxinator command, this fixes the issue inside Raycast.