### PR TITLE
Fix tmuxinator double-attach error on session kill

### DIFF
--- a/connector/tmuxinator.go
+++ b/connector/tmuxinator.go
@@ -1,6 +1,8 @@
 package connector
 
 import (
+	"fmt"
+
 	"github.com/joshmedeski/sesh/v2/model"
 )
 
@@ -19,6 +21,8 @@ func tmuxinatorStrategy(c *RealConnector, name string) (model.Connection, error)
 }
 
 func connectToTmuxinator(c *RealConnector, connection model.Connection, opts model.ConnectOpts) (string, error) {
-	c.tmuxinator.Start(connection.Session.Name)
+	if _, err := c.tmuxinator.Start(connection.Session.Name); err != nil {
+		return "", fmt.Errorf("failed to start tmuxinator session: %w", err)
+	}
 	return c.tmux.SwitchOrAttach(connection.Session.Name, opts)
 }

--- a/connector/tmuxinator_test.go
+++ b/connector/tmuxinator_test.go
@@ -1,0 +1,73 @@
+package connector
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/dir"
+	"github.com/joshmedeski/sesh/v2/home"
+	"github.com/joshmedeski/sesh/v2/lister"
+	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/namer"
+	"github.com/joshmedeski/sesh/v2/startup"
+	"github.com/joshmedeski/sesh/v2/tmux"
+	"github.com/joshmedeski/sesh/v2/tmuxinator"
+	"github.com/joshmedeski/sesh/v2/zoxide"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func newConnectorWithMocks() (*RealConnector, *tmuxinator.MockTmuxinator, *tmux.MockTmux) {
+	mockTmuxinator := new(tmuxinator.MockTmuxinator)
+	mockTmux := new(tmux.MockTmux)
+	c := &RealConnector{
+		model.Config{},
+		new(dir.MockDir),
+		new(home.MockHome),
+		new(lister.MockLister),
+		new(namer.MockNamer),
+		new(startup.MockStartup),
+		mockTmux,
+		new(zoxide.MockZoxide),
+		mockTmuxinator,
+	}
+	return c, mockTmuxinator, mockTmux
+}
+
+func TestConnectToTmuxinator(t *testing.T) {
+	t.Run("propagates error from Start and does not attach", func(t *testing.T) {
+		c, mockTmuxinator, mockTmux := newConnectorWithMocks()
+		mockTmuxinator.EXPECT().
+			Start("sys").
+			Return("", errors.New("boom"))
+
+		connection := model.Connection{
+			Found:   true,
+			Session: model.SeshSession{Src: "tmuxinator", Name: "sys"},
+			New:     true,
+		}
+		_, err := connectToTmuxinator(c, connection, model.ConnectOpts{})
+
+		assert.ErrorContains(t, err, "failed to start tmuxinator session")
+		assert.ErrorContains(t, err, "boom")
+		mockTmux.AssertNotCalled(t, "AttachSession", mock.Anything)
+		mockTmux.AssertNotCalled(t, "SwitchClient", mock.Anything)
+	})
+
+	t.Run("attaches via SwitchOrAttach after successful Start", func(t *testing.T) {
+		c, mockTmuxinator, mockTmux := newConnectorWithMocks()
+		opts := model.ConnectOpts{}
+		mockTmuxinator.EXPECT().Start("sys").Return("", nil)
+		mockTmux.EXPECT().SwitchOrAttach("sys", opts).Return("attaching to tmux session: sys", nil)
+
+		connection := model.Connection{
+			Found:   true,
+			Session: model.SeshSession{Src: "tmuxinator", Name: "sys"},
+			New:     true,
+		}
+		msg, err := connectToTmuxinator(c, connection, opts)
+
+		assert.Nil(t, err)
+		assert.Equal(t, "attaching to tmux session: sys", msg)
+	})
+}

--- a/tmuxinator/tmuxinator.go
+++ b/tmuxinator/tmuxinator.go
@@ -19,5 +19,5 @@ func NewTmuxinator(shell shell.Shell) Tmuxinator {
 }
 
 func (t *RealTmuxinator) Start(targetSession string) (string, error) {
-	return t.shell.Cmd("tmuxinator", "start", targetSession)
+	return t.shell.Cmd("tmuxinator", "start", "--no-attach", "--name", targetSession, targetSession)
 }

--- a/tmuxinator/tmuxinator_test.go
+++ b/tmuxinator/tmuxinator_test.go
@@ -1,0 +1,23 @@
+package tmuxinator
+
+import (
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/shell"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStart(t *testing.T) {
+	t.Run("runs tmuxinator with --no-attach and --name matching the project", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		tmuxinator := &RealTmuxinator{shell: mockShell}
+		mockShell.EXPECT().
+			Cmd("tmuxinator", "start", "--no-attach", "--name", "sys", "sys").
+			Return("", nil)
+
+		_, err := tmuxinator.Start("sys")
+
+		assert.Nil(t, err)
+		mockShell.AssertExpectations(t)
+	})
+}


### PR DESCRIPTION
## Summary

- Fixes #363. Pass `--no-attach` to `tmuxinator start` — the double attach was the leading cause of the "Failed to attach to tmux session: exit status 1" error when killing a tmuxinator session.
- Also pass `--name=<project>` so the tmux session name matches the entry returned by `tmuxinator list`, keeping the picker list and session name in parity.
- Propagate the error from `tmuxinator.Start` which was previously discarded.

## Test plan

- [x] `just test` passes
- [x] `sesh connect <tmuxinator-project>` attaches cleanly
- [x] Inside that session, `prefix+s` then `x` kills the session and exits back to the shell with exit code 0
- [x] Zoxide/dir/config sessions still work unchanged