### PR TITLE
Add -b/--blacklisted flag to list blacklisted sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,6 +560,8 @@ You may want to blacklist certain tmux sessions from showing up in the results. 
 blacklist = ["scratch"]
 ```
 
+To surface blacklisted sessions for management, pass `-b` (or `--blacklisted`) to `sesh list`. It composes with source flags, so `sesh list -b -t` lists blacklisted tmux sessions only.
+
 ### Directory Length
 
 Control how many directory components are used for session names. Default is 1 (only the directory basename).

--- a/lister/list.go
+++ b/lister/list.go
@@ -19,6 +19,7 @@ type (
 		Tmuxinator     bool
 		HideDuplicates bool
 		Panes          bool
+		Blacklisted    bool
 	}
 	srcStrategy func(*RealLister) (model.SeshSessions, error)
 )
@@ -76,13 +77,13 @@ func (l *RealLister) List(opts ListOptions) (model.SeshSessions, error) {
 		}
 	}
 
-	if len(l.config.Blacklist) > 0 {
+	if len(l.config.Blacklist) > 0 || opts.Blacklisted {
 		compiled := compileBlacklist(l.config.Blacklist)
 		filteredIndex := make([]string, 0, len(fullOrderedIndex))
 		filteredDirectory := make(model.SeshSessionMap)
 		for _, index := range fullOrderedIndex {
 			session := fullDirectory[index]
-			if !isBlacklisted(compiled, session.Name) {
+			if isBlacklisted(compiled, session.Name) == opts.Blacklisted {
 				filteredIndex = append(filteredIndex, index)
 				filteredDirectory[index] = session
 			}

--- a/lister/list_test.go
+++ b/lister/list_test.go
@@ -190,3 +190,84 @@ func TestHideDuplicates(t *testing.T) {
 		})
 	}
 }
+
+func TestBlacklistedFlag(t *testing.T) {
+	tests := []struct {
+		name          string
+		blacklist     []string
+		tmuxSessions  []*model.TmuxSession
+		blacklisted   bool
+		expectedNames []string
+	}{
+		{
+			name:      "flag on, some sessions match patterns",
+			blacklist: []string{"^scratch$", "^temp"},
+			tmuxSessions: []*model.TmuxSession{
+				{Name: "scratch", Path: "/path/to/scratch"},
+				{Name: "work", Path: "/path/to/work"},
+				{Name: "temporary", Path: "/path/to/temporary"},
+			},
+			blacklisted:   true,
+			expectedNames: []string{"scratch", "temporary"},
+		},
+		{
+			name:      "flag on, no sessions match patterns",
+			blacklist: []string{"^nomatch$"},
+			tmuxSessions: []*model.TmuxSession{
+				{Name: "alpha", Path: "/path/to/alpha"},
+				{Name: "beta", Path: "/path/to/beta"},
+			},
+			blacklisted:   true,
+			expectedNames: []string{},
+		},
+		{
+			name:      "flag on, empty blacklist in config",
+			blacklist: []string{},
+			tmuxSessions: []*model.TmuxSession{
+				{Name: "alpha", Path: "/path/to/alpha"},
+			},
+			blacklisted:   true,
+			expectedNames: []string{},
+		},
+		{
+			name:      "flag off preserves existing hide-blacklisted behavior",
+			blacklist: []string{"^scratch$"},
+			tmuxSessions: []*model.TmuxSession{
+				{Name: "scratch", Path: "/path/to/scratch"},
+				{Name: "work", Path: "/path/to/work"},
+			},
+			blacklisted:   false,
+			expectedNames: []string{"work"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockTmux := new(tmux.MockTmux)
+			mockZoxide := new(zoxide.MockZoxide)
+			mockHome := new(home.MockHome)
+			mockTmuxinator := new(tmuxinator.MockTmuxinator)
+
+			mockTmux.On("ListSessions").Return(tt.tmuxSessions, nil)
+
+			config := model.Config{Blacklist: tt.blacklist}
+			lister := NewLister(config, mockHome, mockTmux, mockZoxide, mockTmuxinator)
+
+			result, err := lister.List(ListOptions{
+				Tmux:        true,
+				Blacklisted: tt.blacklisted,
+			})
+
+			assert.NoError(t, err)
+			assert.Equal(t, len(tt.expectedNames), len(result.OrderedIndex))
+			for i, expectedName := range tt.expectedNames {
+				if i < len(result.OrderedIndex) {
+					session := result.Directory[result.OrderedIndex[i]]
+					assert.Equal(t, expectedName, session.Name)
+				}
+			}
+
+			mockTmux.AssertExpectations(t)
+		})
+	}
+}

--- a/seshcli/list.go
+++ b/seshcli/list.go
@@ -34,6 +34,7 @@ func NewListCommand(base *BaseDeps) *cobra.Command {
 			tmuxinator, _ := cmd.Flags().GetBool("tmuxinator")
 			hideDuplicates, _ := cmd.Flags().GetBool("hide-duplicates")
 			panes, _ := cmd.Flags().GetBool("panes")
+			blacklisted, _ := cmd.Flags().GetBool("blacklisted")
 
 			if panes && !deps.Tmux.IsAttached() {
 				return errors.New("--panes requires being inside a tmux session")
@@ -50,6 +51,7 @@ func NewListCommand(base *BaseDeps) *cobra.Command {
 				Tmuxinator:     tmuxinator,
 				HideDuplicates: hideDuplicates,
 				Panes:          panes,
+				Blacklisted:    blacklisted,
 			})
 			if err != nil {
 				return fmt.Errorf("couldn't list sessions: %q", err)
@@ -90,6 +92,7 @@ func NewListCommand(base *BaseDeps) *cobra.Command {
 	cmd.Flags().BoolP("tmuxinator", "T", false, "show tmuxinator configs")
 	cmd.Flags().BoolP("hide-duplicates", "d", false, "hide duplicate entries")
 	cmd.Flags().BoolP("panes", "p", false, "show panes in current session")
+	cmd.Flags().BoolP("blacklisted", "b", false, "show blacklisted sessions")
 
 	return cmd
 }


### PR DESCRIPTION
## Summary
- Adds a `-b` / `--blacklisted` flag to `sesh list` that inverts the blacklist filter, returning only sessions matching the configured `blacklist` patterns so users can manage sessions that are normally hidden.
- Composes with existing source flags (`-t`, `-z`, `-c`, `-T`, `-p`) the same way they compose with each other — e.g. `sesh list -b -t` lists blacklisted tmux sessions only.
- `-b` with an empty `blacklist` in config returns an empty list; default behavior (flag off) is unchanged.

Closes #366

## Test plan
- [x] `just test` — full suite green (lister coverage 67.6%)
- [x] `just build` — succeeds
- [x] `sesh list --help` shows the new `-b, --blacklisted` flag alongside other source flags
- [x] New `TestBlacklistedFlag` cases in `lister/list_test.go`: some match, no match, empty config blacklist, flag-off regression
- [x] Manual smoke test with a local `sesh.toml` containing `blacklist = ["scratch"]`:
  - `sesh list` excludes `scratch` (regression)
  - `sesh list -b` returns only `scratch`
  - `sesh list -b -t` returns only blacklisted tmux sessions
  - `sesh list -b -j` returns valid JSON array