### PR TITLE
Add man page generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,5 @@ go.work
 sesh
 
 dist/
+man/
 .DS_Store

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,6 +14,8 @@ before:
     - go mod tidy
     # you may remove this if you don't need go generate
     - go generate ./...
+    - mkdir -p man
+    - sh -c "go run . man > man/sesh.1"
 
 builds:
   - env:
@@ -39,6 +41,9 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
+    files:
+      - src: man/sesh.1
+        dst: share/man/man1/
 
 changelog:
   sort: asc
@@ -61,6 +66,9 @@ brews:
     commit_author:
       name: goreleaser-bot
       email: bot@goreleaser.com
+    install: |
+      bin.install "sesh"
+      man1.install "share/man/man1/sesh.1"
     dependencies:
       - tmux
       - zoxide
@@ -76,8 +84,6 @@ aurs:
       - zoxide
         tmux
     package: |-
-      # bin
       install -Dm755 $_pkgname "$pkgdir/usr/bin/$_pkgname"
-
-      # license
+      install -Dm644 share/man/man1/sesh.1 "$pkgdir/usr/share/man/man1/sesh.1"
       install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"

--- a/justfile
+++ b/justfile
@@ -9,3 +9,8 @@ test: mock
 # Build sesh binary to GOPATH/bin
 build version="dev":
     go build -buildvcs=false -ldflags "-X 'main.version={{version}}'" -o `go env GOPATH`/bin/sesh
+
+# Generate man page
+man: build
+    mkdir -p man
+    sesh man > man/sesh.1


### PR DESCRIPTION
Closes #27

## Summary
- Wire the hidden `sesh man` subcommand (from `fang`/`mango-cobra`, already a dependency) into the build and release pipeline
- Add `just man` target for local man page generation
- Configure goreleaser to generate, archive, and install the man page for Homebrew and AUR

## Test plan
- [x] Run `just man` and verify `man/sesh.1` is generated
- [x] Run `man ./man/sesh.1` to preview the man page
- [x] Verify goreleaser config is valid (`goreleaser check`)
