### PR TITLE
Add configurable multiplexer support (psmux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,16 @@ sesh --config /path/to/custom/sesh.toml connect my-session
 
 The flag works with any subcommand. When specified, the file must exist or sesh will return an error. Without the flag, sesh uses the default config path.
 
+### Custom Multiplexer (psmux)
+
+Sesh uses `tmux` as the default terminal multiplexer, but you can configure it to use any tmux-compatible multiplexer like [psmux](https://github.com/psmux/psmux) by setting `tmux_command` in your `sesh.toml`:
+
+```toml
+tmux_command = "psmux"
+```
+
+This replaces the `tmux` binary in all commands sesh runs (session creation, switching, attaching, etc.). The configured multiplexer must support tmux's CLI interface.
+
 ### Schema (Editor Autocomplete)
 
 Sesh provides a [JSON Schema](https://json-schema.org/) for `sesh.toml` that enables autocomplete, validation, and documentation in your editor. This works with any editor that supports the [taplo](https://taplo.tamasfe.dev/) TOML language server.

--- a/model/config.go
+++ b/model/config.go
@@ -13,6 +13,7 @@ type (
 		WildcardConfigs      []WildcardConfig     `toml:"wildcard"`
 		DirLength            int                  `toml:"dir_length"`
 		SeparatorAware       bool                 `toml:"separator_aware"`
+		TmuxCommand          string               `toml:"tmux_command"`
 	}
 	Evaluation struct {
 		StrictMode bool `toml:"strict_mode"`

--- a/seshcli/deps.go
+++ b/seshcli/deps.go
@@ -45,7 +45,6 @@ type BaseDeps struct {
 	Replacer   replacer.Replacer
 	Git        git.Git
 	Dir        dir.Dir
-	Tmux       tmux.Tmux
 	Zoxide     zoxide.Zoxide
 	Tmuxinator tmuxinator.Tmuxinator
 }
@@ -54,6 +53,7 @@ type BaseDeps struct {
 type Deps struct {
 	BaseDeps
 	Config        model.Config
+	Tmux          tmux.Tmux
 	Lister        lister.Lister
 	CachingLister *lister.CachingLister
 	Startup       startup.Startup
@@ -78,7 +78,6 @@ func NewBaseDeps() *BaseDeps {
 
 	g := git.NewGit(sh)
 	d := dir.NewDir(os, g, path)
-	t := tmux.NewTmux(os, sh)
 	z := zoxide.NewZoxide(sh)
 	ti := tmuxinator.NewTmuxinator(sh)
 
@@ -93,7 +92,6 @@ func NewBaseDeps() *BaseDeps {
 		Replacer:   r,
 		Git:        g,
 		Dir:        d,
-		Tmux:       t,
 		Zoxide:     z,
 		Tmuxinator: ti,
 	}
@@ -108,8 +106,10 @@ func (b *BaseDeps) BuildAll(configPath string) (*Deps, error) {
 
 	slog.Debug("deps: BuildAll", "config", config)
 
+	t := tmux.NewTmux(b.Os, b.Shell, config.TmuxCommand)
+
 	l := ls.NewLs(config, b.Shell)
-	li := lister.NewLister(config, b.Home, b.Tmux, b.Zoxide, b.Tmuxinator)
+	li := lister.NewLister(config, b.Home, t, b.Zoxide, b.Tmuxinator)
 
 	var usedLister lister.Lister = li
 	var cachedLi *lister.CachingLister
@@ -119,16 +119,17 @@ func (b *BaseDeps) BuildAll(configPath string) (*Deps, error) {
 		usedLister = cachedLi
 	}
 
-	s := startup.NewStartup(config, usedLister, b.Tmux, b.Home, b.Replacer)
+	s := startup.NewStartup(config, usedLister, t, b.Home, b.Replacer)
 	n := namer.NewNamer(b.Path, b.Git, b.Home, config)
-	c := connector.NewConnector(config, b.Dir, b.Home, usedLister, n, s, b.Tmux, b.Zoxide, b.Tmuxinator)
+	c := connector.NewConnector(config, b.Dir, b.Home, usedLister, n, s, t, b.Zoxide, b.Tmuxinator)
 	ic := icon.NewIcon(config)
-	p := previewer.NewPreviewer(usedLister, b.Tmux, ic, b.Dir, b.Home, l, config, b.Shell)
+	p := previewer.NewPreviewer(usedLister, t, ic, b.Dir, b.Home, l, config, b.Shell)
 	cl := cloner.NewCloner(c, b.Git)
 
 	return &Deps{
 		BaseDeps:      *b,
 		Config:        config,
+		Tmux:          t,
 		Lister:        usedLister,
 		CachingLister: cachedLi,
 		Startup:       s,

--- a/seshcli/last.go
+++ b/seshcli/last.go
@@ -22,7 +22,7 @@ func NewLastCommand(base *BaseDeps) *cobra.Command {
 				// TODO: silently fail?
 				return fmt.Errorf("No last session found")
 			}
-			base.Tmux.SwitchClient(lastSession.Name)
+			deps.Tmux.SwitchClient(lastSession.Name)
 			return nil
 		},
 	}

--- a/tmux/list.go
+++ b/tmux/list.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (t *RealTmux) ListSessions() ([]*model.TmuxSession, error) {
-	output, err := t.shell.ListCmd("tmux", "list-sessions", "-F", listsessionsformat())
+	output, err := t.shell.ListCmd(t.bin, "list-sessions", "-F", listsessionsformat())
 	if err != nil {
 		return []*model.TmuxSession{}, nil
 	}

--- a/tmux/list_test.go
+++ b/tmux/list_test.go
@@ -13,7 +13,7 @@ import (
 func TestListSessions(t *testing.T) {
 	t.Run("List tmux session", func(t *testing.T) {
 		mockShell := &shell.MockShell{}
-		tmux := &RealTmux{shell: mockShell}
+		tmux := &RealTmux{shell: mockShell, bin: "tmux"}
 		mockShell.EXPECT().ListCmd("tmux", "list-sessions", "-F", mock.Anything).Return([]string{"1714092246::::0::::1714089765::1::::::::::::::0::$1::1714092246::0::0::sesh/main::/Users/joshmedeski/c/sesh/main::2,1::2"},
 			nil,
 		)

--- a/tmux/switch_or_attach_test.go
+++ b/tmux/switch_or_attach_test.go
@@ -14,7 +14,7 @@ import (
 func TestSwitchOrAttach(t *testing.T) {
 	mockOs := new(oswrap.MockOs)
 	mockShell := new(shell.MockShell)
-	tmux := NewTmux(mockOs, mockShell)
+	tmux := NewTmux(mockOs, mockShell, "")
 
 	t.Run("switches because of option", func(t *testing.T) {
 		mockOs.ExpectedCalls = nil
@@ -53,5 +53,38 @@ func TestSwitchOrAttach(t *testing.T) {
 		response, error := tmux.SwitchOrAttach("dotfiles", model.ConnectOpts{Switch: false})
 		assert.Equal(t, "attaching to tmux session: dotfiles", response)
 		assert.Equal(t, nil, error)
+	})
+}
+
+func TestCustomBin(t *testing.T) {
+	mockOs := new(oswrap.MockOs)
+	mockShell := new(shell.MockShell)
+	psmux := NewTmux(mockOs, mockShell, "psmux")
+
+	t.Run("uses psmux binary for new session", func(t *testing.T) {
+		mockShell.On("Cmd", "psmux", "new-session", "-d", "-s", "dotfiles", "-c", "/home/user/dotfiles").Return("", nil)
+		_, err := psmux.NewSession("dotfiles", "/home/user/dotfiles")
+		assert.Nil(t, err)
+		mockShell.AssertCalled(t, "Cmd", "psmux", "new-session", "-d", "-s", "dotfiles", "-c", "/home/user/dotfiles")
+	})
+
+	t.Run("uses psmux binary for switch client", func(t *testing.T) {
+		mockOs.On("Getenv", "TMUX").Return("/private/tmp/tmux-501/default,72439,4")
+		mockShell.On("Cmd", "psmux", "switch-client", "-t", "dotfiles").Return("", nil)
+		response, err := psmux.SwitchOrAttach("dotfiles", model.ConnectOpts{Switch: true})
+		assert.Nil(t, err)
+		assert.Equal(t, "switching to tmux session: dotfiles", response)
+		mockShell.AssertCalled(t, "Cmd", "psmux", "switch-client", "-t", "dotfiles")
+	})
+
+	t.Run("uses psmux binary for attach session", func(t *testing.T) {
+		mockOs.ExpectedCalls = nil
+		mockShell.ExpectedCalls = nil
+		mockOs.On("Getenv", "TMUX").Return("")
+		mockShell.On("Cmd", "psmux", "attach-session", "-t", "dotfiles").Return("", nil)
+		response, err := psmux.SwitchOrAttach("dotfiles", model.ConnectOpts{Switch: false})
+		assert.Nil(t, err)
+		assert.Equal(t, "attaching to tmux session: dotfiles", response)
+		mockShell.AssertCalled(t, "Cmd", "psmux", "attach-session", "-t", "dotfiles")
 	})
 }

--- a/tmux/tmux.go
+++ b/tmux/tmux.go
@@ -22,38 +22,42 @@ type Tmux interface {
 type RealTmux struct {
 	os    oswrap.Os
 	shell shell.Shell
+	bin   string
 }
 
-func NewTmux(os oswrap.Os, shell shell.Shell) Tmux {
-	return &RealTmux{os, shell}
+func NewTmux(os oswrap.Os, shell shell.Shell, bin string) Tmux {
+	if bin == "" {
+		bin = "tmux"
+	}
+	return &RealTmux{os, shell, bin}
 }
 
 func (t *RealTmux) AttachSession(targetSession string) (string, error) {
-	return t.shell.Cmd("tmux", "attach-session", "-t", targetSession)
+	return t.shell.Cmd(t.bin, "attach-session", "-t", targetSession)
 }
 
 func (t *RealTmux) SwitchClient(targetSession string) (string, error) {
-	return t.shell.Cmd("tmux", "switch-client", "-t", targetSession)
+	return t.shell.Cmd(t.bin, "switch-client", "-t", targetSession)
 }
 
 func (t *RealTmux) SendKeys(targetPane string, keys string) (string, error) {
-	return t.shell.Cmd("tmux", "send-keys", "-t", targetPane, keys, "Enter")
+	return t.shell.Cmd(t.bin, "send-keys", "-t", targetPane, keys, "Enter")
 }
 
 func (t *RealTmux) NewSession(sessionName string, startDir string) (string, error) {
-	return t.shell.Cmd("tmux", "new-session", "-d", "-s", sessionName, "-c", startDir)
+	return t.shell.Cmd(t.bin, "new-session", "-d", "-s", sessionName, "-c", startDir)
 }
 
 func (t *RealTmux) NewWindow(startDir string, name string) (string, error) {
-	return t.shell.Cmd("tmux", "new-window", "-n", name, "-c", startDir)
+	return t.shell.Cmd(t.bin, "new-window", "-n", name, "-c", startDir)
 }
 
 func (t *RealTmux) CapturePane(targetSession string) (string, error) {
-	return t.shell.Cmd("tmux", "capture-pane", "-e", "-p", "-t", targetSession)
+	return t.shell.Cmd(t.bin, "capture-pane", "-e", "-p", "-t", targetSession)
 }
 
 func (t *RealTmux) NextWindow() (string, error) {
-	return t.shell.Cmd("tmux", "next-window")
+	return t.shell.Cmd(t.bin, "next-window")
 }
 
 func (t *RealTmux) IsAttached() bool {


### PR DESCRIPTION
Closes #358

## Summary
- Add `tmux_command` config option to `sesh.toml` for using tmux-compatible multiplexers like [psmux](https://github.com/psmux/psmux)
- Replace all hardcoded `"tmux"` binary references with a configurable value (defaults to `"tmux"`)
- Move tmux construction from `BaseDeps` to `Deps` so the config value is available at initialization

## Test plan
- [x] All existing tests pass (`just test`)
- [x] New `TestCustomBin` test verifies psmux binary is used for new-session, switch-client, and attach-session
- [x] Manual: verify default behavior (no config set) still uses `tmux`
- [ ] Manual: set `tmux_command = "psmux"` in `sesh.toml` and verify sesh commands work with psmux
