### PR TITLE
fix(startup): keep pane alive after startup_command exits without double-init

### DIFF
--- a/startup/exec_test.go
+++ b/startup/exec_test.go
@@ -31,7 +31,7 @@ func TestExecCreatesWindowsInTargetSession(t *testing.T) {
 
 	mockHome.On("ExpandPath", "/tmp").Return("/tmp", nil)
 	mockOs.On("Getenv", "SHELL").Return("/bin/zsh")
-	mockTmux.On("NewWindowInSession", "editor", "/tmp", "demo", `'/bin/zsh' -i -c 'echo hi'`).Return("", nil)
+	mockTmux.On("NewWindowInSession", "editor", "/tmp", "demo", `'/bin/zsh' -i -c 'echo hi; exec /bin/zsh -i -f'`).Return("", nil)
 	mockTmux.On("SelectWindow", "demo:^").Return("", nil)
 	mockLister.On("FindConfigSession", "demo").Return(model.SeshSession{}, false)
 	mockLister.On("FindConfigWildcard", "/tmp").Return(model.WildcardConfig{}, false)
@@ -39,5 +39,5 @@ func TestExecCreatesWindowsInTargetSession(t *testing.T) {
 	msg, err := s.Exec(session)
 	assert.Nil(t, err)
 	assert.Equal(t, "", msg)
-	mockTmux.AssertNotCalled(t, "NewWindow", "/tmp", "editor", `'/bin/zsh' -i -c 'echo hi'`)
+	mockTmux.AssertNotCalled(t, "NewWindow", "/tmp", "editor", `'/bin/zsh' -i -c 'echo hi; exec /bin/zsh -i -f'`)
 }

--- a/startup/startup.go
+++ b/startup/startup.go
@@ -2,6 +2,7 @@ package startup
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/joshmedeski/sesh/v2/home"
 	"github.com/joshmedeski/sesh/v2/lister"
@@ -55,9 +56,10 @@ func (s *RealStartup) ResolveCommand(session model.SeshSession) (string, error) 
 
 // WrapForShell returns a shell-command string suitable for passing as the
 // trailing positional argument to `tmux new-session` / `tmux new-window`.
-// The resulting pane runs $SHELL interactively and executes command as part
-// of pane creation, avoiding send-keys races without re-running shell init a
-// second time after the command exits.
+// The resulting pane runs the startup command inside $SHELL, then exec's into
+// a fresh interactive shell to keep the pane alive. The exec'd shell uses
+// flags to skip init files (-f for zsh, --norc --noprofile for bash) to avoid
+// double-init (e.g. p10k/gitstatus reloading).
 // Returns "" for empty input so callers can detect "no command".
 func (s *RealStartup) WrapForShell(command string) string {
 	if command == "" {
@@ -67,7 +69,14 @@ func (s *RealStartup) WrapForShell(command string) string {
 	if shellPath == "" {
 		shellPath = "/bin/sh"
 	}
-	return posixSingleQuote(shellPath) + " -i -c " + posixSingleQuote(command)
+	initSkipFlags := ""
+	if strings.Contains(shellPath, "zsh") {
+		initSkipFlags = " -f"
+	} else if strings.Contains(shellPath, "bash") {
+		initSkipFlags = " --norc --noprofile"
+	}
+	innerCmd := command + "; exec " + shellPath + " -i" + initSkipFlags
+	return posixSingleQuote(shellPath) + " -i -c " + posixSingleQuote(innerCmd)
 }
 
 func (s *RealStartup) Exec(session model.SeshSession) (string, error) {

--- a/startup/wrap_for_shell_test.go
+++ b/startup/wrap_for_shell_test.go
@@ -15,13 +15,23 @@ func TestWrapForShell(t *testing.T) {
 		mockOs.AssertNotCalled(t, "Getenv")
 	})
 
-	t.Run("wraps command with $SHELL from env", func(t *testing.T) {
+	t.Run("wraps command with $SHELL from env (zsh)", func(t *testing.T) {
 		mockOs := new(oswrap.MockOs)
 		mockOs.On("Getenv", "SHELL").Return("/bin/zsh")
 		s := &RealStartup{os: mockOs}
 
 		got := s.WrapForShell("nvim")
-		want := `'/bin/zsh' -i -c 'nvim'`
+		want := `'/bin/zsh' -i -c 'nvim; exec /bin/zsh -i -f'`
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("wraps command with $SHELL from env (bash)", func(t *testing.T) {
+		mockOs := new(oswrap.MockOs)
+		mockOs.On("Getenv", "SHELL").Return("/bin/bash")
+		s := &RealStartup{os: mockOs}
+
+		got := s.WrapForShell("nvim")
+		want := `'/bin/bash' -i -c 'nvim; exec /bin/bash -i --norc --noprofile'`
 		assert.Equal(t, want, got)
 	})
 
@@ -31,7 +41,7 @@ func TestWrapForShell(t *testing.T) {
 		s := &RealStartup{os: mockOs}
 
 		got := s.WrapForShell("ls")
-		want := `'/bin/sh' -i -c 'ls'`
+		want := `'/bin/sh' -i -c 'ls; exec /bin/sh -i'`
 		assert.Equal(t, want, got)
 	})
 
@@ -41,7 +51,7 @@ func TestWrapForShell(t *testing.T) {
 		s := &RealStartup{os: mockOs}
 
 		got := s.WrapForShell("echo 'hi'")
-		want := `'/bin/zsh' -i -c 'echo '\''hi'\'''`
+		want := `'/bin/zsh' -i -c 'echo '\''hi'\''; exec /bin/zsh -i -f'`
 		assert.Equal(t, want, got)
 	})
 }


### PR DESCRIPTION
Fixes https://github.com/joshmedeski/sesh/issues/379

## Problem

Since v2.26.1 (PR #378), sessions with a `startup_command` (e.g. nvim) exhibit two regressions:

1. **Pane closes immediately** when the command exits — no shell remains
2. **Ctrl-Z (SIGTSTP) orphans the suspended process** — the shell exits anyway

## Root Cause

PR #378 removed the `; exec $SHELL -i` suffix from `WrapForShell` to fix double-init with p10k/gitstatus. But the current `$SHELL -i -c '<command>'` exits after the `-c` command returns, breaking pane longevity and job control.

## Fix

Restore the `exec $SHELL` suffix but with flags to skip init files, avoiding the double-init regression:

| Shell | Flags | Effect |
|-------|-------|--------|
| zsh   | `-f`  | Don't run .zshrc/.zshenv/.zprofile/.zlogin |
| bash  | `--norc --noprofile` | Skip init files |

The resulting command for zsh:
```
'/bin/zsh' -i -c 'nvim; exec /bin/zsh -i -f'
```

The `-i` flag ensures job control works (Ctrl-Z, fg, etc.), and the shell-specific flags prevent re-reading init files.

## Files Changed

- `startup/startup.go` — `WrapForShell` now detects shell type and adds init-skip flags
- `startup/wrap_for_shell_test.go` — Updated test expectations + added bash test case

## Verification

- `go build ./...` passes
- Tests updated for new output format