### PR TITLE
Add support for /** wildcard in config patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,10 @@ startup_command = "nvim"
 pattern = "~/work/*"
 startup_command = "make dev"
 preview_command = "ls -la"
+
+[[wildcard]]
+pattern = "~/repos/**"
+startup_command = "git status"
 ```
 
 When you run `sesh connect ~/projects/myapp`, sesh matches the path against your wildcard patterns and automatically creates a session named from the directory (using git remote or folder name), runs the configured startup command, and adds the path to zoxide.
@@ -590,7 +594,7 @@ Available fields:
 | `preview_command` | Command to run when previewing the session |
 | `disable_startup_command` | Set to `true` to suppress the startup command |
 
-**Note:** Patterns use Go's `filepath.Match` syntax which supports `*` (any sequence), `?` (single character), and `[...]` (character classes). Recursive matching with `**` is not supported -- `~/projects/*` matches `~/projects/foo` but not `~/projects/foo/bar`. Explicit `[[session]]` configs always take priority over wildcard matches. If multiple wildcards match, the first one in config order wins.
+**Note:** Patterns use Go's `filepath.Match` syntax which supports `*` (any sequence), `?` (single character), and `[...]` (character classes). You can also use `/**` at the end of a pattern for recursive matching -- `~/projects/**` matches `~/projects/foo`, `~/projects/foo/bar`, and any deeper nesting. A single `*` only matches one level: `~/projects/*` matches `~/projects/foo` but not `~/projects/foo/bar`. Explicit `[[session]]` configs always take priority over wildcard matches. If multiple wildcards match, the first one in config order wins.
 
 ### Listing Configurations
 

--- a/lister/config_wildcard.go
+++ b/lister/config_wildcard.go
@@ -26,10 +26,16 @@ func (l *RealLister) FindConfigWildcard(path string) (model.WildcardConfig, bool
 }
 
 func matchWildcard(pattern, path string) bool {
+	cleanPath := filepath.Clean(path)
+
 	if strings.HasSuffix(pattern, "/**") {
 		prefix := strings.TrimSuffix(pattern, "/**")
-		return strings.HasPrefix(path, prefix+"/")
+		if !strings.HasPrefix(cleanPath, prefix+"/") {
+			return false
+		}
+		return len(cleanPath) > len(prefix)+1
 	}
-	matched, err := filepath.Match(pattern, path)
+
+	matched, err := filepath.Match(pattern, cleanPath)
 	return err == nil && matched
 }

--- a/lister/config_wildcard_test.go
+++ b/lister/config_wildcard_test.go
@@ -93,4 +93,10 @@ func TestFindConfigWildcard(t *testing.T) {
 		_, found := realLister.FindConfigWildcard("/Users/test/deep")
 		assert.False(t, found)
 	})
+
+	t.Run("should not match the prefix directory with trailing slash and **", func(t *testing.T) {
+		mockHome.On("ExpandHome", "/Users/test/deep/").Return("/Users/test/deep/", nil)
+		_, found := realLister.FindConfigWildcard("/Users/test/deep/")
+		assert.False(t, found)
+	})
 }


### PR DESCRIPTION
Adds support for `**` (double-star) glob patterns in `[[wildcard]]` config entries. Previously, only single-level `*` globs worked (via filepath.Match), forcing users to specify exact directory depths. Now `~/projects/**` matches all nested paths under `~/projects/`.
