### PR TITLE
feat(picker): add separator-aware fuzzy matching

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -12,6 +12,7 @@ type (
 		WindowConfigs        []WindowConfig       `toml:"window"`
 		WildcardConfigs      []WildcardConfig     `toml:"wildcard"`
 		DirLength            int                  `toml:"dir_length"`
+		SeparatorAware       bool                 `toml:"separator_aware"`
 	}
 	Evaluation struct {
 		StrictMode bool `toml:"strict_mode"`

--- a/seshcli/deps.go
+++ b/seshcli/deps.go
@@ -10,6 +10,7 @@ import (
 	"github.com/joshmedeski/sesh/v2/cloner"
 	"github.com/joshmedeski/sesh/v2/configurator"
 	"github.com/joshmedeski/sesh/v2/connector"
+	"github.com/joshmedeski/sesh/v2/model"
 	"github.com/joshmedeski/sesh/v2/dir"
 	"github.com/joshmedeski/sesh/v2/execwrap"
 	"github.com/joshmedeski/sesh/v2/git"
@@ -52,6 +53,7 @@ type BaseDeps struct {
 // Deps holds all dependencies including config-dependent ones.
 type Deps struct {
 	BaseDeps
+	Config        model.Config
 	Lister        lister.Lister
 	CachingLister *lister.CachingLister
 	Startup       startup.Startup
@@ -126,6 +128,7 @@ func (b *BaseDeps) BuildAll(configPath string) (*Deps, error) {
 
 	return &Deps{
 		BaseDeps:      *b,
+		Config:        config,
 		Lister:        usedLister,
 		CachingLister: cachedLi,
 		Startup:       s,

--- a/seshcli/picker.go
+++ b/seshcli/picker.go
@@ -33,6 +33,11 @@ func NewPickerCommand(base *BaseDeps) *cobra.Command {
 			tmuxinator, _ := cmd.Flags().GetBool("tmuxinator")
 			hideDuplicates, _ := cmd.Flags().GetBool("hide-duplicates")
 
+			separatorAware := deps.Config.SeparatorAware
+			if cmd.Flags().Changed("separator-aware") {
+				separatorAware, _ = cmd.Flags().GetBool("separator-aware")
+			}
+
 			opts := lister.ListOptions{
 				Config:         config,
 				HideAttached:   hideAttached,
@@ -46,7 +51,7 @@ func NewPickerCommand(base *BaseDeps) *cobra.Command {
 				return deps.Lister.List(opts)
 			}
 
-			m := picker.New(fetchFunc, icons)
+			m := picker.New(fetchFunc, icons, separatorAware)
 			p := tea.NewProgram(m)
 			result, err := p.Run()
 			if err != nil {
@@ -81,6 +86,7 @@ func NewPickerCommand(base *BaseDeps) *cobra.Command {
 	cmd.Flags().BoolP("icons", "i", false, "show icons")
 	cmd.Flags().BoolP("tmuxinator", "T", false, "show tmuxinator configs")
 	cmd.Flags().BoolP("hide-duplicates", "d", false, "hide duplicate entries")
+	cmd.Flags().BoolP("separator-aware", "s", false, "match spaces to separators (-_/\\)")
 
 	return cmd
 }


### PR DESCRIPTION
## Summary

- Adds separator-aware matching mode to `sesh picker` so separator characters (`-`, `_`, `/`, `\`) are treated as token boundaries during fuzzy search
- Configurable via `separator_aware = true` in `sesh.toml` or `--separator-aware` / `-s` flag on `sesh picker`
- Searching "client libs ts" now matches `client-libs/ts` when enabled

Closes #338

## Test plan

- [x] Unit tests for `normalizeSeparators` covering all separator types
- [x] Tests for separator-aware filtering (space matches dash, slash)
- [x] Tests verifying pattern normalization (dash in query still matches dash)
- [x] Tests confirming disabled mode does not cross-match separators