### PR TITLE
docs: Fix tmux binding in README.md for connecting to root session

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ While working in a nested session, you may way to connect to the root session of
 I recommend adding this to your `tmux.conf`:
 
 ```sh
-bind -N "switch to root session (via sesh) " 9 run-shell "sesh connect --root \'$(pwd)\'"
+bind -N "switch to root session (via sesh) " 9 run-shell "sesh connect --root $(pwd)"
 ```
 
 ### Filter by root


### PR DESCRIPTION
Thanks for sesh, it has been very useful!

I tried using the "Connect to root" feature, but the tmux binding listed in the README did not work.
Using the command without single quotes worked for me so I created this PR.

## BEFORE
Currently the docs state

```sh
bind -N "switch to root session (via sesh) " 9 run-shell "sesh connect --root \'$(pwd)\'"
```

Which results in

```
$ tmux list-keys | grep "sesh connect --root"
bind-key    -T prefix       9                         run-shell "sesh connect --root '$(pwd)'"
```

Which when executed gives me `'sesh connect --root '$(pwd)'' returned 1` when used.
Seemingly due to the single quotes making `$(pwd)` be interpreted literally.

## AFTER

Removed the single quotes

```sh
bind -N "switch to root session (via sesh) " 9 run-shell "sesh connect --root $(pwd)"
```
Which results in 

```
$ tmux list-keys | grep "sesh connect --root"
bind-key    -T prefix       9                         run-shell "sesh connect --root $(pwd)"
```

Which works for me.

I also saw that you used this version without single quotes in [your dotfiles](https://github.com/joshmedeski/dotfiles/blob/e1d51305d3c1a83fe605b34a14ad7b91dc1b8ced/.config/tmux/tmux.conf#L112) too


