### PR TITLE
Fix --hide-duplicates hiding live tmux sessions (#385)

### DIFF
--- a/lister/caching_lister.go
+++ b/lister/caching_lister.go
@@ -79,36 +79,29 @@ func (cl *CachingLister) applyFilters(sessions model.SeshSessions, opts ListOpti
 		filtered = result
 	}
 
-	// 2. HideDuplicates: deduplicate by name, then by path.
-	if opts.HideDuplicates {
-		nameHash := make(map[string]bool)
-		pathHash := make(map[string]bool)
-		destIndex := 0
-		for _, index := range filtered {
-			session := sessions.Directory[index]
-			nameIsDuplicate := nameHash[session.Name]
-			pathIsDuplicate := session.Path != "" && pathHash[session.Path]
-			if !nameIsDuplicate && !pathIsDuplicate {
-				filtered[destIndex] = index
-				nameHash[session.Name] = true
-				pathHash[session.Path] = true
-				destIndex++
-			}
-		}
-		filtered = filtered[:destIndex]
-	}
-
-	// 3. HideAttached: remove the currently attached tmux session.
+	// 2. HideAttached runs before HideDuplicates so the attached tmux
+	// session is removed from the dedup input. Otherwise tmux would win
+	// the dedup against a same-named config/tmuxinator entry and then be
+	// hidden, leaving no entry for the user to pick.
 	if opts.HideAttached {
 		attached, ok := cl.inner.GetAttachedTmuxSession()
 		if ok {
 			for i, index := range filtered {
-				if sessions.Directory[index].Name == attached.Name {
+				s := sessions.Directory[index]
+				if s.Src == "tmux" && s.Name == attached.Name {
 					filtered = slices.Delete(slices.Clone(filtered), i, i+1)
 					break
 				}
 			}
 		}
+	}
+
+	// 3. HideDuplicates: per-source dedup rules (see applyDedup).
+	if opts.HideDuplicates {
+		filtered = applyDedup(model.SeshSessions{
+			OrderedIndex: filtered,
+			Directory:    sessions.Directory,
+		})
 	}
 
 	if len(filtered) == len(sessions.OrderedIndex) {

--- a/lister/caching_lister_test.go
+++ b/lister/caching_lister_test.go
@@ -351,6 +351,32 @@ func TestCachingLister_SourceFilter_ColdStart(t *testing.T) {
 	cl.Wait()
 }
 
+func TestCachingLister_HideAttached_BeforeHideDuplicates(t *testing.T) {
+	dir := t.TempDir()
+	fc := cache.NewFileCacheWithPath(filepath.Join(dir, "sessions.gob"))
+	inner := lister.NewMockLister(t)
+
+	sessions := model.SeshSessions{
+		OrderedIndex: []string{"tmux:project", "config:project", "tmux:other"},
+		Directory: model.SeshSessionMap{
+			"tmux:project":   {Src: "tmux", Name: "project", Path: "/p"},
+			"config:project": {Src: "config", Name: "project", Path: "/p"},
+			"tmux:other":     {Src: "tmux", Name: "other", Path: "/o"},
+		},
+	}
+	require.NoError(t, fc.Write(sessions))
+
+	inner.On("GetAttachedTmuxSession").Return(sessions.Directory["tmux:project"], true)
+
+	cl := lister.NewCachingLister(inner, fc)
+	got, err := cl.List(lister.ListOptions{HideAttached: true, HideDuplicates: true})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"config:project", "tmux:other"}, got.OrderedIndex)
+
+	cl.Wait()
+	inner.AssertNotCalled(t, "List")
+}
+
 func TestCachingLister_HideDuplicates_PostCache(t *testing.T) {
 	dir := t.TempDir()
 	fc := cache.NewFileCacheWithPath(filepath.Join(dir, "sessions.gob"))

--- a/lister/dedup.go
+++ b/lister/dedup.go
@@ -1,0 +1,133 @@
+package lister
+
+import (
+	"github.com/joshmedeski/sesh/v2/model"
+)
+
+type dedupKey string
+
+const (
+	keyName dedupKey = "name"
+	keyPath dedupKey = "path"
+)
+
+type dedupRule struct {
+	against []string
+	key     dedupKey
+}
+
+// Per-source rules: each source declares which other sources cause it to be
+// dropped on a given key, and which key is used for the comparison.
+// Sources without a rule (tmux, tmux-pane) are always kept.
+var dedupRules = map[string]dedupRule{
+	"config":     {against: []string{"tmux"}, key: keyName},
+	"tmuxinator": {against: []string{"tmux"}, key: keyName},
+	// zoxide is not deduped against tmuxinator: tmuxinator entries do not
+	// carry a Path (only Name), so a path-keyed rule would never match.
+	// Revisit if tmuxinator's `root:` becomes available on SeshSession.
+	"zoxide": {against: []string{"tmux", "config"}, key: keyPath},
+}
+
+// sourceTier orders sources by priority: tier 0 always wins, tier 1 may lose
+// only to tier 0 sources, tier 2 may lose to tier 0 or 1. applyDedup walks
+// tiers in order and only checks against values from KEPT earlier-tier
+// sessions, so a dropped session never causes another session to be dropped.
+// Unknown sources default to the highest tier (lowest priority); see
+// tierOf.
+var sourceTier = map[string]int{
+	"tmux":       0,
+	"tmux-pane":  0,
+	"config":     1,
+	"tmuxinator": 1,
+	"zoxide":     2,
+}
+
+func tierOf(src string) int {
+	if t, ok := sourceTier[src]; ok {
+		return t
+	}
+	return maxDedupTier
+}
+
+var maxDedupTier = func() int {
+	max := 0
+	for _, t := range sourceTier {
+		if t > max {
+			max = t
+		}
+	}
+	return max
+}()
+
+type srcKey struct {
+	src string
+	key dedupKey
+}
+
+func valueOf(k dedupKey, s model.SeshSession) string {
+	switch k {
+	case keyName:
+		return s.Name
+	case keyPath:
+		return s.Path
+	}
+	return ""
+}
+
+func applyDedup(in model.SeshSessions) []string {
+	keptSets := make(map[srcKey]map[string]struct{})
+	keep := make(map[string]bool, len(in.OrderedIndex))
+
+	for tier := 0; tier <= maxDedupTier; tier++ {
+		for _, idx := range in.OrderedIndex {
+			s := in.Directory[idx]
+			if tierOf(s.Src) != tier {
+				continue
+			}
+			if !shouldKeep(s, keptSets) {
+				continue
+			}
+			keep[idx] = true
+			recordValues(s, keptSets)
+		}
+	}
+
+	out := make([]string, 0, len(keep))
+	for _, idx := range in.OrderedIndex {
+		if keep[idx] {
+			out = append(out, idx)
+		}
+	}
+	return out
+}
+
+func shouldKeep(s model.SeshSession, keptSets map[srcKey]map[string]struct{}) bool {
+	rule, hasRule := dedupRules[s.Src]
+	if !hasRule {
+		return true
+	}
+	v := valueOf(rule.key, s)
+	if v == "" {
+		return true
+	}
+	for _, against := range rule.against {
+		if _, found := keptSets[srcKey{against, rule.key}][v]; found {
+			return false
+		}
+	}
+	return true
+}
+
+func recordValues(s model.SeshSession, keptSets map[srcKey]map[string]struct{}) {
+	for _, k := range []dedupKey{keyName, keyPath} {
+		v := valueOf(k, s)
+		if v == "" {
+			continue
+		}
+		sk := srcKey{s.Src, k}
+		if keptSets[sk] == nil {
+			keptSets[sk] = make(map[string]struct{})
+		}
+		keptSets[sk][v] = struct{}{}
+	}
+}

--- a/lister/dedup_test.go
+++ b/lister/dedup_test.go
@@ -1,0 +1,138 @@
+package lister
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func mkSess(src, name, path string) model.SeshSession {
+	return model.SeshSession{Src: src, Name: name, Path: path}
+}
+
+func mkSessions(ss ...model.SeshSession) model.SeshSessions {
+	out := model.SeshSessions{
+		Directory:    make(model.SeshSessionMap, len(ss)),
+		OrderedIndex: make([]string, 0, len(ss)),
+	}
+	for i, s := range ss {
+		key := fmt.Sprintf("%s:%d", s.Src, i)
+		out.Directory[key] = s
+		out.OrderedIndex = append(out.OrderedIndex, key)
+	}
+	return out
+}
+
+func TestApplyDedup(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    model.SeshSessions
+		expected []string
+		// expectedSrcs is set for cases where two candidates share the
+		// rendered Name/Path; asserting on Src ensures the right source
+		// survives.
+		expectedSrcs []string
+	}{
+		{
+			name:     "two_tmux_same_path_different_names",
+			input:    mkSessions(mkSess("tmux", "a", "/p"), mkSess("tmux", "b", "/p")),
+			expected: []string{"a", "b"},
+		},
+		{
+			name:         "tmux_and_config_same_name",
+			input:        mkSessions(mkSess("tmux", "myproj", "/x"), mkSess("config", "myproj", "/y")),
+			expected:     []string{"myproj"},
+			expectedSrcs: []string{"tmux"},
+		},
+		{
+			name:         "tmux_and_zoxide_same_path",
+			input:        mkSessions(mkSess("tmux", "t", "/a"), mkSess("zoxide", "", "/a")),
+			expected:     []string{"t"},
+			expectedSrcs: []string{"tmux"},
+		},
+		{
+			name:     "tmux_and_config_same_path_diff_names",
+			input:    mkSessions(mkSess("tmux", "x", "/a"), mkSess("config", "y", "/a")),
+			expected: []string{"x", "y"},
+		},
+		{
+			name:     "config_and_tmuxinator_same_name",
+			input:    mkSessions(mkSess("config", "myproj", "/a"), mkSess("tmuxinator", "myproj", "")),
+			expected: []string{"myproj", "myproj"},
+		},
+		{
+			name:         "config_and_zoxide_same_path",
+			input:        mkSessions(mkSess("config", "x", "/x.path"), mkSess("zoxide", "", "/x.path")),
+			expected:     []string{"x"},
+			expectedSrcs: []string{"config"},
+		},
+		{
+			name:     "two_config_same_path_diff_names",
+			input:    mkSessions(mkSess("config", "a", "/p"), mkSess("config", "b", "/p")),
+			expected: []string{"a", "b"},
+		},
+		{
+			name:     "empty_input",
+			input:    mkSessions(),
+			expected: []string{},
+		},
+		{
+			name:     "single_source_only_tmux",
+			input:    mkSessions(mkSess("tmux", "a", "/1"), mkSess("tmux", "b", "/2"), mkSess("tmux", "c", "/3")),
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "bug_repro_two_tmux_same_path",
+			input:    mkSessions(mkSess("tmux", "ddd-sandbox", "/s"), mkSess("tmux", "claude c02df2feed", "/s")),
+			expected: []string{"ddd-sandbox", "claude c02df2feed"},
+		},
+		{
+			name:         "order_independence_zoxide_before_tmux",
+			input:        mkSessions(mkSess("zoxide", "", "/a"), mkSess("tmux", "t", "/a")),
+			expected:     []string{"t"},
+			expectedSrcs: []string{"tmux"},
+		},
+		{
+			// tmuxinator currently has no Path, so a path-keyed dedup
+			// rule cannot match. Both entries must survive.
+			name:     "zoxide_and_tmuxinator_kept_no_path_on_tmuxinator",
+			input:    mkSessions(mkSess("tmuxinator", "myproj", ""), mkSess("zoxide", "~/code/myproj", "/home/u/code/myproj")),
+			expected: []string{"myproj", "~/code/myproj"},
+		},
+		{
+			// Cascading drop guard: config loses to tmux on name, but
+			// zoxide must still be kept because it would only have lost
+			// to the now-dropped config's path, not to any kept session.
+			name: "zoxide_survives_when_only_dropped_config_owned_path",
+			input: mkSessions(
+				mkSess("tmux", "foo", "/q"),
+				mkSess("config", "foo", "/p"),
+				mkSess("zoxide", "", "/p"),
+			),
+			expected: []string{"foo", "/p"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := applyDedup(tc.input)
+			got := make([]string, 0, len(result))
+			gotSrcs := make([]string, 0, len(result))
+			for _, idx := range result {
+				s := tc.input.Directory[idx]
+				if s.Name != "" {
+					got = append(got, s.Name)
+				} else {
+					got = append(got, s.Path)
+				}
+				gotSrcs = append(gotSrcs, s.Src)
+			}
+			assert.Equal(t, tc.expected, got)
+			if tc.expectedSrcs != nil {
+				assert.Equal(t, tc.expectedSrcs, gotSrcs)
+			}
+		})
+	}
+}

--- a/lister/list.go
+++ b/lister/list.go
@@ -92,32 +92,27 @@ func (l *RealLister) List(opts ListOptions) (model.SeshSessions, error) {
 		fullDirectory = filteredDirectory
 	}
 
-	if opts.HideDuplicates {
-		directoryHash := make(map[string]int)
-		nameHash := make(map[string]int)
-		destIndex := 0
-		for _, index := range fullOrderedIndex {
-			session := fullDirectory[index]
-			nameIsDuplicate := nameHash[session.Name] != 0
-			pathIsDuplicate := session.Path != "" && directoryHash[session.Path] != 0
-			if !nameIsDuplicate && !pathIsDuplicate {
-				fullOrderedIndex[destIndex] = index
-				directoryHash[session.Path] = 1
-				nameHash[session.Name] = 1
-				destIndex = destIndex + 1
+	// HideAttached runs before HideDuplicates so the attached tmux session
+	// is removed from the dedup input. Otherwise tmux would win the dedup
+	// against a same-named config/tmuxinator entry and then be hidden,
+	// leaving no entry for the user to pick.
+	if opts.HideAttached {
+		if attachedSession, ok := GetAttachedTmuxSession(l); ok {
+			for i, index := range fullOrderedIndex {
+				s := fullDirectory[index]
+				if s.Src == "tmux" && s.Name == attachedSession.Name {
+					fullOrderedIndex = slices.Delete(fullOrderedIndex, i, i+1)
+					break
+				}
 			}
 		}
-		fullOrderedIndex = fullOrderedIndex[:destIndex]
 	}
 
-	if opts.HideAttached {
-		attachedSession, _ := GetAttachedTmuxSession(l)
-		for i, index := range fullOrderedIndex {
-			if fullDirectory[index].Name == attachedSession.Name {
-				fullOrderedIndex = slices.Delete(fullOrderedIndex, i, i+1)
-				break
-			}
-		}
+	if opts.HideDuplicates {
+		fullOrderedIndex = applyDedup(model.SeshSessions{
+			OrderedIndex: fullOrderedIndex,
+			Directory:    fullDirectory,
+		})
 	}
 
 	return model.SeshSessions{

--- a/lister/list_test.go
+++ b/lister/list_test.go
@@ -35,7 +35,7 @@ func TestHideDuplicates(t *testing.T) {
 			expectedNames: []string{"session1", "session2"},
 		},
 		{
-			name: "name duplicates only",
+			name: "name_collision_kept_when_paths_differ",
 			tmuxSessions: []*model.TmuxSession{
 				{Name: "dev", Path: "/path/to/dev1"},
 			},
@@ -45,7 +45,7 @@ func TestHideDuplicates(t *testing.T) {
 			homeShortenHome: map[string]string{
 				"/path/to/dev2": "dev",
 			},
-			expectedNames: []string{"dev"},
+			expectedNames: []string{"dev", "dev"},
 		},
 		{
 			name: "path duplicates only",
@@ -61,16 +61,7 @@ func TestHideDuplicates(t *testing.T) {
 			expectedNames: []string{"dev1"},
 		},
 		{
-			name: "empty path tmuxinator sessions filtered by name only",
-			tmuxinatorConfigs: []*model.TmuxinatorConfig{
-				{Name: "tmux1"},
-				{Name: "tmux1"},
-				{Name: "tmux2"},
-			},
-			expectedNames: []string{"tmux1", "tmux2"},
-		},
-		{
-			name: "mixed empty path and regular sessions with name conflicts",
+			name: "tmuxinator_and_zoxide_kept_no_rule_between_them",
 			tmuxinatorConfigs: []*model.TmuxinatorConfig{
 				{Name: "dev"},
 			},
@@ -80,7 +71,7 @@ func TestHideDuplicates(t *testing.T) {
 			homeShortenHome: map[string]string{
 				"/path/to/dev": "dev",
 			},
-			expectedNames: []string{"dev"},
+			expectedNames: []string{"dev", "dev"},
 		},
 		{
 			name: "order preservation",
@@ -189,6 +180,35 @@ func TestHideDuplicates(t *testing.T) {
 			mockTmuxinator.AssertExpectations(t)
 		})
 	}
+}
+
+func TestHideAttachedBeforeHideDuplicates(t *testing.T) {
+	mockTmux := new(tmux.MockTmux)
+	mockZoxide := new(zoxide.MockZoxide)
+	mockHome := new(home.MockHome)
+	mockTmuxinator := new(tmuxinator.MockTmuxinator)
+
+	mockTmux.On("ListSessions").Return([]*model.TmuxSession{
+		{Name: "project", Path: "/p", Attached: 1},
+	}, nil)
+	mockHome.On("ExpandPath", "/p").Return("/p", nil)
+
+	config := model.Config{
+		SessionConfigs: []model.SessionConfig{{Name: "project", Path: "/p"}},
+	}
+	l := NewLister(config, mockHome, mockTmux, mockZoxide, mockTmuxinator)
+
+	result, err := l.List(ListOptions{
+		Tmux:           true,
+		Config:         true,
+		HideAttached:   true,
+		HideDuplicates: true,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(result.OrderedIndex))
+	kept := result.Directory[result.OrderedIndex[0]]
+	assert.Equal(t, "config", kept.Src)
+	assert.Equal(t, "project", kept.Name)
 }
 
 func TestBlacklistedFlag(t *testing.T) {


### PR DESCRIPTION
Closes #385.

Use source-specific rules instead of a global filter.

| source     | dedups against | key  |
| ---------- | -------------- | ---- |
| zoxide     | tmux, config   | path |
| config     | tmux           | name |
| tmuxinator | tmux           | name |
| tmux       | nothing        | —    |

Preserves the behavior introduced in #301.

## Update

Originally the table also listed `tmuxinator` under zoxide's targets.
Removed: tmuxinator entries currently carry no `Path` (sesh only calls
`tmuxinator list -n`), so a path-keyed rule cannot match. Should be
re-added once tmuxinator's `root:` is surfaced.