### PR TITLE
Add support for listing and connecting to tmux panes

### DIFF
--- a/connector/connect.go
+++ b/connector/connect.go
@@ -13,6 +13,7 @@ func (c *RealConnector) Connect(name string, opts model.ConnectOpts) (string, er
 	// TODO: make it configurable to disable certain strategies (including flags for optimized fzf commands)
 	// sesh connect --config (sesh list --config | fzf)
 	strategies := []func(*RealConnector, string) (model.Connection, error){
+		tmuxPaneStrategy,
 		tmuxStrategy,
 		tmuxinatorStrategy,
 		configStrategy,
@@ -22,6 +23,7 @@ func (c *RealConnector) Connect(name string, opts model.ConnectOpts) (string, er
 	}
 
 	connectStrategy := map[string]func(c *RealConnector, connection model.Connection, opts model.ConnectOpts) (string, error){
+		"tmux-pane":       connectToTmuxPane,
 		"tmux":            connectToTmux,
 		"tmuxinator":      connectToTmuxinator,
 		"config":          connectToTmux,

--- a/connector/pane.go
+++ b/connector/pane.go
@@ -1,0 +1,66 @@
+package connector
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/joshmedeski/sesh/v2/model"
+)
+
+func isTmuxPaneFormat(name string) bool {
+	return strings.Contains(name, "/") && !strings.HasPrefix(name, "/")
+}
+
+func tmuxPaneStrategy(c *RealConnector, name string) (model.Connection, error) {
+	if !isTmuxPaneFormat(name) {
+		return model.Connection{Found: false}, nil
+	}
+
+	sessions, err := c.lister.ListTmuxPanes()
+	if err != nil {
+		return model.Connection{Found: false}, nil
+	}
+
+	for _, key := range sessions.OrderedIndex {
+		session := sessions.Directory[key]
+		if session.Name == name {
+			return model.Connection{
+				Found:       true,
+				Session:     session,
+				New:         false,
+				AddToZoxide: false,
+			}, nil
+		}
+	}
+
+	return model.Connection{Found: false}, nil
+}
+
+func connectToTmuxPane(c *RealConnector, connection model.Connection, opts model.ConnectOpts) (string, error) {
+	panes, err := c.tmux.ListTmuxPanes()
+	if err != nil {
+		return "", err
+	}
+
+	sessions, err := c.lister.ListTmuxPanes()
+	if err != nil {
+		return "", err
+	}
+
+	var targetPaneKey string
+	for _, key := range sessions.OrderedIndex {
+		if sessions.Directory[key].Name == connection.Session.Name {
+			targetPaneKey = key
+			break
+		}
+	}
+
+	for _, pane := range panes {
+		paneKey := fmt.Sprintf("tmux-pane:%s/%s", pane.WindowName, pane.PaneID)
+		if paneKey == targetPaneKey {
+			return c.tmux.SelectPane(pane.WindowIndex, pane.PaneIndex)
+		}
+	}
+
+	return "", fmt.Errorf("pane not found: %s", connection.Session.Name)
+}

--- a/connector/pane.go
+++ b/connector/pane.go
@@ -12,7 +12,7 @@ func isTmuxPaneFormat(name string) bool {
 }
 
 func tmuxPaneStrategy(c *RealConnector, name string) (model.Connection, error) {
-	if !isTmuxPaneFormat(name) {
+	if !c.tmux.IsAttached() || !isTmuxPaneFormat(name) {
 		return model.Connection{Found: false}, nil
 	}
 
@@ -36,7 +36,7 @@ func tmuxPaneStrategy(c *RealConnector, name string) (model.Connection, error) {
 	return model.Connection{Found: false}, nil
 }
 
-func connectToTmuxPane(c *RealConnector, connection model.Connection, opts model.ConnectOpts) (string, error) {
+func connectToTmuxPane(c *RealConnector, connection model.Connection, _ model.ConnectOpts) (string, error) {
 	panes, err := c.tmux.ListTmuxPanes()
 	if err != nil {
 		return "", err

--- a/icon/icon.go
+++ b/icon/icon.go
@@ -26,6 +26,7 @@ var (
 	tmuxIcon       string = ""
 	configIcon     string = ""
 	tmuxinatorIcon string = ""
+	tmuxPaneIcon       string = ""
 )
 
 // Glyph holds the icon character and ANSI color code for a session source.
@@ -40,8 +41,8 @@ var Glyphs = map[string]Glyph{
 	"config":     {Icon: configIcon, ColorCode: 90},
 	"zoxide":     {Icon: zoxideIcon, ColorCode: 36},
 	"tmuxinator": {Icon: tmuxinatorIcon, ColorCode: 33},
+	"tmux-pane":  {Icon: tmuxPaneIcon, ColorCode: 32},
 }
-
 
 func ansiString(code int, s string) string {
 	return fmt.Sprintf("\033[%dm%s\033[39m", code, s)
@@ -62,7 +63,7 @@ func (i *RealIcon) AddIconNoColor(s model.SeshSession) string {
 }
 
 func (i *RealIcon) RemoveIcon(name string) string {
-	if strings.HasPrefix(name, tmuxIcon) || strings.HasPrefix(name, zoxideIcon) || strings.HasPrefix(name, configIcon) || strings.HasPrefix(name, tmuxinatorIcon) {
+	if strings.HasPrefix(name, tmuxIcon) || strings.HasPrefix(name, zoxideIcon) || strings.HasPrefix(name, configIcon) || strings.HasPrefix(name, tmuxinatorIcon) || strings.HasPrefix(name, tmuxPaneIcon) {
 		return name[4:]
 	}
 	return name

--- a/lister/caching_lister.go
+++ b/lister/caching_lister.go
@@ -123,7 +123,7 @@ func (cl *CachingLister) applyFilters(sessions model.SeshSessions, opts ListOpti
 // sourceSet returns a set of allowed source names based on opts, or nil if
 // no source flags are set (meaning all sources are allowed).
 func sourceSet(opts ListOptions) map[string]bool {
-	if !opts.Tmux && !opts.Config && !opts.Zoxide && !opts.Tmuxinator {
+	if !opts.Tmux && !opts.Config && !opts.Zoxide && !opts.Tmuxinator && !opts.Panes {
 		return nil
 	}
 	m := make(map[string]bool)
@@ -138,6 +138,9 @@ func sourceSet(opts ListOptions) map[string]bool {
 	}
 	if opts.Tmuxinator {
 		m["tmuxinator"] = true
+	}
+	if opts.Panes {
+		m["tmux-pane"] = true
 	}
 	return m
 }
@@ -170,6 +173,10 @@ func (cl *CachingLister) Wait() {
 }
 
 // --- Delegate all other Lister methods to inner ---
+
+func (cl *CachingLister) ListTmuxPanes() (model.SeshSessions, error) {
+	return cl.inner.ListTmuxPanes()
+}
 
 func (cl *CachingLister) FindTmuxSession(name string) (model.SeshSession, bool) {
 	return cl.inner.FindTmuxSession(name)

--- a/lister/caching_lister_test.go
+++ b/lister/caching_lister_test.go
@@ -139,6 +139,7 @@ func TestCachingLister_DelegatesMethods(t *testing.T) {
 	inner.On("FindConfigWildcard", "/path").Return(model.WildcardConfig{}, false)
 	inner.On("FindZoxideSession", "test").Return(session, true)
 	inner.On("FindTmuxinatorConfig", "test").Return(session, true)
+	inner.On("ListTmuxPanes").Return(model.SeshSessions{}, nil)
 
 	cl := lister.NewCachingLister(inner, fc)
 
@@ -163,6 +164,10 @@ func TestCachingLister_DelegatesMethods(t *testing.T) {
 
 	s, ok = cl.FindTmuxinatorConfig("test")
 	assert.True(t, ok)
+
+	panes, pErr := cl.ListTmuxPanes()
+	assert.NoError(t, pErr)
+	assert.Empty(t, panes.OrderedIndex)
 }
 
 func sessionsWithAttached() model.SeshSessions {

--- a/lister/list.go
+++ b/lister/list.go
@@ -18,6 +18,7 @@ type (
 		Zoxide         bool
 		Tmuxinator     bool
 		HideDuplicates bool
+		Panes          bool
 	}
 	srcStrategy func(*RealLister) (model.SeshSessions, error)
 )
@@ -33,6 +34,7 @@ var srcStrategies = map[string]srcStrategy{
 	"config":     listConfig,
 	"tmuxinator": listTmuxinator,
 	"zoxide":     listZoxide,
+	"tmux-pane":  listTmuxPanes,
 }
 
 func (l *RealLister) List(opts ListOptions) (model.SeshSessions, error) {

--- a/lister/lister.go
+++ b/lister/lister.go
@@ -10,6 +10,7 @@ import (
 
 type Lister interface {
 	List(opts ListOptions) (model.SeshSessions, error)
+	ListTmuxPanes() (model.SeshSessions, error)
 	FindTmuxSession(name string) (model.SeshSession, bool)
 	GetAttachedTmuxSession() (model.SeshSession, bool)
 	GetLastTmuxSession() (model.SeshSession, bool)

--- a/lister/pane.go
+++ b/lister/pane.go
@@ -1,0 +1,70 @@
+package lister
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/joshmedeski/sesh/v2/model"
+)
+
+func tmuxPaneKey(windowName string, paneID string) string {
+	return fmt.Sprintf("tmux-pane:%s/%s", windowName, paneID)
+}
+
+func tmuxPaneDisplayName(pane *model.TmuxPane) string {
+	hostname, _ := os.Hostname()
+	if pane.PaneTitle != "" && pane.PaneTitle != hostname {
+		return pane.PaneTitle
+	}
+	return pane.PaneCommand
+}
+
+func listTmuxPanes(l *RealLister) (model.SeshSessions, error) {
+	tmuxPanes, err := l.tmux.ListTmuxPanes()
+	if err != nil {
+		return model.SeshSessions{}, fmt.Errorf("couldn't list tmux panes: %q", err)
+	}
+
+	// Count raw names to detect duplicates needing .0, .1 suffixes
+	type paneEntry struct {
+		pane    *model.TmuxPane
+		rawName string
+	}
+	entries := make([]paneEntry, len(tmuxPanes))
+	nameCounts := make(map[string]int)
+	for i, pane := range tmuxPanes {
+		rawName := fmt.Sprintf("%s/%s", pane.WindowName, tmuxPaneDisplayName(pane))
+		entries[i] = paneEntry{pane: pane, rawName: rawName}
+		nameCounts[rawName]++
+	}
+
+	directory := make(map[string]model.SeshSession)
+	orderedIndex := []string{}
+	nameIndexes := make(map[string]int)
+
+	for _, entry := range entries {
+		name := entry.rawName
+		if nameCounts[entry.rawName] > 1 {
+			idx := nameIndexes[entry.rawName]
+			name = fmt.Sprintf("%s.%d", entry.rawName, idx)
+			nameIndexes[entry.rawName] = idx + 1
+		}
+
+		key := tmuxPaneKey(entry.pane.WindowName, entry.pane.PaneID)
+		orderedIndex = append(orderedIndex, key)
+		directory[key] = model.SeshSession{
+			Src:  "tmux-pane",
+			Name: name,
+			Path: entry.pane.PanePath,
+		}
+	}
+
+	return model.SeshSessions{
+		Directory:    directory,
+		OrderedIndex: orderedIndex,
+	}, nil
+}
+
+func (l *RealLister) ListTmuxPanes() (model.SeshSessions, error) {
+	return listTmuxPanes(l)
+}

--- a/lister/pane_test.go
+++ b/lister/pane_test.go
@@ -1,0 +1,113 @@
+package lister
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/home"
+	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/tmux"
+	"github.com/joshmedeski/sesh/v2/tmuxinator"
+	"github.com/joshmedeski/sesh/v2/zoxide"
+	"github.com/stretchr/testify/assert"
+)
+
+func makeTmuxPane(windowIndex int, windowName string, paneIndex int, paneTitle, paneCommand, panePath, paneID string) *model.TmuxPane {
+	return &model.TmuxPane{
+		WindowIndex: windowIndex,
+		WindowName:  windowName,
+		PaneIndex:   paneIndex,
+		PaneTitle:   paneTitle,
+		PaneCommand: paneCommand,
+		PanePath:    panePath,
+		PaneID:      paneID,
+	}
+}
+
+func TestListTmuxPanes(t *testing.T) {
+	hostname, _ := os.Hostname()
+
+	t.Run("should list tmux panes", func(t *testing.T) {
+		mockTmux := new(tmux.MockTmux)
+		mockTmux.On("ListTmuxPanes").Return([]*model.TmuxPane{
+			makeTmuxPane(0, "editor", 0, hostname, "vim", "/home/user/project", "%0"),
+			makeTmuxPane(0, "editor", 1, hostname, "zsh", "/home/user/project", "%1"),
+			makeTmuxPane(1, "tests", 0, hostname, "go", "/home/user/project", "%2"),
+		}, nil)
+
+		lister := NewLister(model.Config{}, new(home.MockHome), mockTmux, new(zoxide.MockZoxide), new(tmuxinator.MockTmuxinator))
+		realLister, ok := lister.(*RealLister)
+		if !ok {
+			log.Fatal("Cannot convert lister to *RealLister")
+		}
+
+		sessions, err := listTmuxPanes(realLister)
+		assert.Nil(t, err)
+		assert.Equal(t, 3, len(sessions.OrderedIndex))
+		assert.Equal(t, "tmux-pane:editor/%0", sessions.OrderedIndex[0])
+		assert.Equal(t, "editor/vim", sessions.Directory["tmux-pane:editor/%0"].Name)
+		assert.Equal(t, "tmux-pane", sessions.Directory["tmux-pane:editor/%0"].Src)
+		assert.Equal(t, "tmux-pane:editor/%1", sessions.OrderedIndex[1])
+		assert.Equal(t, "editor/zsh", sessions.Directory["tmux-pane:editor/%1"].Name)
+		assert.Equal(t, "tmux-pane:tests/%2", sessions.OrderedIndex[2])
+		assert.Equal(t, "tests/go", sessions.Directory["tmux-pane:tests/%2"].Name)
+	})
+
+	t.Run("should use pane title when explicitly set", func(t *testing.T) {
+		mockTmux := new(tmux.MockTmux)
+		mockTmux.On("ListTmuxPanes").Return([]*model.TmuxPane{
+			makeTmuxPane(0, "editor", 0, "my-editor", "vim", "/home/user/project", "%0"),
+			makeTmuxPane(0, "editor", 1, hostname, "zsh", "/home/user/project", "%1"),
+		}, nil)
+
+		lister := NewLister(model.Config{}, new(home.MockHome), mockTmux, new(zoxide.MockZoxide), new(tmuxinator.MockTmuxinator))
+		realLister, ok := lister.(*RealLister)
+		if !ok {
+			log.Fatal("Cannot convert lister to *RealLister")
+		}
+
+		sessions, err := listTmuxPanes(realLister)
+		assert.Nil(t, err)
+		assert.Equal(t, "editor/my-editor", sessions.Directory["tmux-pane:editor/%0"].Name)
+		assert.Equal(t, "editor/zsh", sessions.Directory["tmux-pane:editor/%1"].Name)
+	})
+
+	t.Run("should disambiguate duplicate names with suffixes", func(t *testing.T) {
+		mockTmux := new(tmux.MockTmux)
+		mockTmux.On("ListTmuxPanes").Return([]*model.TmuxPane{
+			makeTmuxPane(0, "editor", 0, hostname, "zsh", "/home/user/project", "%0"),
+			makeTmuxPane(0, "editor", 1, hostname, "zsh", "/home/user/project", "%1"),
+			makeTmuxPane(1, "tests", 0, hostname, "zsh", "/tmp", "%2"),
+		}, nil)
+
+		lister := NewLister(model.Config{}, new(home.MockHome), mockTmux, new(zoxide.MockZoxide), new(tmuxinator.MockTmuxinator))
+		realLister, ok := lister.(*RealLister)
+		if !ok {
+			log.Fatal("Cannot convert lister to *RealLister")
+		}
+
+		sessions, err := listTmuxPanes(realLister)
+		assert.Nil(t, err)
+		assert.Equal(t, "editor/zsh.0", sessions.Directory["tmux-pane:editor/%0"].Name)
+		assert.Equal(t, "editor/zsh.1", sessions.Directory["tmux-pane:editor/%1"].Name)
+		assert.Equal(t, "tests/zsh", sessions.Directory["tmux-pane:tests/%2"].Name)
+	})
+
+	t.Run("should return empty sessions on error", func(t *testing.T) {
+		mockTmux := new(tmux.MockTmux)
+		mockTmux.On("ListTmuxPanes").Return(nil, fmt.Errorf("some error"))
+
+		lister := NewLister(model.Config{}, new(home.MockHome), mockTmux, new(zoxide.MockZoxide), new(tmuxinator.MockTmuxinator))
+		realLister, ok := lister.(*RealLister)
+		if !ok {
+			log.Fatal("Cannot convert lister to *RealLister")
+		}
+
+		sessions, err := listTmuxPanes(realLister)
+		assert.Equal(t, model.SeshSessions{}, sessions)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "couldn't list tmux panes")
+	})
+}

--- a/lister/srcs.go
+++ b/lister/srcs.go
@@ -48,7 +48,7 @@ func srcs(opts ListOptions) []string {
 		count++
 	}
 	if count == 0 {
-		return []string{"tmux", "config", "tmuxinator", "zoxide", "tmux-pane"}
+		return []string{"tmux", "config", "tmuxinator", "zoxide"}
 	}
 	srcs := make([]string, 0, count)
 	if opts.Tmux {

--- a/lister/srcs.go
+++ b/lister/srcs.go
@@ -31,7 +31,6 @@ func sortSources(sources, sortOrder []string) []string {
 }
 
 func srcs(opts ListOptions) []string {
-	var srcs []string
 	count := 0
 	if opts.Tmux {
 		count++
@@ -45,26 +44,27 @@ func srcs(opts ListOptions) []string {
 	if opts.Zoxide {
 		count++
 	}
-	if count == 0 {
-		return []string{"tmux", "config", "tmuxinator", "zoxide"}
+	if opts.Panes {
+		count++
 	}
-	srcs = make([]string, count)
-	i := 0
+	if count == 0 {
+		return []string{"tmux", "config", "tmuxinator", "zoxide", "tmux-pane"}
+	}
+	srcs := make([]string, 0, count)
 	if opts.Tmux {
-		srcs[i] = "tmux"
-		i++
+		srcs = append(srcs, "tmux")
 	}
 	if opts.Config {
-		srcs[i] = "config"
-		i++
+		srcs = append(srcs, "config")
 	}
 	if opts.Tmuxinator {
-		srcs[i] = "tmuxinator"
-		i++
+		srcs = append(srcs, "tmuxinator")
 	}
 	if opts.Zoxide {
-		srcs[i] = "zoxide"
-		i++
+		srcs = append(srcs, "zoxide")
+	}
+	if opts.Panes {
+		srcs = append(srcs, "tmux-pane")
 	}
 	return srcs
 }

--- a/lister/srcs_test.go
+++ b/lister/srcs_test.go
@@ -54,7 +54,7 @@ func TestSrcs(t *testing.T) {
 		{
 			name:     "All options are false",
 			opts:     ListOptions{},
-			expected: []string{"tmux", "config", "tmuxinator", "zoxide", "tmux-pane"},
+			expected: []string{"tmux", "config", "tmuxinator", "zoxide"},
 		},
 		{
 			name:     "Only Tmux is true",

--- a/lister/srcs_test.go
+++ b/lister/srcs_test.go
@@ -54,7 +54,7 @@ func TestSrcs(t *testing.T) {
 		{
 			name:     "All options are false",
 			opts:     ListOptions{},
-			expected: []string{"tmux", "config", "tmuxinator", "zoxide"},
+			expected: []string{"tmux", "config", "tmuxinator", "zoxide", "tmux-pane"},
 		},
 		{
 			name:     "Only Tmux is true",
@@ -90,6 +90,26 @@ func TestSrcs(t *testing.T) {
 			name:     "All options are true",
 			opts:     ListOptions{Tmux: true, Config: true, Zoxide: true},
 			expected: []string{"tmux", "config", "zoxide"},
+		},
+		{
+			name:     "Only Panes is true",
+			opts:     ListOptions{Panes: true},
+			expected: []string{"tmux-pane"},
+		},
+		{
+			name:     "Panes with Tmux",
+			opts:     ListOptions{Panes: true, Tmux: true},
+			expected: []string{"tmux", "tmux-pane"},
+		},
+		{
+			name:     "Panes with Zoxide",
+			opts:     ListOptions{Panes: true, Zoxide: true},
+			expected: []string{"zoxide", "tmux-pane"},
+		},
+		{
+			name:     "Panes with all sources",
+			opts:     ListOptions{Panes: true, Tmux: true, Config: true, Zoxide: true, Tmuxinator: true},
+			expected: []string{"tmux", "config", "tmuxinator", "zoxide", "tmux-pane"},
 		},
 	}
 

--- a/model/tmux_pane.go
+++ b/model/tmux_pane.go
@@ -1,0 +1,11 @@
+package model
+
+type TmuxPane struct {
+	WindowIndex int
+	WindowName  string
+	PaneIndex   int
+	PaneTitle   string
+	PaneCommand string
+	PanePath    string
+	PaneID      string
+}

--- a/seshcli/list.go
+++ b/seshcli/list.go
@@ -1,6 +1,7 @@
 package seshcli
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -32,6 +33,11 @@ func NewListCommand(base *BaseDeps) *cobra.Command {
 			noColor, _ := cmd.Flags().GetBool("no-color")
 			tmuxinator, _ := cmd.Flags().GetBool("tmuxinator")
 			hideDuplicates, _ := cmd.Flags().GetBool("hide-duplicates")
+			panes, _ := cmd.Flags().GetBool("panes")
+
+			if panes && !base.Tmux.IsAttached() {
+				return errors.New("--panes requires being inside a tmux session")
+			}
 
 			sessions, err := deps.Lister.List(lister.ListOptions{
 				Config:         config,
@@ -43,6 +49,7 @@ func NewListCommand(base *BaseDeps) *cobra.Command {
 				Zoxide:         zoxide,
 				Tmuxinator:     tmuxinator,
 				HideDuplicates: hideDuplicates,
+				Panes:          panes,
 			})
 			if err != nil {
 				return fmt.Errorf("couldn't list sessions: %q", err)
@@ -82,6 +89,7 @@ func NewListCommand(base *BaseDeps) *cobra.Command {
 	cmd.Flags().BoolP("no-color", "n", false, "show icons without color (requires --icons)")
 	cmd.Flags().BoolP("tmuxinator", "T", false, "show tmuxinator configs")
 	cmd.Flags().BoolP("hide-duplicates", "d", false, "hide duplicate entries")
+	cmd.Flags().BoolP("panes", "p", false, "show panes in current session")
 
 	return cmd
 }

--- a/tmux/pane.go
+++ b/tmux/pane.go
@@ -1,0 +1,64 @@
+package tmux
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/joshmedeski/sesh/v2/convert"
+	"github.com/joshmedeski/sesh/v2/model"
+)
+
+func listpanesformat() string {
+	variables := []string{
+		"#{window_index}",
+		"#{window_name}",
+		"#{pane_index}",
+		"#{pane_title}",
+		"#{pane_current_command}",
+		"#{pane_current_path}",
+		"#{pane_id}",
+	}
+	return strings.Join(variables, separator)
+}
+
+func (t *RealTmux) ListTmuxPanes() ([]*model.TmuxPane, error) {
+	output, err := t.shell.ListCmd("tmux", "list-panes", "-s", "-F", listpanesformat())
+	if err != nil {
+		return []*model.TmuxPane{}, nil
+	}
+	return parseTmuxPanesOutput(output)
+}
+
+func parseTmuxPanesOutput(rawList []string) ([]*model.TmuxPane, error) {
+	panes := make([]*model.TmuxPane, 0, len(rawList))
+	for _, line := range rawList {
+		fields := strings.Split(line, separator)
+		if len(fields) != 7 {
+			continue
+		}
+		panes = append(panes, &model.TmuxPane{
+			WindowIndex: convert.StringToInt(fields[0]),
+			WindowName:  fields[1],
+			PaneIndex:   convert.StringToInt(fields[2]),
+			PaneTitle:   fields[3],
+			PaneCommand: fields[4],
+			PanePath:    fields[5],
+			PaneID:      fields[6],
+		})
+	}
+	return panes, nil
+}
+
+func (t *RealTmux) SelectPane(windowIndex int, paneIndex int) (string, error) {
+	if _, err := t.shell.Cmd("tmux", "select-window", "-t", fmt.Sprintf(":%d", windowIndex)); err != nil {
+		return "", fmt.Errorf("failed to select window %d: %w", windowIndex, err)
+	}
+	if _, err := t.shell.Cmd("tmux", "select-pane", "-t", fmt.Sprintf(".%d", paneIndex)); err != nil {
+		return "", fmt.Errorf("failed to select pane %d: %w", paneIndex, err)
+	}
+	return fmt.Sprintf("selected pane %d in window %d", paneIndex, windowIndex), nil
+}
+
+func (t *RealTmux) GetCurrentSession() (string, error) {
+	return t.shell.Cmd("tmux", "display-message", "-p", "#{session_name}")
+}

--- a/tmux/pane.go
+++ b/tmux/pane.go
@@ -50,11 +50,17 @@ func parseTmuxPanesOutput(rawList []string) ([]*model.TmuxPane, error) {
 }
 
 func (t *RealTmux) SelectPane(windowIndex int, paneIndex int) (string, error) {
-	if _, err := t.shell.Cmd("tmux", "select-window", "-t", fmt.Sprintf(":%d", windowIndex)); err != nil {
+	sessionName, err := t.GetCurrentSession()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current session: %w", err)
+	}
+
+	target := fmt.Sprintf("%s:%d.%d", sessionName, windowIndex, paneIndex)
+	if _, err := t.shell.Cmd("tmux", "select-window", "-t", fmt.Sprintf("%s:%d", sessionName, windowIndex)); err != nil {
 		return "", fmt.Errorf("failed to select window %d: %w", windowIndex, err)
 	}
-	if _, err := t.shell.Cmd("tmux", "select-pane", "-t", fmt.Sprintf(".%d", paneIndex)); err != nil {
-		return "", fmt.Errorf("failed to select pane %d: %w", paneIndex, err)
+	if _, err := t.shell.Cmd("tmux", "select-pane", "-t", target); err != nil {
+		return "", fmt.Errorf("failed to select pane %d in window %d: %w", paneIndex, windowIndex, err)
 	}
 	return fmt.Sprintf("selected pane %d in window %d", paneIndex, windowIndex), nil
 }

--- a/tmux/tmux.go
+++ b/tmux/tmux.go
@@ -17,6 +17,9 @@ type Tmux interface {
 	CapturePane(targetSession string) (string, error)
 	NextWindow() (string, error)
 	SwitchOrAttach(name string, opts model.ConnectOpts) (string, error)
+	ListTmuxPanes() ([]*model.TmuxPane, error)
+	SelectPane(windowIndex int, paneIndex int) (string, error)
+	GetCurrentSession() (string, error)
 }
 
 type RealTmux struct {


### PR DESCRIPTION
Add pane listing and jumping support

- `sesh list --panes` lists all panes in the current tmux session as `window_name/pane_display`
- `sesh connect editor/vim` detects the pane format and jumps to the matching window+pane
- Enables the standard workflow: `sesh list --panes | fzf | xargs sesh connect`

Notes:
- Pane display name uses `pane_title` if explicitly set, otherwise falls back to `pane_current_command`
- Duplicate names are disambiguated with `.0`, `.1` suffixes (e.g. editor/zsh.0, editor/zsh.1)
- Pane format detection: contains / but doesn't start with / (avoids matching absolute paths)
- `--panes` is scoped to the current session only; returns an error outside tmux
