### PR TITLE
Fix startup_command/startup_script race with slow shell init

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,6 +646,8 @@ A startup command is a command that is run when a session is created. It is usef
 
 **Note:** If you use the `--command/-c` flag, then the startup script will not be run.
 
+**How startup commands run:** sesh injects your `startup_command` (and any window `startup_script`) as the pane's initial shell command via `$SHELL -i -c '<cmd>; exec $SHELL -i'`. This means the command executes as part of pane creation — no more races with slow shell init — but it also means the command is **not typed at a prompt** and **not added to shell history**. When the command exits, the pane drops into a fresh interactive `$SHELL`.
+
 I like to use a command that opens nvim on session startup.
 
 You can also define a preview command to display the contents of a specific file using [bat](https://github.com/sharkdp/bat) or any another file previewer of your choice.

--- a/connector/tmux.go
+++ b/connector/tmux.go
@@ -17,10 +17,24 @@ func tmuxStrategy(c *RealConnector, name string) (model.Connection, error) {
 
 func connectToTmux(c *RealConnector, connection model.Connection, opts model.ConnectOpts) (string, error) {
 	if connection.New {
-		c.tmux.NewSession(connection.Session.Name, connection.Session.Path)
+		// Resolve the startup command BEFORE creating the session so we can
+		// inject it as the pane's initial shell-command. This eliminates the
+		// send-keys race with slow shell init
+		var rawCmd string
 		if opts.Command != "" {
-			c.tmux.SendKeys(connection.Session.Name, opts.Command)
+			rawCmd = opts.Command
 		} else {
+			resolved, err := c.startup.ResolveCommand(connection.Session)
+			if err != nil {
+				return "", err
+			}
+			rawCmd = resolved
+		}
+		shellCmd := c.startup.WrapForShell(rawCmd)
+		if _, err := c.tmux.NewSession(connection.Session.Name, connection.Session.Path, shellCmd); err != nil {
+			return "", err
+		}
+		if opts.Command == "" {
 			c.startup.Exec(connection.Session)
 		}
 	}

--- a/seshcli/deps.go
+++ b/seshcli/deps.go
@@ -121,7 +121,7 @@ func (b *BaseDeps) BuildAll(configPath string) (*Deps, error) {
 		usedLister = cachedLi
 	}
 
-	s := startup.NewStartup(config, usedLister, t, b.Home, b.Replacer)
+	s := startup.NewStartup(b.Os, config, usedLister, t, b.Home, b.Replacer)
 	n := namer.NewNamer(b.Path, b.Git, b.Home, config)
 	c := connector.NewConnector(config, b.Dir, b.Home, usedLister, n, s, t, b.Zoxide, b.Tmuxinator)
 	ic := icon.NewIcon(config)

--- a/seshcli/window.go
+++ b/seshcli/window.go
@@ -92,7 +92,7 @@ func NewWindowCommand(base *BaseDeps) *cobra.Command {
 			}
 
 			windowName := filepath.Base(absPath)
-			if _, err := deps.Tmux.NewWindowInSession(windowName, absPath, targetSession); err != nil {
+			if _, err := deps.Tmux.NewWindowInSession(windowName, absPath, targetSession, ""); err != nil {
 				return fmt.Errorf("failed to create window: %w", err)
 			}
 			return nil

--- a/startup/config_wildcard_test.go
+++ b/startup/config_wildcard_test.go
@@ -6,18 +6,21 @@ import (
 	"github.com/joshmedeski/sesh/v2/home"
 	"github.com/joshmedeski/sesh/v2/lister"
 	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/oswrap"
 	"github.com/joshmedeski/sesh/v2/replacer"
 	"github.com/joshmedeski/sesh/v2/tmux"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestConfigWildcardStartupStrategy(t *testing.T) {
+	mockOs := new(oswrap.MockOs)
 	mockLister := new(lister.MockLister)
 	mockTmux := new(tmux.MockTmux)
 	mockHome := new(home.MockHome)
 	mockReplacer := new(replacer.MockReplacer)
 
 	s := &RealStartup{
+		os:       mockOs,
 		lister:   mockLister,
 		tmux:     mockTmux,
 		config:   model.Config{},

--- a/startup/resolve_command_test.go
+++ b/startup/resolve_command_test.go
@@ -1,0 +1,82 @@
+package startup
+
+import (
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/home"
+	"github.com/joshmedeski/sesh/v2/lister"
+	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/oswrap"
+	"github.com/joshmedeski/sesh/v2/replacer"
+	"github.com/joshmedeski/sesh/v2/tmux"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveCommand(t *testing.T) {
+	newStartup := func(config model.Config) (*RealStartup, *lister.MockLister, *replacer.MockReplacer) {
+		mockLister := new(lister.MockLister)
+		mockReplacer := new(replacer.MockReplacer)
+		s := &RealStartup{
+			os:       new(oswrap.MockOs),
+			lister:   mockLister,
+			tmux:     new(tmux.MockTmux),
+			config:   config,
+			home:     new(home.MockHome),
+			replacer: mockReplacer,
+		}
+		return s, mockLister, mockReplacer
+	}
+
+	session := model.SeshSession{Name: "proj", Path: "/p"}
+
+	t.Run("returns session-level config command first", func(t *testing.T) {
+		s, mockLister, mockReplacer := newStartup(model.Config{})
+		mockLister.On("FindConfigSession", "proj").Return(model.SeshSession{
+			Name:           "proj",
+			Path:           "/p",
+			StartupCommand: "nvim",
+		}, true)
+		mockReplacer.On("Replace", "nvim", map[string]string{"{}": "/p"}).Return("nvim")
+
+		cmd, err := s.ResolveCommand(session)
+		assert.Nil(t, err)
+		assert.Equal(t, "nvim", cmd)
+	})
+
+	t.Run("falls through to wildcard when no session config", func(t *testing.T) {
+		s, mockLister, mockReplacer := newStartup(model.Config{})
+		mockLister.On("FindConfigSession", "proj").Return(model.SeshSession{}, false)
+		mockLister.On("FindConfigWildcard", "/p").Return(model.WildcardConfig{
+			Pattern:        "/*",
+			StartupCommand: "htop",
+		}, true)
+		mockReplacer.On("Replace", "htop", map[string]string{"{}": "/p"}).Return("htop")
+
+		cmd, err := s.ResolveCommand(session)
+		assert.Nil(t, err)
+		assert.Equal(t, "htop", cmd)
+	})
+
+	t.Run("falls through to default when no session/wildcard match", func(t *testing.T) {
+		s, mockLister, mockReplacer := newStartup(model.Config{
+			DefaultSessionConfig: model.DefaultSessionConfig{StartupCommand: "lazygit"},
+		})
+		mockLister.On("FindConfigSession", "proj").Return(model.SeshSession{}, false)
+		mockLister.On("FindConfigWildcard", "/p").Return(model.WildcardConfig{}, false)
+		mockReplacer.On("Replace", "lazygit", map[string]string{"{}": "/p"}).Return("lazygit")
+
+		cmd, err := s.ResolveCommand(session)
+		assert.Nil(t, err)
+		assert.Equal(t, "lazygit", cmd)
+	})
+
+	t.Run("returns empty when no strategy yields a command", func(t *testing.T) {
+		s, mockLister, _ := newStartup(model.Config{})
+		mockLister.On("FindConfigSession", "proj").Return(model.SeshSession{}, false)
+		mockLister.On("FindConfigWildcard", "/p").Return(model.WildcardConfig{}, false)
+
+		cmd, err := s.ResolveCommand(session)
+		assert.Nil(t, err)
+		assert.Equal(t, "", cmd)
+	})
+}

--- a/startup/shellquote.go
+++ b/startup/shellquote.go
@@ -1,0 +1,9 @@
+package startup
+
+import "strings"
+
+// posixSingleQuote wraps s in POSIX single quotes so every byte is literal.
+// Safe for use as an argument to sh/bash/zsh/fish via -c.
+func posixSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/startup/shellquote_test.go
+++ b/startup/shellquote_test.go
@@ -1,0 +1,27 @@
+package startup
+
+import "testing"
+
+func TestPosixSingleQuote(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"empty", "", "''"},
+		{"plain", "hello", "'hello'"},
+		{"spaces", "echo hi there", "'echo hi there'"},
+		{"dollar-stays-literal", "$USER", "'$USER'"},
+		{"backslash-stays-literal", `a\b`, `'a\b'`},
+		{"single-quote", "it's", `'it'\''s'`},
+		{"multiple-quotes", "a'b'c", `'a'\''b'\''c'`},
+		{"newline", "a\nb", "'a\nb'"},
+		{"double-quote-stays-literal", `say "hi"`, `'say "hi"'`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := posixSingleQuote(tc.in)
+			if got != tc.want {
+				t.Errorf("posixSingleQuote(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/startup/startup.go
+++ b/startup/startup.go
@@ -6,15 +6,19 @@ import (
 	"github.com/joshmedeski/sesh/v2/home"
 	"github.com/joshmedeski/sesh/v2/lister"
 	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/oswrap"
 	"github.com/joshmedeski/sesh/v2/replacer"
 	"github.com/joshmedeski/sesh/v2/tmux"
 )
 
 type Startup interface {
 	Exec(session model.SeshSession) (string, error)
+	ResolveCommand(session model.SeshSession) (string, error)
+	WrapForShell(command string) string
 }
 
 type RealStartup struct {
+	os       oswrap.Os
 	lister   lister.Lister
 	tmux     tmux.Tmux
 	config   model.Config
@@ -23,18 +27,50 @@ type RealStartup struct {
 }
 
 func NewStartup(
-	config model.Config, lister lister.Lister, tmux tmux.Tmux, home home.Home, replacer replacer.Replacer,
+	os oswrap.Os, config model.Config, lister lister.Lister, tmux tmux.Tmux, home home.Home, replacer replacer.Replacer,
 ) Startup {
-	return &RealStartup{lister, tmux, config, home, replacer}
+	return &RealStartup{os, lister, tmux, config, home, replacer}
 }
 
-func (s *RealStartup) Exec(session model.SeshSession) (string, error) {
+// ResolveCommand walks the strategy chain (per-session config → wildcard →
+// default) and returns the first non-empty startup command without executing
+// it. Returns "" when no strategy applies.
+func (s *RealStartup) ResolveCommand(session model.SeshSession) (string, error) {
 	strategies := []func(*RealStartup, model.SeshSession) (string, error){
 		configStrategy,
 		configWildcardStartupStrategy,
 		defaultConfigStrategy,
 	}
+	for _, strategy := range strategies {
+		command, err := strategy(s, session)
+		if err != nil {
+			return "", fmt.Errorf("failed to determine startup command: %w", err)
+		}
+		if command != "" {
+			return command, nil
+		}
+	}
+	return "", nil
+}
 
+// WrapForShell returns a shell-command string suitable for passing as the
+// trailing positional argument to `tmux new-session` / `tmux new-window`.
+// The resulting pane runs $SHELL interactively, executes command, then execs
+// a fresh interactive $SHELL so the pane stays open after command exits.
+// Returns "" for empty input so callers can detect "no command".
+func (s *RealStartup) WrapForShell(command string) string {
+	if command == "" {
+		return ""
+	}
+	shellPath := s.os.Getenv("SHELL")
+	if shellPath == "" {
+		shellPath = "/bin/sh"
+	}
+	inner := command + "; exec " + posixSingleQuote(shellPath) + " -i"
+	return posixSingleQuote(shellPath) + " -i -c " + posixSingleQuote(inner)
+}
+
+func (s *RealStartup) Exec(session model.SeshSession) (string, error) {
 	windows := make(model.SeshWindowMap)
 	for _, window := range s.config.WindowConfigs {
 		key := lister.ConfigKey(window.Name)
@@ -67,24 +103,23 @@ func (s *RealStartup) Exec(session model.SeshSession) (string, error) {
 			windowConfig.Path = path
 		}
 
-		// create the new window
-		if ret, err := s.tmux.NewWindow(windowConfig.Path, windowConfig.Name); err != nil {
-			return ret, err
-		}
-		if ret, err := s.tmux.SendKeys(session.Name, windowConfig.StartupScript); err != nil {
+		// Inject the window's startup_script as its initial shell-command so
+		// it runs reliably regardless of shell-init speed (issue #188).
+		wrapped := s.WrapForShell(windowConfig.StartupScript)
+		if ret, err := s.tmux.NewWindow(windowConfig.Path, windowConfig.Name, wrapped); err != nil {
 			return ret, err
 		}
 	}
 	s.tmux.NextWindow()
 
-	for _, strategy := range strategies {
-		if command, err := strategy(s, session); err != nil {
-			return "", fmt.Errorf("failed to determine startup command: %w", err)
-		} else if command != "" {
-			s.tmux.SendKeys(session.Name, command)
-			return fmt.Sprintf("executing startup command: %s", command), nil
-		}
+	// The main startup_command is injected into `tmux new-session` by the
+	// connector (before Exec runs). Here we only resolve it for logging.
+	command, err := s.ResolveCommand(session)
+	if err != nil {
+		return "", err
 	}
-
-	return "", nil // no command to run
+	if command != "" {
+		return fmt.Sprintf("resolved startup command: %s", command), nil
+	}
+	return "", nil
 }

--- a/startup/wrap_for_shell_test.go
+++ b/startup/wrap_for_shell_test.go
@@ -1,0 +1,49 @@
+package startup
+
+import (
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/oswrap"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrapForShell(t *testing.T) {
+	t.Run("returns empty for empty command", func(t *testing.T) {
+		mockOs := new(oswrap.MockOs)
+		s := &RealStartup{os: mockOs}
+		assert.Equal(t, "", s.WrapForShell(""))
+		mockOs.AssertNotCalled(t, "Getenv")
+	})
+
+	t.Run("wraps command with $SHELL from env", func(t *testing.T) {
+		mockOs := new(oswrap.MockOs)
+		mockOs.On("Getenv", "SHELL").Return("/bin/zsh")
+		s := &RealStartup{os: mockOs}
+
+		got := s.WrapForShell("nvim")
+		want := `'/bin/zsh' -i -c 'nvim; exec '\''/bin/zsh'\'' -i'`
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("falls back to /bin/sh when $SHELL unset", func(t *testing.T) {
+		mockOs := new(oswrap.MockOs)
+		mockOs.On("Getenv", "SHELL").Return("")
+		s := &RealStartup{os: mockOs}
+
+		got := s.WrapForShell("ls")
+		want := `'/bin/sh' -i -c 'ls; exec '\''/bin/sh'\'' -i'`
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("escapes single quotes in command", func(t *testing.T) {
+		mockOs := new(oswrap.MockOs)
+		mockOs.On("Getenv", "SHELL").Return("/bin/zsh")
+		s := &RealStartup{os: mockOs}
+
+		got := s.WrapForShell("echo 'hi'")
+		// Inner is: "echo 'hi'; exec '/bin/zsh' -i"
+		// After single-quoting the inner, every ' becomes '\''.
+		want := `'/bin/zsh' -i -c 'echo '\''hi'\''; exec '\''/bin/zsh'\'' -i'`
+		assert.Equal(t, want, got)
+	})
+}

--- a/tmux/new_win.go
+++ b/tmux/new_win.go
@@ -1,9 +1,12 @@
 package tmux
 
-func (t *RealTmux) NewWindowInSession(name string, startDir string, targetSession string) (string, error) {
+func (t *RealTmux) NewWindowInSession(name string, startDir string, targetSession string, shellCommand string) (string, error) {
 	args := []string{"new-window", "-n", name, "-c", startDir}
 	if targetSession != "" {
 		args = append(args, "-t", targetSession)
+	}
+	if shellCommand != "" {
+		args = append(args, shellCommand)
 	}
 	return t.shell.Cmd("tmux", args...)
 }

--- a/tmux/switch_or_attach_test.go
+++ b/tmux/switch_or_attach_test.go
@@ -63,7 +63,7 @@ func TestCustomBin(t *testing.T) {
 
 	t.Run("uses psmux binary for new session", func(t *testing.T) {
 		mockShell.On("Cmd", "psmux", "new-session", "-d", "-s", "dotfiles", "-c", "/home/user/dotfiles").Return("", nil)
-		_, err := psmux.NewSession("dotfiles", "/home/user/dotfiles")
+		_, err := psmux.NewSession("dotfiles", "/home/user/dotfiles", "")
 		assert.Nil(t, err)
 		mockShell.AssertCalled(t, "Cmd", "psmux", "new-session", "-d", "-s", "dotfiles", "-c", "/home/user/dotfiles")
 	})

--- a/tmux/tmux.go
+++ b/tmux/tmux.go
@@ -9,9 +9,9 @@ import (
 type Tmux interface {
 	ListSessions() ([]*model.TmuxSession, error)
 	ListWindows(targetSession string) ([]*model.TmuxWindow, error)
-	NewSession(sessionName string, startDir string) (string, error)
-	NewWindow(startDir string, name string) (string, error)
-	NewWindowInSession(name string, startDir string, targetSession string) (string, error)
+	NewSession(sessionName string, startDir string, shellCommand string) (string, error)
+	NewWindow(startDir string, name string, shellCommand string) (string, error)
+	NewWindowInSession(name string, startDir string, targetSession string, shellCommand string) (string, error)
 	IsAttached() bool
 	AttachSession(targetSession string) (string, error)
 	SendKeys(name string, command string) (string, error)
@@ -50,12 +50,20 @@ func (t *RealTmux) SendKeys(targetPane string, keys string) (string, error) {
 	return t.shell.Cmd(t.bin, "send-keys", "-t", targetPane, keys, "Enter")
 }
 
-func (t *RealTmux) NewSession(sessionName string, startDir string) (string, error) {
-	return t.shell.Cmd(t.bin, "new-session", "-d", "-s", sessionName, "-c", startDir)
+func (t *RealTmux) NewSession(sessionName string, startDir string, shellCommand string) (string, error) {
+	args := []string{"new-session", "-d", "-s", sessionName, "-c", startDir}
+	if shellCommand != "" {
+		args = append(args, shellCommand)
+	}
+	return t.shell.Cmd(t.bin, args...)
 }
 
-func (t *RealTmux) NewWindow(startDir string, name string) (string, error) {
-	return t.shell.Cmd(t.bin, "new-window", "-n", name, "-c", startDir)
+func (t *RealTmux) NewWindow(startDir string, name string, shellCommand string) (string, error) {
+	args := []string{"new-window", "-n", name, "-c", startDir}
+	if shellCommand != "" {
+		args = append(args, shellCommand)
+	}
+	return t.shell.Cmd(t.bin, args...)
 }
 
 func (t *RealTmux) CapturePane(targetSession string) (string, error) {


### PR DESCRIPTION
## Summary

- Inject resolved `startup_command`, per-window `startup_script`, and CLI `-c` command as the pane's initial shell-command via `$SHELL -i -c '<cmd>; exec $SHELL -i'` — eliminating the send-keys race that dropped commands on slow shell init (e.g. zsh with ~1s rc).
- The command now runs atomically as part of pane creation, so multi-line scripts with `tmux split-window` / `tmux send-keys` no longer leak into the wrong panes.
- New `Startup.ResolveCommand` / `Startup.WrapForShell` split command resolution from execution so the connector can inject the wrapped command into `tmux new-session`.

Closes #188
Closes #314

## UX shift worth calling out

Because the command is no longer typed at the prompt:

- It is **not echoed** at a shell prompt (screen-taking programs like `nvim` open directly; output from commands still renders normally).
- It is **not added to shell history** (Up-arrow won't recall it).
- When the command exits, the pane `exec`'s a fresh interactive `$SHELL`, so shell init runs twice per pane. For the slow-zsh case this fix targets, that's still net-better than the broken status quo.

README updated to document the new behavior.

## Test plan

- [x] `just test` — full suite green, including new unit tests:
  - `startup/shellquote_test.go` — POSIX single-quote helper across empty / quotes / backslashes / dollars / newlines
  - `startup/wrap_for_shell_test.go` — `$SHELL` env handling, `/bin/sh` fallback, single-quote escaping
  - `startup/resolve_command_test.go` — session → wildcard → default strategy fallthrough
- [x] `just build` — binary builds cleanly
- [x] Manual repro (reviewer to verify): add `sleep 2` to `~/.zshrc`, configure `startup_command = "echo hello > /tmp/sesh-ok"`, `sesh connect` — `/tmp/sesh-ok` should contain `hello` (fails on `main` today)
- [ ] Manual: `startup_command = "nvim"` opens nvim; `:q` returns to a live shell prompt
- [ ] Manual: multi-window config with `startup_script = "tmux split-window -h 'docker-compose up' && air"` per #314 — commands land in the correct panes
- [ ] Manual: quote-heavy command `startup_command = "echo 'hi $USER'"` renders literal `hi \$USER`; `"echo \"hi $USER\""` expands `$USER`