### PR TITLE
Fix startup regressions from #372

### DIFF
--- a/connector/connect_to_tmux_test.go
+++ b/connector/connect_to_tmux_test.go
@@ -1,0 +1,52 @@
+package connector
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/dir"
+	"github.com/joshmedeski/sesh/v2/home"
+	"github.com/joshmedeski/sesh/v2/lister"
+	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/namer"
+	"github.com/joshmedeski/sesh/v2/startup"
+	"github.com/joshmedeski/sesh/v2/tmux"
+	"github.com/joshmedeski/sesh/v2/tmuxinator"
+	"github.com/joshmedeski/sesh/v2/zoxide"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConnectToTmuxReturnsStartupExecError(t *testing.T) {
+	mockStartup := new(startup.MockStartup)
+	mockTmux := new(tmux.MockTmux)
+
+	c := &RealConnector{
+		config:     model.Config{},
+		dir:        new(dir.MockDir),
+		home:       new(home.MockHome),
+		lister:     new(lister.MockLister),
+		namer:      new(namer.MockNamer),
+		startup:    mockStartup,
+		tmux:       mockTmux,
+		zoxide:     new(zoxide.MockZoxide),
+		tmuxinator: new(tmuxinator.MockTmuxinator),
+	}
+
+	connection := model.Connection{
+		New: true,
+		Session: model.SeshSession{
+			Name: "demo",
+			Path: "/tmp",
+		},
+	}
+
+	mockStartup.On("ResolveCommand", connection.Session).Return("", nil)
+	mockStartup.On("WrapForShell", "").Return("")
+	mockTmux.On("NewSession", "demo", "/tmp", "").Return("", nil)
+	mockStartup.On("Exec", connection.Session).Return("", errors.New("boom"))
+
+	msg, err := connectToTmux(c, connection, model.ConnectOpts{})
+	assert.Equal(t, "", msg)
+	assert.EqualError(t, err, "boom")
+	mockTmux.AssertNotCalled(t, "SwitchOrAttach", "demo", model.ConnectOpts{})
+}

--- a/connector/tmux.go
+++ b/connector/tmux.go
@@ -35,7 +35,9 @@ func connectToTmux(c *RealConnector, connection model.Connection, opts model.Con
 			return "", err
 		}
 		if opts.Command == "" {
-			c.startup.Exec(connection.Session)
+			if _, err := c.startup.Exec(connection.Session); err != nil {
+				return "", err
+			}
 		}
 	}
 	return c.tmux.SwitchOrAttach(connection.Session.Name, opts)

--- a/startup/exec_test.go
+++ b/startup/exec_test.go
@@ -1,0 +1,43 @@
+package startup
+
+import (
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/home"
+	"github.com/joshmedeski/sesh/v2/lister"
+	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/oswrap"
+	"github.com/joshmedeski/sesh/v2/replacer"
+	"github.com/joshmedeski/sesh/v2/tmux"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExecCreatesWindowsInTargetSession(t *testing.T) {
+	mockOs := new(oswrap.MockOs)
+	mockLister := new(lister.MockLister)
+	mockTmux := new(tmux.MockTmux)
+	mockHome := new(home.MockHome)
+	mockReplacer := new(replacer.MockReplacer)
+
+	s := &RealStartup{
+		os:       mockOs,
+		lister:   mockLister,
+		tmux:     mockTmux,
+		config:   model.Config{WindowConfigs: []model.WindowConfig{{Name: "editor", StartupScript: "echo hi"}}},
+		home:     mockHome,
+		replacer: mockReplacer,
+	}
+	session := model.SeshSession{Name: "demo", Path: "/tmp", WindowNames: []string{"editor"}}
+
+	mockHome.On("ExpandPath", "/tmp").Return("/tmp", nil)
+	mockOs.On("Getenv", "SHELL").Return("/bin/zsh")
+	mockTmux.On("NewWindowInSession", "editor", "/tmp", "demo", `'/bin/zsh' -i -c 'echo hi'`).Return("", nil)
+	mockTmux.On("SelectWindow", "demo:^").Return("", nil)
+	mockLister.On("FindConfigSession", "demo").Return(model.SeshSession{}, false)
+	mockLister.On("FindConfigWildcard", "/tmp").Return(model.WildcardConfig{}, false)
+
+	msg, err := s.Exec(session)
+	assert.Nil(t, err)
+	assert.Equal(t, "", msg)
+	mockTmux.AssertNotCalled(t, "NewWindow", "/tmp", "editor", `'/bin/zsh' -i -c 'echo hi'`)
+}

--- a/startup/startup.go
+++ b/startup/startup.go
@@ -55,8 +55,9 @@ func (s *RealStartup) ResolveCommand(session model.SeshSession) (string, error) 
 
 // WrapForShell returns a shell-command string suitable for passing as the
 // trailing positional argument to `tmux new-session` / `tmux new-window`.
-// The resulting pane runs $SHELL interactively, executes command, then execs
-// a fresh interactive $SHELL so the pane stays open after command exits.
+// The resulting pane runs $SHELL interactively and executes command as part
+// of pane creation, avoiding send-keys races without re-running shell init a
+// second time after the command exits.
 // Returns "" for empty input so callers can detect "no command".
 func (s *RealStartup) WrapForShell(command string) string {
 	if command == "" {
@@ -66,8 +67,7 @@ func (s *RealStartup) WrapForShell(command string) string {
 	if shellPath == "" {
 		shellPath = "/bin/sh"
 	}
-	inner := command + "; exec " + posixSingleQuote(shellPath) + " -i"
-	return posixSingleQuote(shellPath) + " -i -c " + posixSingleQuote(inner)
+	return posixSingleQuote(shellPath) + " -i -c " + posixSingleQuote(command)
 }
 
 func (s *RealStartup) Exec(session model.SeshSession) (string, error) {
@@ -106,11 +106,15 @@ func (s *RealStartup) Exec(session model.SeshSession) (string, error) {
 		// Inject the window's startup_script as its initial shell-command so
 		// it runs reliably regardless of shell-init speed (issue #188).
 		wrapped := s.WrapForShell(windowConfig.StartupScript)
-		if ret, err := s.tmux.NewWindow(windowConfig.Path, windowConfig.Name, wrapped); err != nil {
+		if ret, err := s.tmux.NewWindowInSession(windowConfig.Name, windowConfig.Path, session.Name, wrapped); err != nil {
 			return ret, err
 		}
 	}
-	s.tmux.NextWindow()
+	if len(session.WindowNames) > 0 {
+		if _, err := s.tmux.SelectWindow(session.Name + ":^"); err != nil {
+			return "", err
+		}
+	}
 
 	// The main startup_command is injected into `tmux new-session` by the
 	// connector (before Exec runs). Here we only resolve it for logging.

--- a/startup/wrap_for_shell_test.go
+++ b/startup/wrap_for_shell_test.go
@@ -21,7 +21,7 @@ func TestWrapForShell(t *testing.T) {
 		s := &RealStartup{os: mockOs}
 
 		got := s.WrapForShell("nvim")
-		want := `'/bin/zsh' -i -c 'nvim; exec '\''/bin/zsh'\'' -i'`
+		want := `'/bin/zsh' -i -c 'nvim'`
 		assert.Equal(t, want, got)
 	})
 
@@ -31,7 +31,7 @@ func TestWrapForShell(t *testing.T) {
 		s := &RealStartup{os: mockOs}
 
 		got := s.WrapForShell("ls")
-		want := `'/bin/sh' -i -c 'ls; exec '\''/bin/sh'\'' -i'`
+		want := `'/bin/sh' -i -c 'ls'`
 		assert.Equal(t, want, got)
 	})
 
@@ -41,9 +41,7 @@ func TestWrapForShell(t *testing.T) {
 		s := &RealStartup{os: mockOs}
 
 		got := s.WrapForShell("echo 'hi'")
-		// Inner is: "echo 'hi'; exec '/bin/zsh' -i"
-		// After single-quoting the inner, every ' becomes '\''.
-		want := `'/bin/zsh' -i -c 'echo '\''hi'\''; exec '\''/bin/zsh'\'' -i'`
+		want := `'/bin/zsh' -i -c 'echo '\''hi'\'''`
 		assert.Equal(t, want, got)
 	})
 }

--- a/tmux/new_win.go
+++ b/tmux/new_win.go
@@ -8,5 +8,5 @@ func (t *RealTmux) NewWindowInSession(name string, startDir string, targetSessio
 	if shellCommand != "" {
 		args = append(args, shellCommand)
 	}
-	return t.shell.Cmd("tmux", args...)
+	return t.shell.Cmd(t.bin, args...)
 }

--- a/tmux/select_win.go
+++ b/tmux/select_win.go
@@ -1,5 +1,5 @@
 package tmux
 
 func (t *RealTmux) SelectWindow(targetWindow string) (string, error) {
-	return t.shell.Cmd("tmux", "select-window", "-t", targetWindow)
+	return t.shell.Cmd(t.bin, "select-window", "-t", targetWindow)
 }

--- a/tmux/select_win_test.go
+++ b/tmux/select_win_test.go
@@ -10,7 +10,7 @@ import (
 func TestSelectWindow(t *testing.T) {
 	t.Run("calls tmux select-window", func(t *testing.T) {
 		mockShell := &shell.MockShell{}
-		tmux := &RealTmux{shell: mockShell}
+		tmux := &RealTmux{shell: mockShell, bin: "tmux"}
 		mockShell.EXPECT().Cmd("tmux", "select-window", "-t", "editor").Return("", nil)
 		result, err := tmux.SelectWindow("editor")
 		assert.Nil(t, err)

--- a/tmux/switch_or_attach_test.go
+++ b/tmux/switch_or_attach_test.go
@@ -87,4 +87,20 @@ func TestCustomBin(t *testing.T) {
 		assert.Equal(t, "attaching to tmux session: dotfiles", response)
 		mockShell.AssertCalled(t, "Cmd", "psmux", "attach-session", "-t", "dotfiles")
 	})
+
+	t.Run("uses psmux binary for new window in session", func(t *testing.T) {
+		mockShell.ExpectedCalls = nil
+		mockShell.On("Cmd", "psmux", "new-window", "-n", "editor", "-c", "/home/user/dotfiles", "-t", "dotfiles").Return("", nil)
+		_, err := psmux.NewWindowInSession("editor", "/home/user/dotfiles", "dotfiles", "")
+		assert.Nil(t, err)
+		mockShell.AssertCalled(t, "Cmd", "psmux", "new-window", "-n", "editor", "-c", "/home/user/dotfiles", "-t", "dotfiles")
+	})
+
+	t.Run("uses psmux binary for select window", func(t *testing.T) {
+		mockShell.ExpectedCalls = nil
+		mockShell.On("Cmd", "psmux", "select-window", "-t", "dotfiles:^").Return("", nil)
+		_, err := psmux.SelectWindow("dotfiles:^")
+		assert.Nil(t, err)
+		mockShell.AssertCalled(t, "Cmd", "psmux", "select-window", "-t", "dotfiles:^")
+	})
 }


### PR DESCRIPTION
## Summary

- create configured windows in the newly created session instead of relying on untargeted `tmux new-window`
- propagate startup execution errors so broken session setup no longer exits successfully
- stop re-execing an interactive shell after startup commands, avoiding double shell init and gitstatus/p10k breakage
- use the configured tmux binary for `new-window` and `select-window`, and add regression coverage

## Fixes

Closes #376
Closes #377

## Testing

- `go test ./startup ./connector ./tmux`
- `just build`