### PR TITLE
Add SESHion Manager (Ulauncher extension) to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,11 @@ Here are limitations to keep in mind:
 
 ## Ulauncher Extension
 
-For Linux users using [Ulauncher](https://ulauncher.io/) there is an [extension](https://ext.ulauncher.io/-/github-jacostag-sesh-ulauncher) to use sesh outside the terminal.
+For Linux users using [Ulauncher](https://ulauncher.io/) there are two extensions to use sesh outside the terminal:
+- [Sesh Session Manager](https://ext.ulauncher.io/-/github-jacostag-sesh-ulauncher)
+- [SESHion Manager](https://ext.ulauncher.io/-/github-mrinfinidy-seshion-manager)
 
-
-Here are limitations to keep in mind:
+Here are limitations to keep in mind for Sesh Session Manager:
 
 - tmux has to be running before you can use the extension
 


### PR DESCRIPTION
The original ulauncher extension (Sesh Session Manager) did not work on my system. That is why I forked it and added some new features:
- tmux doesn't have to be running
- open zoxide directories with tmux/sesh
- Selected tmux sessions will be focused if they are already open (in a window)
- If the session is not open SESHion-manager will open it in a new terminal window

I would really appreciate it if you could include my extension in your README.