### PR TITLE
feat: add opt-in session list caching with stale-while-revalidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,20 @@ sort_order = [
   "config", # resulting order: config, tmux, tmuxinator, zoxide
 ]
 ```
+### Cache
+
+Sesh can cache session lists to speed up repeated calls. Caching is opt-in and disabled by default. When enabled, sesh stores results at `$XDG_CACHE_HOME/sesh/sessions.gob` (default `~/.cache/sesh/sessions.gob`) and uses a stale-while-revalidate strategy with a 5-second TTL:
+
+- **Cold start**: no cache exists, fetches live data and writes the cache
+- **Fresh hit** (within 5s): returns cached data instantly
+- **Stale hit** (after 5s): returns cached data instantly and refreshes the cache in the background
+
+The cache is also refreshed automatically after `sesh connect`.
+
+```toml
+cache = true
+```
+
 ### Default Session
 
 The default session can be configured to run a command when connecting to a session. This is useful for running a dev server or starting a tmux plugin.

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,87 @@
+package cache
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/joshmedeski/sesh/v2/model"
+)
+
+func init() {
+	gob.Register(model.SeshSessions{})
+	gob.Register(model.SeshSessionMap{})
+	gob.Register(model.SeshSession{})
+}
+
+// CachedData holds cached sessions along with the time they were written.
+type CachedData struct {
+	Sessions  model.SeshSessions
+	Timestamp time.Time
+}
+
+// Cache reads and writes session data to a persistent store.
+type Cache interface {
+	Read() (CachedData, error)
+	Write(sessions model.SeshSessions) error
+}
+
+// FileCache implements Cache using a gob-encoded file under the XDG cache directory.
+type FileCache struct {
+	path string
+}
+
+// NewFileCache creates a FileCache that stores data at $XDG_CACHE_HOME/sesh/sessions.gob
+// (falling back to ~/.cache/sesh/sessions.gob).
+func NewFileCache() *FileCache {
+	dir := os.Getenv("XDG_CACHE_HOME")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			home = "."
+		}
+		dir = filepath.Join(home, ".cache")
+	}
+	return &FileCache{path: filepath.Join(dir, "sesh", "sessions.gob")}
+}
+
+// NewFileCacheWithPath creates a FileCache at a specific path (useful for testing).
+func NewFileCacheWithPath(path string) *FileCache {
+	return &FileCache{path: path}
+}
+
+func (c *FileCache) Read() (CachedData, error) {
+	data, err := os.ReadFile(c.path)
+	if err != nil {
+		return CachedData{}, fmt.Errorf("cache read: %w", err)
+	}
+	var cached CachedData
+	if err := gob.NewDecoder(bytes.NewReader(data)).Decode(&cached); err != nil {
+		return CachedData{}, fmt.Errorf("cache decode: %w", err)
+	}
+	return cached, nil
+}
+
+func (c *FileCache) Write(sessions model.SeshSessions) error {
+	if err := os.MkdirAll(filepath.Dir(c.path), 0o755); err != nil {
+		return fmt.Errorf("cache mkdir: %w", err)
+	}
+
+	var buf bytes.Buffer
+	cached := CachedData{Sessions: sessions, Timestamp: time.Now()}
+	if err := gob.NewEncoder(&buf).Encode(cached); err != nil {
+		return fmt.Errorf("cache encode: %w", err)
+	}
+
+	tmp := c.path + ".tmp"
+	if err := os.WriteFile(tmp, buf.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("cache write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, c.path); err != nil {
+		return fmt.Errorf("cache rename: %w", err)
+	}
+	return nil
+}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,104 @@
+package cache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/joshmedeski/sesh/v2/model"
+)
+
+func testSessions() model.SeshSessions {
+	return model.SeshSessions{
+		OrderedIndex: []string{"tmux:main", "zoxide:~/code"},
+		Directory: model.SeshSessionMap{
+			"tmux:main": {
+				Src:  "tmux",
+				Name: "main",
+				Path: "/home/user",
+			},
+			"zoxide:~/code": {
+				Src:   "zoxide",
+				Name:  "~/code",
+				Path:  "/home/user/code",
+				Score: 42.5,
+			},
+		},
+	}
+}
+
+func TestFileCache_WriteAndRead(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sesh", "sessions.gob")
+	c := NewFileCacheWithPath(path)
+
+	sessions := testSessions()
+	err := c.Write(sessions)
+	require.NoError(t, err)
+
+	_, err = os.Stat(path)
+	require.NoError(t, err)
+
+	got, err := c.Read()
+	require.NoError(t, err)
+
+	assert.Equal(t, sessions.OrderedIndex, got.Sessions.OrderedIndex)
+	assert.Equal(t, sessions.Directory, got.Sessions.Directory)
+	assert.WithinDuration(t, time.Now(), got.Timestamp, 2*time.Second)
+}
+
+func TestFileCache_ReadMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent.gob")
+	c := NewFileCacheWithPath(path)
+
+	_, err := c.Read()
+	assert.Error(t, err)
+}
+
+func TestFileCache_AtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sesh", "sessions.gob")
+	c := NewFileCacheWithPath(path)
+
+	sessions1 := testSessions()
+	require.NoError(t, c.Write(sessions1))
+
+	sessions2 := model.SeshSessions{
+		OrderedIndex: []string{"tmux:other"},
+		Directory: model.SeshSessionMap{
+			"tmux:other": {Src: "tmux", Name: "other", Path: "/tmp"},
+		},
+	}
+	require.NoError(t, c.Write(sessions2))
+
+	// No temp file left behind
+	_, err := os.Stat(path + ".tmp")
+	assert.True(t, os.IsNotExist(err))
+
+	got, err := c.Read()
+	require.NoError(t, err)
+	assert.Equal(t, sessions2.OrderedIndex, got.Sessions.OrderedIndex)
+	assert.Equal(t, sessions2.Directory, got.Sessions.Directory)
+}
+
+func TestNewFileCache_XDGCacheHome(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", dir)
+
+	c := NewFileCache()
+	expected := filepath.Join(dir, "sesh", "sessions.gob")
+	assert.Equal(t, expected, c.path)
+}
+
+func TestNewFileCache_FallbackToHomeCache(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("HOME", "/fakehome")
+
+	c := NewFileCache()
+	assert.Contains(t, c.path, filepath.Join(".cache", "sesh", "sessions.gob"))
+}

--- a/lister/caching_lister.go
+++ b/lister/caching_lister.go
@@ -1,0 +1,143 @@
+package lister
+
+import (
+	"log/slog"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/joshmedeski/sesh/v2/cache"
+	"github.com/joshmedeski/sesh/v2/model"
+)
+
+const softTTL = 5 * time.Second
+
+// CachingLister wraps a Lister with stale-while-revalidate caching for List().
+// All other Lister methods delegate directly to the inner lister.
+type CachingLister struct {
+	inner Lister
+	cache cache.Cache
+	wg    sync.WaitGroup
+}
+
+// NewCachingLister creates a CachingLister that decorates inner with file-based caching.
+func NewCachingLister(inner Lister, c cache.Cache) *CachingLister {
+	return &CachingLister{inner: inner, cache: c}
+}
+
+// List implements Lister. It returns cached data when available, triggering a
+// background refresh when the cache is older than the soft TTL.
+// The cache always stores the full unfiltered list; view-level filters like
+// HideAttached are applied after reading from cache.
+func (cl *CachingLister) List(opts ListOptions) (model.SeshSessions, error) {
+	// Always fetch/store the full list; we apply filters ourselves.
+	innerOpts := opts
+	innerOpts.HideAttached = false
+
+	cached, err := cl.cache.Read()
+	if err == nil {
+		age := time.Since(cached.Timestamp)
+		if age < softTTL {
+			slog.Debug("cache: hit (fresh)", "age", age)
+			return cl.applyFilters(cached.Sessions, opts), nil
+		}
+		// Stale -- return immediately but revalidate in background
+		slog.Debug("cache: hit (stale, revalidating)", "age", age)
+		cl.wg.Add(1)
+		go func() {
+			defer cl.wg.Done()
+			cl.revalidate(innerOpts)
+		}()
+		return cl.applyFilters(cached.Sessions, opts), nil
+	}
+
+	// Cold start -- fetch synchronously
+	slog.Debug("cache: miss (cold start)")
+	sessions, err := cl.inner.List(innerOpts)
+	if err != nil {
+		return sessions, err
+	}
+	if writeErr := cl.cache.Write(sessions); writeErr != nil {
+		slog.Warn("cache: write failed on cold start", "error", writeErr)
+	}
+	return cl.applyFilters(sessions, opts), nil
+}
+
+// applyFilters applies view-level filters (like HideAttached) that should not
+// affect what gets stored in the cache.
+func (cl *CachingLister) applyFilters(sessions model.SeshSessions, opts ListOptions) model.SeshSessions {
+	if !opts.HideAttached {
+		return sessions
+	}
+	attached, ok := cl.inner.GetAttachedTmuxSession()
+	if !ok {
+		return sessions
+	}
+	for i, index := range sessions.OrderedIndex {
+		if sessions.Directory[index].Name == attached.Name {
+			filtered := slices.Delete(slices.Clone(sessions.OrderedIndex), i, i+1)
+			return model.SeshSessions{
+				OrderedIndex: filtered,
+				Directory:    sessions.Directory,
+			}
+		}
+	}
+	return sessions
+}
+
+func (cl *CachingLister) revalidate(opts ListOptions) {
+	sessions, err := cl.inner.List(opts)
+	if err != nil {
+		slog.Warn("cache: background revalidation fetch failed", "error", err)
+		return
+	}
+	if err := cl.cache.Write(sessions); err != nil {
+		slog.Warn("cache: background revalidation write failed", "error", err)
+	}
+}
+
+// RefreshCache fetches live data from the inner lister and writes it to the cache.
+// This bypasses the cache read entirely, intended for use after sesh connect.
+func (cl *CachingLister) RefreshCache(opts ListOptions) {
+	cl.wg.Add(1)
+	go func() {
+		defer cl.wg.Done()
+		cl.revalidate(opts)
+	}()
+}
+
+// Wait blocks until all background refresh goroutines have completed.
+// Call this before process exit to avoid truncated cache writes.
+func (cl *CachingLister) Wait() {
+	cl.wg.Wait()
+}
+
+// --- Delegate all other Lister methods to inner ---
+
+func (cl *CachingLister) FindTmuxSession(name string) (model.SeshSession, bool) {
+	return cl.inner.FindTmuxSession(name)
+}
+
+func (cl *CachingLister) GetAttachedTmuxSession() (model.SeshSession, bool) {
+	return cl.inner.GetAttachedTmuxSession()
+}
+
+func (cl *CachingLister) GetLastTmuxSession() (model.SeshSession, bool) {
+	return cl.inner.GetLastTmuxSession()
+}
+
+func (cl *CachingLister) FindConfigSession(name string) (model.SeshSession, bool) {
+	return cl.inner.FindConfigSession(name)
+}
+
+func (cl *CachingLister) FindConfigWildcard(path string) (model.WildcardConfig, bool) {
+	return cl.inner.FindConfigWildcard(path)
+}
+
+func (cl *CachingLister) FindZoxideSession(name string) (model.SeshSession, bool) {
+	return cl.inner.FindZoxideSession(name)
+}
+
+func (cl *CachingLister) FindTmuxinatorConfig(name string) (model.SeshSession, bool) {
+	return cl.inner.FindTmuxinatorConfig(name)
+}

--- a/lister/caching_lister_test.go
+++ b/lister/caching_lister_test.go
@@ -1,0 +1,260 @@
+package lister_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/joshmedeski/sesh/v2/cache"
+	"github.com/joshmedeski/sesh/v2/lister"
+	"github.com/joshmedeski/sesh/v2/model"
+)
+
+func fakeSessions() model.SeshSessions {
+	return model.SeshSessions{
+		OrderedIndex: []string{"tmux:main"},
+		Directory: model.SeshSessionMap{
+			"tmux:main": {Src: "tmux", Name: "main", Path: "/home/user"},
+		},
+	}
+}
+
+func updatedSessions() model.SeshSessions {
+	return model.SeshSessions{
+		OrderedIndex: []string{"tmux:main", "tmux:dev"},
+		Directory: model.SeshSessionMap{
+			"tmux:main": {Src: "tmux", Name: "main", Path: "/home/user"},
+			"tmux:dev":  {Src: "tmux", Name: "dev", Path: "/home/user/dev"},
+		},
+	}
+}
+
+func TestCachingLister_ColdStart(t *testing.T) {
+	dir := t.TempDir()
+	fc := cache.NewFileCacheWithPath(filepath.Join(dir, "sessions.gob"))
+	inner := lister.NewMockLister(t)
+	opts := lister.ListOptions{Tmux: true}
+
+	sessions := fakeSessions()
+	inner.On("List", opts).Return(sessions, nil).Once()
+
+	cl := lister.NewCachingLister(inner, fc)
+	got, err := cl.List(opts)
+	require.NoError(t, err)
+	assert.Equal(t, sessions.OrderedIndex, got.OrderedIndex)
+
+	cached, err := fc.Read()
+	require.NoError(t, err)
+	assert.Equal(t, sessions.OrderedIndex, cached.Sessions.OrderedIndex)
+
+	cl.Wait()
+}
+
+func TestCachingLister_WarmHit(t *testing.T) {
+	dir := t.TempDir()
+	fc := cache.NewFileCacheWithPath(filepath.Join(dir, "sessions.gob"))
+	inner := lister.NewMockLister(t)
+	opts := lister.ListOptions{Tmux: true}
+
+	sessions := fakeSessions()
+	require.NoError(t, fc.Write(sessions))
+
+	cl := lister.NewCachingLister(inner, fc)
+	got, err := cl.List(opts)
+	require.NoError(t, err)
+	assert.Equal(t, sessions.OrderedIndex, got.OrderedIndex)
+
+	cl.Wait()
+	inner.AssertNotCalled(t, "List")
+}
+
+func TestCachingLister_RefreshThenWarmRead(t *testing.T) {
+	dir := t.TempDir()
+	fc := cache.NewFileCacheWithPath(filepath.Join(dir, "sessions.gob"))
+	inner := lister.NewMockLister(t)
+	opts := lister.ListOptions{Tmux: true}
+
+	fresh := updatedSessions()
+	inner.On("List", opts).Return(fresh, nil).Once()
+
+	cl := lister.NewCachingLister(inner, fc)
+	cl.RefreshCache(opts)
+	cl.Wait()
+
+	got, err := cl.List(opts)
+	require.NoError(t, err)
+	assert.Equal(t, fresh.OrderedIndex, got.OrderedIndex)
+	assert.Equal(t, fresh.Directory, got.Directory)
+}
+
+func TestCachingLister_ColdStartError(t *testing.T) {
+	dir := t.TempDir()
+	fc := cache.NewFileCacheWithPath(filepath.Join(dir, "sessions.gob"))
+	inner := lister.NewMockLister(t)
+	opts := lister.ListOptions{Tmux: true}
+
+	inner.On("List", opts).Return(model.SeshSessions{}, fmt.Errorf("tmux not running")).Once()
+
+	cl := lister.NewCachingLister(inner, fc)
+	_, err := cl.List(opts)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "tmux not running")
+
+	cl.Wait()
+}
+
+func TestCachingLister_RefreshCache(t *testing.T) {
+	dir := t.TempDir()
+	fc := cache.NewFileCacheWithPath(filepath.Join(dir, "sessions.gob"))
+	inner := lister.NewMockLister(t)
+	opts := lister.ListOptions{Tmux: true}
+
+	freshSessions := updatedSessions()
+	inner.On("List", opts).Return(freshSessions, nil).Once()
+
+	cl := lister.NewCachingLister(inner, fc)
+	cl.RefreshCache(opts)
+	cl.Wait()
+
+	cached, err := fc.Read()
+	require.NoError(t, err)
+	assert.Equal(t, freshSessions.OrderedIndex, cached.Sessions.OrderedIndex)
+}
+
+func TestCachingLister_DelegatesMethods(t *testing.T) {
+	dir := t.TempDir()
+	fc := cache.NewFileCacheWithPath(filepath.Join(dir, "sessions.gob"))
+	inner := lister.NewMockLister(t)
+
+	session := model.SeshSession{Src: "tmux", Name: "test"}
+	inner.On("FindTmuxSession", "test").Return(session, true)
+	inner.On("GetAttachedTmuxSession").Return(session, true)
+	inner.On("GetLastTmuxSession").Return(session, true)
+	inner.On("FindConfigSession", "test").Return(session, true)
+	inner.On("FindConfigWildcard", "/path").Return(model.WildcardConfig{}, false)
+	inner.On("FindZoxideSession", "test").Return(session, true)
+	inner.On("FindTmuxinatorConfig", "test").Return(session, true)
+
+	cl := lister.NewCachingLister(inner, fc)
+
+	s, ok := cl.FindTmuxSession("test")
+	assert.True(t, ok)
+	assert.Equal(t, "test", s.Name)
+
+	s, ok = cl.GetAttachedTmuxSession()
+	assert.True(t, ok)
+
+	s, ok = cl.GetLastTmuxSession()
+	assert.True(t, ok)
+
+	s, ok = cl.FindConfigSession("test")
+	assert.True(t, ok)
+
+	_, ok = cl.FindConfigWildcard("/path")
+	assert.False(t, ok)
+
+	s, ok = cl.FindZoxideSession("test")
+	assert.True(t, ok)
+
+	s, ok = cl.FindTmuxinatorConfig("test")
+	assert.True(t, ok)
+}
+
+func sessionsWithAttached() model.SeshSessions {
+	return model.SeshSessions{
+		OrderedIndex: []string{"tmux:main", "tmux:dev", "tmux:work"},
+		Directory: model.SeshSessionMap{
+			"tmux:main": {Src: "tmux", Name: "main", Path: "/home/user", Attached: 1},
+			"tmux:dev":  {Src: "tmux", Name: "dev", Path: "/home/user/dev"},
+			"tmux:work": {Src: "tmux", Name: "work", Path: "/home/user/work"},
+		},
+	}
+}
+
+func TestCachingLister_HideAttached_ColdStart(t *testing.T) {
+	dir := t.TempDir()
+	fc := cache.NewFileCacheWithPath(filepath.Join(dir, "sessions.gob"))
+	inner := lister.NewMockLister(t)
+
+	sessions := sessionsWithAttached()
+	// Inner should be called WITHOUT HideAttached (cache stores full list)
+	inner.On("List", lister.ListOptions{Tmux: true, HideAttached: false}).Return(sessions, nil).Once()
+	inner.On("GetAttachedTmuxSession").Return(sessions.Directory["tmux:main"], true)
+
+	cl := lister.NewCachingLister(inner, fc)
+	got, err := cl.List(lister.ListOptions{Tmux: true, HideAttached: true})
+	require.NoError(t, err)
+	// "main" should be filtered out
+	assert.Equal(t, []string{"tmux:dev", "tmux:work"}, got.OrderedIndex)
+
+	// Cache should still contain the full unfiltered list
+	cached, err := fc.Read()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"tmux:main", "tmux:dev", "tmux:work"}, cached.Sessions.OrderedIndex)
+
+	cl.Wait()
+}
+
+func TestCachingLister_HideAttached_WarmHit(t *testing.T) {
+	dir := t.TempDir()
+	fc := cache.NewFileCacheWithPath(filepath.Join(dir, "sessions.gob"))
+	inner := lister.NewMockLister(t)
+
+	sessions := sessionsWithAttached()
+	require.NoError(t, fc.Write(sessions))
+
+	inner.On("GetAttachedTmuxSession").Return(sessions.Directory["tmux:main"], true)
+
+	cl := lister.NewCachingLister(inner, fc)
+	got, err := cl.List(lister.ListOptions{Tmux: true, HideAttached: true})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"tmux:dev", "tmux:work"}, got.OrderedIndex)
+
+	cl.Wait()
+	inner.AssertNotCalled(t, "List")
+}
+
+func TestCachingLister_HideAttached_NoAttachedSession(t *testing.T) {
+	dir := t.TempDir()
+	fc := cache.NewFileCacheWithPath(filepath.Join(dir, "sessions.gob"))
+	inner := lister.NewMockLister(t)
+
+	sessions := fakeSessions()
+	require.NoError(t, fc.Write(sessions))
+
+	inner.On("GetAttachedTmuxSession").Return(model.SeshSession{}, false)
+
+	cl := lister.NewCachingLister(inner, fc)
+	got, err := cl.List(lister.ListOptions{Tmux: true, HideAttached: true})
+	require.NoError(t, err)
+	// Nothing filtered since no session is attached
+	assert.Equal(t, sessions.OrderedIndex, got.OrderedIndex)
+
+	cl.Wait()
+}
+
+func TestCachingLister_WaitBlocksUntilDone(t *testing.T) {
+	dir := t.TempDir()
+	fc := cache.NewFileCacheWithPath(filepath.Join(dir, "sessions.gob"))
+	inner := lister.NewMockLister(t)
+	opts := lister.ListOptions{}
+
+	sessions := fakeSessions()
+	inner.On("List", opts).Return(sessions, nil).Run(func(_ mock.Arguments) {
+		time.Sleep(50 * time.Millisecond)
+	})
+
+	cl := lister.NewCachingLister(inner, fc)
+	cl.RefreshCache(opts)
+
+	cl.Wait()
+
+	cached, err := fc.Read()
+	require.NoError(t, err)
+	assert.Equal(t, sessions.OrderedIndex, cached.Sessions.OrderedIndex)
+}

--- a/model/config.go
+++ b/model/config.go
@@ -2,6 +2,7 @@ package model
 
 type (
 	Config struct {
+		Cache                bool                 `toml:"cache"`
 		StrictMode           bool                 `toml:"strict_mode"`
 		ImportPaths          []string             `toml:"import"`
 		DefaultSessionConfig DefaultSessionConfig `toml:"default_session"`

--- a/seshcli/connect.go
+++ b/seshcli/connect.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/joshmedeski/sesh/v2/lister"
 	"github.com/joshmedeski/sesh/v2/model"
 )
 
@@ -46,10 +47,13 @@ func NewConnectCommand(base *BaseDeps) *cobra.Command {
 			if _, err := deps.Connector.Connect(trimmedName, opts); err != nil {
 				// TODO: add to logging
 				return err
-			} else {
-				// TODO: add to logging
-				return nil
 			}
+			// Refresh cache in background so next sesh list has fresh data
+			if deps.CachingLister != nil {
+				deps.CachingLister.RefreshCache(lister.ListOptions{})
+				deps.CachingLister.Wait()
+			}
+			return nil
 		},
 	}
 

--- a/seshcli/list.go
+++ b/seshcli/list.go
@@ -19,6 +19,9 @@ func NewListCommand(base *BaseDeps) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if deps.CachingLister != nil {
+				defer deps.CachingLister.Wait()
+			}
 
 			config, _ := cmd.Flags().GetBool("config")
 			jsonOutput, _ := cmd.Flags().GetBool("json")

--- a/seshcli/picker.go
+++ b/seshcli/picker.go
@@ -21,6 +21,9 @@ func NewPickerCommand(base *BaseDeps) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if deps.CachingLister != nil {
+				defer deps.CachingLister.Wait()
+			}
 
 			config, _ := cmd.Flags().GetBool("config")
 			tmux, _ := cmd.Flags().GetBool("tmux")


### PR DESCRIPTION
> [!NOTE]
> this is an experimental opt-in caching feature that will speed up load times for sesh

## Summary
- Add file-based cache layer (`cache/` package) using gob encoding at `$XDG_CACHE_HOME/sesh/sessions.gob`
- Add `CachingLister` decorator with stale-while-revalidate strategy (5s soft TTL) that wraps the existing lister
- Wire caching into `deps.go` behind a `cache = true` config flag, with automatic refresh after `sesh connect`

## Why
Repeated `sesh list` / `sesh pick` calls can be slow when fetching from tmux, zoxide, and config sources. Caching returns instant results for subsequent calls while keeping data fresh via background revalidation.

## Notes
- Caching is **opt-in** and disabled by default -- no behavior change without `cache = true` in `sesh.toml`
- Cache stores the full unfiltered session list; view-level filters like `HideAttached` are applied after cache read
- Atomic writes via temp file + rename to prevent corruption
- Comprehensive tests for both `cache/` and `lister/` packages

```toml
cache = true
```