### PR TITLE
feat: show git clone output in real-time

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -36,9 +36,6 @@ func (g *RealGit) GitCommonDir(path string) (bool, string, error) {
 }
 
 func (g *RealGit) Clone(url string, cmdDir string, dir string) (string, error) {
-	var out string
-	var err error
-
 	args := []string{"clone", url}
 	if cmdDir != "" {
 		args = append([]string{"-C", cmdDir}, args...)
@@ -47,11 +44,11 @@ func (g *RealGit) Clone(url string, cmdDir string, dir string) (string, error) {
 		args = append(args, dir)
 	}
 
-	out, err = g.shell.Cmd("git", args...)
+	_, err := g.shell.CmdWithOutput("git", args...)
 	if err != nil {
 		return "", err
 	}
-	return out, nil
+	return "", nil
 }
 
 func (g *RealGit) WorktreeList(path string) (bool, string, error) {

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -12,6 +12,7 @@ import (
 
 type Shell interface {
 	Cmd(cmd string, arg ...string) (string, error)
+	CmdWithOutput(cmd string, arg ...string) (string, error)
 	ListCmd(cmd string, arg ...string) ([]string, error)
 	PrepareCmd(cmd string, replacements map[string]string) ([]string, error)
 }
@@ -48,6 +49,21 @@ func (c *RealShell) Cmd(cmd string, args ...string) (string, error) {
 	}
 	trimmedOutput := strings.TrimSuffix(string(stdout.String()), "\n")
 	return trimmedOutput, nil
+}
+
+func (c *RealShell) CmdWithOutput(cmd string, args ...string) (string, error) {
+	foundCmd, err := c.exec.LookPath(cmd)
+	if err != nil {
+		return "", err
+	}
+	command := exec.Command(foundCmd, args...)
+	command.Stdin = os.Stdin
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	if err := command.Run(); err != nil {
+		return "", err
+	}
+	return "", nil
 }
 
 func (c *RealShell) ListCmd(cmd string, arg ...string) ([]string, error) {


### PR DESCRIPTION
Fixes #283

The git clone command now streams output directly to the terminal instead of capturing it to a buffer, allowing users to see clone progress when running 'sesh cl'.

- Add CmdWithOutput() to Shell interface for streaming commands
- Update git Clone() to use CmdWithOutput() instead of Cmd()