### PR TITLE
Add projects source for discovering projects by marker files

### DIFF
--- a/icon/icon.go
+++ b/icon/icon.go
@@ -25,7 +25,22 @@ var (
 	tmuxIcon       string = ""
 	configIcon     string = ""
 	tmuxinatorIcon string = ""
+	projectsIcon   string = ""
 )
+
+var defaultProjectIcons = map[string]string{
+	".git":           "",
+	"package.json":   "",
+	"Cargo.toml":     "",
+	"go.mod":         "",
+	"pyproject.toml": "",
+	"composer.json":  "",
+	"Gemfile":        "",
+	"mix.exs":        "",
+	"pom.xml":        "",
+	"build.gradle":   "",
+	"Makefile":       "",
+}
 
 func ansiString(code int, s string) string {
 	return fmt.Sprintf("\033[%dm%s\033[39m", code, s)
@@ -47,6 +62,9 @@ func (i *RealIcon) AddIcon(s model.SeshSession) string {
 	case "config":
 		icon = configIcon
 		colorCode = 90 // gray
+	case "projects":
+		icon = i.getProjectIcon(s.ProjectType)
+		colorCode = 35 // magenta
 	}
 	if icon != "" {
 		return fmt.Sprintf("%s %s", ansiString(colorCode, icon), s.Name)
@@ -54,7 +72,30 @@ func (i *RealIcon) AddIcon(s model.SeshSession) string {
 	return s.Name
 }
 
+func (i *RealIcon) getProjectIcon(projectType string) string {
+	if i.config.ProjectIcons != nil {
+		if icon, ok := i.config.ProjectIcons[projectType]; ok {
+			return icon
+		}
+	}
+	if icon, ok := defaultProjectIcons[projectType]; ok {
+		return icon
+	}
+	return projectsIcon
+}
+
 func (i *RealIcon) RemoveIcon(name string) string {
+	// Format: \033[XXm<icon>\033[39m <name>
+	if strings.HasPrefix(name, "\033[") {
+		endIdx := strings.Index(name, "m")
+		if endIdx != -1 {
+			remaining := name[endIdx+1:]
+			resetIdx := strings.Index(remaining, "\033[39m ")
+			if resetIdx != -1 {
+				return remaining[resetIdx+7:]
+			}
+		}
+	}
 	if strings.HasPrefix(name, tmuxIcon) || strings.HasPrefix(name, zoxideIcon) || strings.HasPrefix(name, configIcon) || strings.HasPrefix(name, tmuxinatorIcon) {
 		return name[4:]
 	}

--- a/lister/config_test.go
+++ b/lister/config_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/joshmedeski/sesh/v2/home"
 	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/projects"
 	"github.com/joshmedeski/sesh/v2/tmux"
 	"github.com/joshmedeski/sesh/v2/tmuxinator"
 	"github.com/joshmedeski/sesh/v2/zoxide"
@@ -18,6 +19,7 @@ func TestListConfigSessions(t *testing.T) {
 	mockZoxide := new(zoxide.MockZoxide)
 	mockTmux := new(tmux.MockTmux)
 	mockTmuxinator := new(tmuxinator.MockTmuxinator)
+	mockProjects := new(projects.MockProjects)
 	config := model.Config{
 		SessionConfigs: []model.SessionConfig{
 			{
@@ -26,7 +28,7 @@ func TestListConfigSessions(t *testing.T) {
 			},
 		},
 	}
-	lister := NewLister(config, mockHome, mockTmux, mockZoxide, mockTmuxinator)
+	lister := NewLister(config, mockHome, mockTmux, mockZoxide, mockTmuxinator, mockProjects)
 
 	realLister, ok := lister.(*RealLister)
 	if !ok {

--- a/lister/list.go
+++ b/lister/list.go
@@ -16,6 +16,7 @@ type (
 		Tmux           bool
 		Zoxide         bool
 		Tmuxinator     bool
+		Projects       bool
 		HideDuplicates bool
 	}
 	srcStrategy func(*RealLister) (model.SeshSessions, error)
@@ -32,6 +33,7 @@ var srcStrategies = map[string]srcStrategy{
 	"config":     listConfig,
 	"tmuxinator": listTmuxinator,
 	"zoxide":     listZoxide,
+	"projects":   listProjects,
 }
 
 func (l *RealLister) List(opts ListOptions) (model.SeshSessions, error) {

--- a/lister/list_test.go
+++ b/lister/list_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/joshmedeski/sesh/v2/home"
 	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/projects"
 	"github.com/joshmedeski/sesh/v2/tmux"
 	"github.com/joshmedeski/sesh/v2/tmuxinator"
 	"github.com/joshmedeski/sesh/v2/zoxide"
@@ -161,8 +162,9 @@ func TestHideDuplicates(t *testing.T) {
 			config := model.Config{
 				SessionConfigs: tt.configSessions,
 			}
+			mockProjects := new(projects.MockProjects)
 
-			lister := NewLister(config, mockHome, mockTmux, mockZoxide, mockTmuxinator)
+			lister := NewLister(config, mockHome, mockTmux, mockZoxide, mockTmuxinator, mockProjects)
 
 			// Call the actual List function with HideDuplicates
 			result, err := lister.List(ListOptions{

--- a/lister/lister.go
+++ b/lister/lister.go
@@ -3,6 +3,7 @@ package lister
 import (
 	"github.com/joshmedeski/sesh/v2/home"
 	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/projects"
 	"github.com/joshmedeski/sesh/v2/tmux"
 	"github.com/joshmedeski/sesh/v2/tmuxinator"
 	"github.com/joshmedeski/sesh/v2/zoxide"
@@ -24,8 +25,9 @@ type RealLister struct {
 	tmux       tmux.Tmux
 	zoxide     zoxide.Zoxide
 	tmuxinator tmuxinator.Tmuxinator
+	projects   projects.Projects
 }
 
-func NewLister(config model.Config, home home.Home, tmux tmux.Tmux, zoxide zoxide.Zoxide, tmuxinator tmuxinator.Tmuxinator) Lister {
-	return &RealLister{config, home, tmux, zoxide, tmuxinator}
+func NewLister(config model.Config, home home.Home, tmux tmux.Tmux, zoxide zoxide.Zoxide, tmuxinator tmuxinator.Tmuxinator, projects projects.Projects) Lister {
+	return &RealLister{config, home, tmux, zoxide, tmuxinator, projects}
 }

--- a/lister/projects.go
+++ b/lister/projects.go
@@ -1,0 +1,29 @@
+package lister
+
+import (
+	"fmt"
+
+	"github.com/joshmedeski/sesh/v2/model"
+)
+
+func listProjects(l *RealLister) (model.SeshSessions, error) {
+	projectResults, err := l.projects.List()
+	if err != nil {
+		return model.SeshSessions{}, fmt.Errorf("couldn't list projects: %q", err)
+	}
+
+	numProjects := len(projectResults)
+	orderedIndex := make([]string, numProjects)
+	directory := make(model.SeshSessionMap)
+
+	for i, p := range projectResults {
+		key := fmt.Sprintf("projects:%s", p.Path)
+		orderedIndex[i] = key
+		directory[key] = p
+	}
+
+	return model.SeshSessions{
+		Directory:    directory,
+		OrderedIndex: orderedIndex,
+	}, nil
+}

--- a/lister/srcs.go
+++ b/lister/srcs.go
@@ -45,8 +45,11 @@ func srcs(opts ListOptions) []string {
 	if opts.Zoxide {
 		count++
 	}
+	if opts.Projects {
+		count++
+	}
 	if count == 0 {
-		return []string{"tmux", "config", "tmuxinator", "zoxide"}
+		return []string{"tmux", "config", "tmuxinator", "zoxide", "projects"}
 	}
 	srcs = make([]string, count)
 	i := 0
@@ -64,6 +67,10 @@ func srcs(opts ListOptions) []string {
 	}
 	if opts.Zoxide {
 		srcs[i] = "zoxide"
+		i++
+	}
+	if opts.Projects {
+		srcs[i] = "projects"
 		i++
 	}
 	return srcs

--- a/lister/srcs_test.go
+++ b/lister/srcs_test.go
@@ -7,34 +7,34 @@ import (
 )
 
 func TestSortSources(t *testing.T) {
-	defaultSources := []string{"tmux", "config", "tmuxinator", "zoxide"}
+	defaultSources := []string{"tmux", "config", "tmuxinator", "zoxide", "projects"}
 	tests := map[string]struct {
 		sortOrder []string
 		expected  []string
 	}{
 		"a normal configuration": {
 			sortOrder: []string{"tmuxinator", "zoxide", "config", "tmux"},
-			expected:  []string{"tmuxinator", "zoxide", "config", "tmux"},
+			expected:  []string{"tmuxinator", "zoxide", "config", "tmux", "projects"},
 		},
 		"empty configuration": {
 			sortOrder: []string{},
-			expected:  []string{"tmux", "config", "tmuxinator", "zoxide"},
+			expected:  []string{"tmux", "config", "tmuxinator", "zoxide", "projects"},
 		},
 		"partial configuration": {
 			sortOrder: []string{"tmuxinator"},
-			expected:  []string{"tmuxinator", "tmux", "config", "zoxide"},
+			expected:  []string{"tmuxinator", "tmux", "config", "zoxide", "projects"},
 		},
 		"superfluous elements": {
 			sortOrder: []string{"tmuxinator", "apple", "zoxide", "banana", "config", "chocolate", "tmux"},
-			expected:  []string{"tmuxinator", "zoxide", "config", "tmux"},
+			expected:  []string{"tmuxinator", "zoxide", "config", "tmux", "projects"},
 		},
 		"configuration with capitalization": {
 			sortOrder: []string{"tMuxiNator", "Zoxide", "conFIg", "tmux"},
-			expected:  []string{"tmuxinator", "zoxide", "config", "tmux"},
+			expected:  []string{"tmuxinator", "zoxide", "config", "tmux", "projects"},
 		},
 		"configuration with duplicate elements": {
 			sortOrder: []string{"tmuxinator", "zoxide", "tmuxinator", "config", "tmuxinator", "tmux", "tmuxinator", "tmuxinator"},
-			expected:  []string{"zoxide", "config", "tmux", "tmuxinator"},
+			expected:  []string{"zoxide", "config", "tmux", "tmuxinator", "projects"},
 		},
 	}
 	for name, tt := range tests {
@@ -54,7 +54,7 @@ func TestSrcs(t *testing.T) {
 		{
 			name:     "All options are false",
 			opts:     ListOptions{},
-			expected: []string{"tmux", "config", "tmuxinator", "zoxide"},
+			expected: []string{"tmux", "config", "tmuxinator", "zoxide", "projects"},
 		},
 		{
 			name:     "Only Tmux is true",

--- a/lister/tmux_test.go
+++ b/lister/tmux_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/joshmedeski/sesh/v2/tmux"
 	"github.com/joshmedeski/sesh/v2/tmuxinator"
 	"github.com/joshmedeski/sesh/v2/zoxide"
+	"github.com/joshmedeski/sesh/v2/projects"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -77,7 +78,7 @@ func TestListTmuxSessions(t *testing.T) {
 		mockHome := new(home.MockHome)
 		mockZoxide := new(zoxide.MockZoxide)
 		mockTmuxinator := new(tmuxinator.MockTmuxinator)
-		lister := NewLister(mockConfig, mockHome, mockTmux, mockZoxide, mockTmuxinator)
+		lister := NewLister(mockConfig, mockHome, mockTmux, mockZoxide, mockTmuxinator, new(projects.MockProjects))
 
 		realLister, ok := lister.(*RealLister)
 		if !ok {
@@ -101,7 +102,7 @@ func TestListTmuxSessionsError(t *testing.T) {
 		mockHome := new(home.MockHome)
 		mockZoxide := new(zoxide.MockZoxide)
 		mockTmuxinator := new(tmuxinator.MockTmuxinator)
-		lister := NewLister(mockConfig, mockHome, mockTmux, mockZoxide, mockTmuxinator)
+		lister := NewLister(mockConfig, mockHome, mockTmux, mockZoxide, mockTmuxinator, new(projects.MockProjects))
 
 		realLister, ok := lister.(*RealLister)
 		if !ok {

--- a/lister/tmuxinator_test.go
+++ b/lister/tmuxinator_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/joshmedeski/sesh/v2/tmux"
 	"github.com/joshmedeski/sesh/v2/tmuxinator"
 	"github.com/joshmedeski/sesh/v2/zoxide"
+	"github.com/joshmedeski/sesh/v2/projects"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,7 +25,7 @@ func TestListTmuxinatorConfigs(t *testing.T) {
 			{Name: "dotfiles"},
 		}, nil)
 
-		lister := NewLister(mockConfig, mockHome, mockTmux, mockZoxide, mockTmuxinator)
+		lister := NewLister(mockConfig, mockHome, mockTmux, mockZoxide, mockTmuxinator, new(projects.MockProjects))
 
 		realLister, ok := lister.(*RealLister)
 		if !ok {

--- a/lister/zoxide_test.go
+++ b/lister/zoxide_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/joshmedeski/sesh/v2/tmux"
 	"github.com/joshmedeski/sesh/v2/tmuxinator"
 	"github.com/joshmedeski/sesh/v2/zoxide"
+	"github.com/joshmedeski/sesh/v2/projects"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,7 +33,7 @@ func TestListZoxideSessions(t *testing.T) {
 			},
 		}, nil)
 
-		lister := NewLister(mockConfig, mockHome, mockTmux, mockZoxide, mockTmuxinator)
+		lister := NewLister(mockConfig, mockHome, mockTmux, mockZoxide, mockTmuxinator, new(projects.MockProjects))
 
 		realLister, ok := lister.(*RealLister)
 		if !ok {

--- a/model/config.go
+++ b/model/config.go
@@ -10,6 +10,10 @@ type (
 		SortOrder            []string             `toml:"sort_order"`
 		WindowConfigs        []WindowConfig       `toml:"window"`
 		DirLength            int                  `toml:"dir_length"`
+		ProjectRoots         []string             `toml:"project_roots"`
+		ProjectMarkers       []string             `toml:"project_markers"`
+		MaxDepth             int                  `toml:"max_depth"`
+		ProjectIcons         map[string]string    `toml:"project_icons"` // marker -> icon mapping
 	}
 	Evaluation struct {
 		StrictMode bool `toml:"strict_mode"`

--- a/model/sesh_session.go
+++ b/model/sesh_session.go
@@ -12,7 +12,7 @@ type (
 	SeshWindowMap  map[string]WindowConfig
 
 	SeshSession struct {
-		Src  string // The source of the session (config, tmux, zoxide, tmuxinator)
+		Src  string // The source of the session (config, tmux, zoxide, tmuxinator, projects)
 		Name string // The display name
 		Path string // The absolute directory path
 
@@ -25,6 +25,7 @@ type (
 		WindowConfigs         []WindowConfig // The windows used in session config
 		WindowNames           []string       // The names of the windows in session config
 		Score                 float64        // The score of the session (from Zoxide)
+		ProjectType           string         // The marker that identified this project (e.g., "go.mod", "package.json")
 	}
 
 	SeshSrcs struct {

--- a/projects/projects.go
+++ b/projects/projects.go
@@ -1,0 +1,131 @@
+package projects
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/joshmedeski/sesh/v2/home"
+	"github.com/joshmedeski/sesh/v2/model"
+)
+
+type Projects interface {
+	List() ([]model.SeshSession, error)
+}
+
+type RealProjects struct {
+	config model.Config
+	home   home.Home
+}
+
+var markerSpecificity = map[string]int{
+	".git":           1,
+	"Makefile":       1,
+	"package.json":   10,
+	"Cargo.toml":     10,
+	"go.mod":         10,
+	"pyproject.toml": 10,
+	"composer.json":  10,
+	"Gemfile":        10,
+	"mix.exs":        10,
+	"pom.xml":        10,
+	"build.gradle":   10,
+}
+
+func NewProjects(config model.Config, home home.Home) Projects {
+	if len(config.ProjectMarkers) == 0 {
+		config.ProjectMarkers = []string{
+			".git",
+			"package.json",
+			"Cargo.toml",
+			"go.mod",
+			"pyproject.toml",
+			"composer.json",
+			"Gemfile",
+			"mix.exs",
+			"pom.xml",
+			"build.gradle",
+			"Makefile",
+		}
+	}
+	if config.MaxDepth <= 0 {
+		config.MaxDepth = 3
+	}
+	return &RealProjects{config, home}
+}
+
+func (p *RealProjects) List() ([]model.SeshSession, error) {
+	var sessions []model.SeshSession
+	seen := make(map[string]bool)
+
+	for _, root := range p.config.ProjectRoots {
+		expandedRoot, err := p.home.ExpandHome(root)
+		if err != nil {
+			continue
+		}
+
+		err = filepath.WalkDir(expandedRoot, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+
+			if !d.IsDir() {
+				return nil
+			}
+
+			rel, err := filepath.Rel(expandedRoot, path)
+			if err != nil {
+				return nil
+			}
+
+			if rel != "." {
+				depth := len(strings.Split(rel, string(filepath.Separator)))
+				if depth > p.config.MaxDepth {
+					return filepath.SkipDir
+				}
+			}
+
+			entries, err := os.ReadDir(path)
+			if err != nil {
+				return nil
+			}
+
+			bestMarker := ""
+			bestSpecificity := 0
+			for _, entry := range entries {
+				for _, marker := range p.config.ProjectMarkers {
+					if entry.Name() == marker {
+						specificity := markerSpecificity[marker]
+						if specificity == 0 {
+							specificity = 5
+						}
+						if specificity > bestSpecificity {
+							bestSpecificity = specificity
+							bestMarker = marker
+						}
+					}
+				}
+			}
+
+			if bestMarker != "" {
+				if !seen[path] {
+					name, err := p.home.ShortenHome(path)
+					if err != nil {
+						name = path
+					}
+					sessions = append(sessions, model.SeshSession{
+						Src:         "projects",
+						Name:        name,
+						Path:        path,
+						ProjectType: bestMarker,
+					})
+					seen[path] = true
+				}
+			}
+
+			return nil
+		})
+	}
+
+	return sessions, nil
+}

--- a/seshcli/list.go
+++ b/seshcli/list.go
@@ -24,6 +24,7 @@ func NewListCommand(icon icon.Icon, json json.Json, list lister.Lister) *cobra.C
 			hideAttached, _ := cmd.Flags().GetBool("hide-attached")
 			icons, _ := cmd.Flags().GetBool("icons")
 			tmuxinator, _ := cmd.Flags().GetBool("tmuxinator")
+			projects, _ := cmd.Flags().GetBool("projects")
 			hideDuplicates, _ := cmd.Flags().GetBool("hide-duplicates")
 
 			sessions, err := list.List(lister.ListOptions{
@@ -34,6 +35,7 @@ func NewListCommand(icon icon.Icon, json json.Json, list lister.Lister) *cobra.C
 				Tmux:           tmux,
 				Zoxide:         zoxide,
 				Tmuxinator:     tmuxinator,
+				Projects:       projects,
 				HideDuplicates: hideDuplicates,
 			})
 			if err != nil {
@@ -68,6 +70,7 @@ func NewListCommand(icon icon.Icon, json json.Json, list lister.Lister) *cobra.C
 	cmd.Flags().BoolP("hide-attached", "H", false, "don't show currently attached sessions")
 	cmd.Flags().BoolP("icons", "i", false, "show icons")
 	cmd.Flags().BoolP("tmuxinator", "T", false, "show tmuxinator configs")
+	cmd.Flags().BoolP("projects", "p", false, "show project directories")
 	cmd.Flags().BoolP("hide-duplicates", "d", false, "hide duplicate entries")
 
 	return cmd

--- a/seshcli/root_command.go
+++ b/seshcli/root_command.go
@@ -22,6 +22,7 @@ import (
 	"github.com/joshmedeski/sesh/v2/oswrap"
 	"github.com/joshmedeski/sesh/v2/pathwrap"
 	"github.com/joshmedeski/sesh/v2/previewer"
+	"github.com/joshmedeski/sesh/v2/projects"
 	"github.com/joshmedeski/sesh/v2/replacer"
 	"github.com/joshmedeski/sesh/v2/runtimewrap"
 	"github.com/joshmedeski/sesh/v2/shell"
@@ -68,7 +69,8 @@ func NewRootCommand(version string) *cobra.Command {
 
 	// core dependencies
 	ls := ls.NewLs(config, shell)
-	lister := lister.NewLister(config, home, tmux, zoxide, tmuxinator)
+	projects := projects.NewProjects(config, home)
+	lister := lister.NewLister(config, home, tmux, zoxide, tmuxinator, projects)
 	startup := startup.NewStartup(config, lister, tmux, home, replacer)
 	namer := namer.NewNamer(path, git, home, config)
 	connector := connector.NewConnector(config, dir, home, lister, namer, startup, tmux, zoxide, tmuxinator)


### PR DESCRIPTION
Implements a new "projects" source that scans configured directories for project markers (like `.git`, `package.json`, `go.mod`, etc.) to discover projects. Projects can appear in the session list even if never visited with zoxide.

The envisioned use-case is to set your `project_roots` to directories where you tend to create new projects in (ie. `~/projects`, `~/development`) and then `sesh list -p` will list all of the projects it finds with markers. The `.git` marker should find all git repos, but the other markers (and the `max_depth` property) can find projects within projects for monorepos and other such structures.

This is very similar to what is done in [twm](https://github.com/vinnymeller/), but just in sesh.

## Usage
```sh
sesh list -p
```

## Key features:

- Configurable project roots, markers, and scan depth
- Marker specificity logic prioritizes language-specific markers over generic ones (e.g., go.mod > .git)
- Technology-specific NerdFont icons based on detected marker
- User-configurable icon overrides via project_icons config
- CLI flag `-p/--projects` to show project directories

Sample toml config file:
```toml
project_roots = ["~/development"]
# Optional, binary comes with a reasonable list of markers baked in
project_markers = [".git", "package.json", "go.mod", "Cargo.toml"]
max_depth = 3
```