### PR TITLE
Fix cache to store full session list, filter post-cache

### DIFF
--- a/lister/caching_lister_test.go
+++ b/lister/caching_lister_test.go
@@ -38,13 +38,13 @@ func TestCachingLister_ColdStart(t *testing.T) {
 	dir := t.TempDir()
 	fc := cache.NewFileCacheWithPath(filepath.Join(dir, "sessions.gob"))
 	inner := lister.NewMockLister(t)
-	opts := lister.ListOptions{Tmux: true}
 
 	sessions := fakeSessions()
-	inner.On("List", opts).Return(sessions, nil).Once()
+	// Inner is always called with empty opts (full list)
+	inner.On("List", lister.ListOptions{}).Return(sessions, nil).Once()
 
 	cl := lister.NewCachingLister(inner, fc)
-	got, err := cl.List(opts)
+	got, err := cl.List(lister.ListOptions{Tmux: true})
 	require.NoError(t, err)
 	assert.Equal(t, sessions.OrderedIndex, got.OrderedIndex)
 
@@ -96,12 +96,12 @@ func TestCachingLister_ColdStartError(t *testing.T) {
 	dir := t.TempDir()
 	fc := cache.NewFileCacheWithPath(filepath.Join(dir, "sessions.gob"))
 	inner := lister.NewMockLister(t)
-	opts := lister.ListOptions{Tmux: true}
 
-	inner.On("List", opts).Return(model.SeshSessions{}, fmt.Errorf("tmux not running")).Once()
+	// Inner is always called with empty opts
+	inner.On("List", lister.ListOptions{}).Return(model.SeshSessions{}, fmt.Errorf("tmux not running")).Once()
 
 	cl := lister.NewCachingLister(inner, fc)
-	_, err := cl.List(opts)
+	_, err := cl.List(lister.ListOptions{Tmux: true})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "tmux not running")
 
@@ -182,8 +182,8 @@ func TestCachingLister_HideAttached_ColdStart(t *testing.T) {
 	inner := lister.NewMockLister(t)
 
 	sessions := sessionsWithAttached()
-	// Inner should be called WITHOUT HideAttached (cache stores full list)
-	inner.On("List", lister.ListOptions{Tmux: true, HideAttached: false}).Return(sessions, nil).Once()
+	// Inner is always called with empty opts (cache stores full list)
+	inner.On("List", lister.ListOptions{}).Return(sessions, nil).Once()
 	inner.On("GetAttachedTmuxSession").Return(sessions.Directory["tmux:main"], true)
 
 	cl := lister.NewCachingLister(inner, fc)
@@ -257,4 +257,123 @@ func TestCachingLister_WaitBlocksUntilDone(t *testing.T) {
 	cached, err := fc.Read()
 	require.NoError(t, err)
 	assert.Equal(t, sessions.OrderedIndex, cached.Sessions.OrderedIndex)
+}
+
+// --- Source filtering and dedup tests ---
+
+func mixedSessions() model.SeshSessions {
+	return model.SeshSessions{
+		OrderedIndex: []string{"tmux:main", "config:project", "zoxide:code"},
+		Directory: model.SeshSessionMap{
+			"tmux:main":      {Src: "tmux", Name: "main", Path: "/home/user"},
+			"config:project": {Src: "config", Name: "project", Path: "/home/user/project"},
+			"zoxide:code":    {Src: "zoxide", Name: "code", Path: "/home/user/code"},
+		},
+	}
+}
+
+func TestCachingLister_SourceFilter_FromCache(t *testing.T) {
+	dir := t.TempDir()
+	fc := cache.NewFileCacheWithPath(filepath.Join(dir, "sessions.gob"))
+	inner := lister.NewMockLister(t)
+
+	// Pre-populate cache with mixed-source sessions
+	sessions := mixedSessions()
+	require.NoError(t, fc.Write(sessions))
+
+	cl := lister.NewCachingLister(inner, fc)
+
+	// Request only tmux — should filter from full cache
+	got, err := cl.List(lister.ListOptions{Tmux: true})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"tmux:main"}, got.OrderedIndex)
+
+	cl.Wait()
+	inner.AssertNotCalled(t, "List")
+}
+
+func TestCachingLister_SourceFilter_DifferentFilters(t *testing.T) {
+	dir := t.TempDir()
+	fc := cache.NewFileCacheWithPath(filepath.Join(dir, "sessions.gob"))
+	inner := lister.NewMockLister(t)
+
+	// Pre-populate cache with mixed-source sessions
+	sessions := mixedSessions()
+	require.NoError(t, fc.Write(sessions))
+
+	cl := lister.NewCachingLister(inner, fc)
+
+	// First call: tmux only
+	got, err := cl.List(lister.ListOptions{Tmux: true})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"tmux:main"}, got.OrderedIndex)
+
+	// Second call: zoxide only — must NOT return tmux sessions
+	got, err = cl.List(lister.ListOptions{Zoxide: true})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"zoxide:code"}, got.OrderedIndex)
+
+	// Third call: no source flags — returns all
+	got, err = cl.List(lister.ListOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, sessions.OrderedIndex, got.OrderedIndex)
+
+	cl.Wait()
+	inner.AssertNotCalled(t, "List")
+}
+
+func TestCachingLister_SourceFilter_ColdStart(t *testing.T) {
+	dir := t.TempDir()
+	fc := cache.NewFileCacheWithPath(filepath.Join(dir, "sessions.gob"))
+	inner := lister.NewMockLister(t)
+
+	sessions := mixedSessions()
+	// Inner is called with empty opts (fetches all sources)
+	inner.On("List", lister.ListOptions{}).Return(sessions, nil).Once()
+
+	cl := lister.NewCachingLister(inner, fc)
+
+	// Request only zoxide — inner fetches all, cache stores all, filter returns zoxide
+	got, err := cl.List(lister.ListOptions{Zoxide: true})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"zoxide:code"}, got.OrderedIndex)
+
+	// Cache should contain all sources
+	cached, err := fc.Read()
+	require.NoError(t, err)
+	assert.Equal(t, sessions.OrderedIndex, cached.Sessions.OrderedIndex)
+
+	cl.Wait()
+}
+
+func TestCachingLister_HideDuplicates_PostCache(t *testing.T) {
+	dir := t.TempDir()
+	fc := cache.NewFileCacheWithPath(filepath.Join(dir, "sessions.gob"))
+	inner := lister.NewMockLister(t)
+
+	// Sessions with duplicate name and path across sources
+	sessions := model.SeshSessions{
+		OrderedIndex: []string{"tmux:project", "config:project", "zoxide:other"},
+		Directory: model.SeshSessionMap{
+			"tmux:project":   {Src: "tmux", Name: "project", Path: "/home/user/project"},
+			"config:project": {Src: "config", Name: "project", Path: "/home/user/project"},
+			"zoxide:other":   {Src: "zoxide", Name: "other", Path: "/home/user/other"},
+		},
+	}
+	require.NoError(t, fc.Write(sessions))
+
+	cl := lister.NewCachingLister(inner, fc)
+
+	// With HideDuplicates, "config:project" is a duplicate of "tmux:project" (same name + path)
+	got, err := cl.List(lister.ListOptions{HideDuplicates: true})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"tmux:project", "zoxide:other"}, got.OrderedIndex)
+
+	// Without HideDuplicates, all returned
+	got, err = cl.List(lister.ListOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, sessions.OrderedIndex, got.OrderedIndex)
+
+	cl.Wait()
+	inner.AssertNotCalled(t, "List")
 }


### PR DESCRIPTION
## Summary
- The `CachingLister` was passing source filters (`--tmux`, `--zoxide`, etc.) and `HideDuplicates` through to the inner lister, causing the cache to store partial results. Subsequent calls with different filters returned incorrect data from cache (e.g. `sesh list --tmux` then `sesh list --zoxide` would return tmux sessions for both).
- Now the inner lister always fetches all sources without dedup, and source filtering, `HideDuplicates`, and `HideAttached` are all applied as post-cache filters in `applyFilters`.
- Added tests for source filtering from cache, sequential calls with different filters, and post-cache dedup.

## Test plan
- [x] `just test` — all existing + new tests pass
- [x] Manual: enable `cache = true` in config, run `sesh list --tmux` then `sesh list --zoxide` and confirm each returns the correct source

🤖 Generated with [Claude Code](https://claude.com/claude-code)