### PR TITLE
Fix git namer for sibling worktrees + add git_dir_length

### DIFF
--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -116,6 +116,9 @@ func (c *RealConfigurator) applyDefaults(config *model.Config) {
 	if config.DirLength < 1 {
 		config.DirLength = 1
 	}
+	if config.GitDirLength < 1 {
+		config.GitDirLength = 1
+	}
 	if config.TUI.Prompt == "" {
 		config.TUI.Prompt = "> "
 	}

--- a/model/config.go
+++ b/model/config.go
@@ -2,19 +2,21 @@ package model
 
 type (
 	Config struct {
-		Cache                bool                 `toml:"cache"`
-		StrictMode           bool                 `toml:"strict_mode"`
-		ImportPaths          []string             `toml:"import"`
-		DefaultSessionConfig DefaultSessionConfig `toml:"default_session"`
-		Blacklist            []string             `toml:"blacklist"`
-		SessionConfigs       []SessionConfig      `toml:"session"`
-		SortOrder            []string             `toml:"sort_order"`
-		WindowConfigs        []WindowConfig       `toml:"window"`
-		WildcardConfigs      []WildcardConfig     `toml:"wildcard"`
-		DirLength            int                  `toml:"dir_length"`
-		SeparatorAware       bool                 `toml:"separator_aware"`
-		TmuxCommand          string               `toml:"tmux_command"`
-		TUI                  TUIConfig            `toml:"tui"`
+		Cache                   bool                 `toml:"cache"`
+		StrictMode              bool                 `toml:"strict_mode"`
+		ImportPaths             []string             `toml:"import"`
+		DefaultSessionConfig    DefaultSessionConfig `toml:"default_session"`
+		Blacklist               []string             `toml:"blacklist"`
+		SessionConfigs          []SessionConfig      `toml:"session"`
+		SortOrder               []string             `toml:"sort_order"`
+		WindowConfigs           []WindowConfig       `toml:"window"`
+		WildcardConfigs         []WildcardConfig     `toml:"wildcard"`
+		DirLength               int                  `toml:"dir_length"`
+		GitNamerUseWorktreeRoot bool                 `toml:"git_namer_use_worktree_root"`
+		GitDirLength            int                  `toml:"git_dir_length"`
+		SeparatorAware          bool                 `toml:"separator_aware"`
+		TmuxCommand             string               `toml:"tmux_command"`
+		TUI                     TUIConfig            `toml:"tui"`
 	}
 	Evaluation struct {
 		StrictMode bool `toml:"strict_mode"`

--- a/namer/dir.go
+++ b/namer/dir.go
@@ -5,38 +5,41 @@ import (
 	"strings"
 )
 
-// Gets the name from a directory
-func dirName(n *RealNamer, path string) (string, error) {
-	dirLength := n.config.DirLength
-
-	if dirLength <= 1 {
-		return n.pathwrap.Base(path), nil
+// lastNComponents returns the last n path components joined by "/".
+// For n <= 1 it returns the basename. Empty string in, empty string out.
+func lastNComponents(path string, n int) string {
+	if path == "" {
+		return ""
+	}
+	if n <= 1 {
+		return filepath.Base(path)
 	}
 
 	cleanPath := filepath.Clean(path)
-
-	parts := make([]string, 0, dirLength)
+	parts := make([]string, 0, n)
 	current := cleanPath
 
-	// Collect path components backwards
-	for len(parts) < dirLength && current != "/" && current != "." {
+	for len(parts) < n && current != "/" && current != "." {
 		base := filepath.Base(current)
 		if base == "" || base == "." {
 			break
 		}
-
 		parts = append(parts, base)
 		current = filepath.Dir(current)
 	}
 
 	if len(parts) == 0 {
-		return n.pathwrap.Base(path), nil
+		return filepath.Base(path)
 	}
 
-	// Reverse the parts
 	for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
 		parts[i], parts[j] = parts[j], parts[i]
 	}
 
-	return strings.Join(parts, "/"), nil
+	return strings.Join(parts, "/")
+}
+
+// Gets the name from a directory
+func dirName(n *RealNamer, path string) (string, error) {
+	return lastNComponents(path, n.config.DirLength), nil
 }

--- a/namer/git.go
+++ b/namer/git.go
@@ -107,7 +107,7 @@ func gitRootName(n *RealNamer, path string) (string, error) {
 	if n.config.GitNamerUseWorktreeRoot {
 		isGit, topLevel, err := n.git.ShowTopLevel(path)
 		if err != nil {
-			return "", err
+			return "", nil
 		}
 		if !isGit || topLevel == "" {
 			return "", nil

--- a/namer/git.go
+++ b/namer/git.go
@@ -56,18 +56,47 @@ func getGitRootPath(n *RealNamer, path string) (bool, string, error) {
 	return true, rootPath, nil
 }
 
+// gitAnchor returns the path used as the naming anchor for git strategies.
+// When git_namer_use_worktree_root is true, the current worktree's top-level
+// directory (`git rev-parse --show-toplevel`) is used so sibling worktrees
+// (e.g. `git worktree add ../feat`) get named after themselves rather than
+// the main clone. Otherwise the main working tree root is used.
+func gitAnchor(n *RealNamer, path string) (bool, string, error) {
+	if n.config.GitNamerUseWorktreeRoot {
+		isGit, topLevel, err := n.git.ShowTopLevel(path)
+		if err != nil {
+			return false, "", nil
+		}
+		if !isGit || topLevel == "" {
+			return false, "", nil
+		}
+		return true, topLevel, nil
+	}
+	return getGitRootPath(n, path)
+}
+
+// anchorRepoName returns the repo-name segment for a git anchor path, applying
+// git_dir_length when set (mirrors dir_length behavior, but scoped to git).
+func anchorRepoName(n *RealNamer, anchor string) string {
+	if n.config.GitDirLength > 1 {
+		return lastNComponents(anchor, n.config.GitDirLength)
+	}
+	return n.pathwrap.Base(anchor)
+}
+
 // Names a session as <repoName>/<relativePath> where repoName is the basename
-// of the main working tree and relativePath is the input path's offset from it.
+// of the anchor (main working tree or current worktree top-level, depending on
+// config) and relativePath is the input path's offset from that anchor.
 func gitName(n *RealNamer, path string) (string, error) {
-	isGit, rootPath, err := getGitRootPath(n, path)
+	isGit, anchor, err := gitAnchor(n, path)
 	if err != nil {
 		return "", err
 	}
-	if !isGit || rootPath == "" {
+	if !isGit || anchor == "" {
 		return "", nil
 	}
-	repoName := n.pathwrap.Base(rootPath)
-	relativePath := strings.TrimPrefix(path, rootPath)
+	repoName := anchorRepoName(n, anchor)
+	relativePath := strings.TrimPrefix(path, anchor)
 	return repoName + relativePath, nil
 }
 
@@ -75,6 +104,17 @@ func gitName(n *RealNamer, path string) (string, error) {
 // path is derived from the current worktree's top-level directory. This collapses
 // nested subdirectories to their containing worktree (main tree or linked worktree).
 func gitRootName(n *RealNamer, path string) (string, error) {
+	if n.config.GitNamerUseWorktreeRoot {
+		isGit, topLevel, err := n.git.ShowTopLevel(path)
+		if err != nil {
+			return "", err
+		}
+		if !isGit || topLevel == "" {
+			return "", nil
+		}
+		return anchorRepoName(n, topLevel), nil
+	}
+
 	isGit, rootPath, err := getGitRootPath(n, path)
 	if err != nil {
 		return "", err
@@ -82,7 +122,7 @@ func gitRootName(n *RealNamer, path string) (string, error) {
 	if !isGit || rootPath == "" {
 		return "", nil
 	}
-	repoName := n.pathwrap.Base(rootPath)
+	repoName := anchorRepoName(n, rootPath)
 	_, topLevel, _ := n.git.ShowTopLevel(path)
 	if topLevel == "" {
 		return repoName, nil

--- a/namer/git_test.go
+++ b/namer/git_test.go
@@ -343,3 +343,138 @@ branch refs/heads/main
 		assert.Equal(t, "", name)
 	})
 }
+
+// Sibling-worktree layout from issue #388:
+//
+//	~/work/path/bernoulli/master   (main clone)
+//	~/work/path/bernoulli/dev      (added via `git worktree add ../dev`)
+func newSiblingWorktreeNamer(cfg model.Config) (*RealNamer, *pathwrap.MockPath, *git.MockGit) {
+	mockPathwrap := new(pathwrap.MockPath)
+	mockGit := new(git.MockGit)
+	mockHome := new(home.MockHome)
+	return &RealNamer{pathwrap: mockPathwrap, git: mockGit, home: mockHome, config: cfg}, mockPathwrap, mockGit
+}
+
+func TestGitNameWithWorktreeRootOption(t *testing.T) {
+	siblingList := `worktree /Users/semi/work/path/bernoulli/master
+HEAD aaaaaaa
+branch refs/heads/master
+
+worktree /Users/semi/work/path/bernoulli/dev
+HEAD bbbbbbb
+branch refs/heads/dev
+`
+
+	t.Run("sibling worktree without options reproduces broken long name", func(t *testing.T) {
+		n, mp, mg := newSiblingWorktreeNamer(model.Config{DirLength: 1})
+		path := "/Users/semi/work/path/bernoulli/dev"
+		mg.On("WorktreeList", path).Return(true, siblingList, nil)
+		mp.On("Base", "/Users/semi/work/path/bernoulli/master").Return("master")
+
+		name, err := gitName(n, path)
+		assert.NoError(t, err)
+		// The sibling path is not a prefix of the main worktree path, so
+		// TrimPrefix returns the unchanged absolute path — the bug from #388.
+		assert.Equal(t, "master/Users/semi/work/path/bernoulli/dev", name)
+	})
+
+	t.Run("git_namer_use_worktree_root anchors on current worktree", func(t *testing.T) {
+		n, mp, mg := newSiblingWorktreeNamer(model.Config{GitNamerUseWorktreeRoot: true})
+		path := "/Users/semi/work/path/bernoulli/dev"
+		mg.On("ShowTopLevel", path).Return(true, "/Users/semi/work/path/bernoulli/dev", nil)
+		mp.On("Base", "/Users/semi/work/path/bernoulli/dev").Return("dev")
+
+		name, err := gitName(n, path)
+		assert.NoError(t, err)
+		assert.Equal(t, "dev", name)
+	})
+
+	t.Run("git_namer_use_worktree_root + git_dir_length=2 produces parent/worktree", func(t *testing.T) {
+		cfg := model.Config{GitNamerUseWorktreeRoot: true, GitDirLength: 2}
+		n, _, mg := newSiblingWorktreeNamer(cfg)
+		path := "/Users/semi/work/path/bernoulli/dev"
+		mg.On("ShowTopLevel", path).Return(true, "/Users/semi/work/path/bernoulli/dev", nil)
+
+		name, err := gitName(n, path)
+		assert.NoError(t, err)
+		assert.Equal(t, "bernoulli/dev", name)
+	})
+
+	t.Run("git_namer_use_worktree_root + git_dir_length=2 on main worktree", func(t *testing.T) {
+		cfg := model.Config{GitNamerUseWorktreeRoot: true, GitDirLength: 2}
+		n, _, mg := newSiblingWorktreeNamer(cfg)
+		path := "/Users/semi/work/path/bernoulli/master"
+		mg.On("ShowTopLevel", path).Return(true, "/Users/semi/work/path/bernoulli/master", nil)
+
+		name, err := gitName(n, path)
+		assert.NoError(t, err)
+		assert.Equal(t, "bernoulli/master", name)
+	})
+
+	t.Run("git_namer_use_worktree_root preserves subdirectory under worktree", func(t *testing.T) {
+		cfg := model.Config{GitNamerUseWorktreeRoot: true, GitDirLength: 2}
+		n, _, mg := newSiblingWorktreeNamer(cfg)
+		path := "/Users/semi/work/path/bernoulli/dev/src/pkg"
+		mg.On("ShowTopLevel", path).Return(true, "/Users/semi/work/path/bernoulli/dev", nil)
+
+		name, err := gitName(n, path)
+		assert.NoError(t, err)
+		assert.Equal(t, "bernoulli/dev/src/pkg", name)
+	})
+
+	t.Run("git_dir_length=2 without use_worktree_root on nested worktree", func(t *testing.T) {
+		// Nested .wk/ layout — main worktree path IS a prefix, so existing
+		// logic works; git_dir_length just expands the repo-name segment.
+		cfg := model.Config{GitDirLength: 2}
+		n, _, mg := newSiblingWorktreeNamer(cfg)
+		path := "/Users/hansolo/code/project/nu/.wk/5969"
+		list := `worktree /Users/hansolo/code/project/nu
+HEAD bb976dcdc
+branch refs/heads/main
+
+worktree /Users/hansolo/code/project/nu/.wk/5969
+HEAD f31c5985c
+branch refs/heads/jam/5969
+`
+		mg.On("WorktreeList", path).Return(true, list, nil)
+
+		name, err := gitName(n, path)
+		assert.NoError(t, err)
+		assert.Equal(t, "project/nu/.wk/5969", name)
+	})
+
+	t.Run("git_namer_use_worktree_root on non-git directory", func(t *testing.T) {
+		cfg := model.Config{GitNamerUseWorktreeRoot: true}
+		n, _, mg := newSiblingWorktreeNamer(cfg)
+		path := "/Users/hansolo/.config/nvim"
+		mg.On("ShowTopLevel", path).Return(false, "", nil)
+
+		name, err := gitName(n, path)
+		assert.NoError(t, err)
+		assert.Equal(t, "", name)
+	})
+}
+
+func TestGitRootNameWithWorktreeRootOption(t *testing.T) {
+	t.Run("git_namer_use_worktree_root collapses nested subdir to worktree", func(t *testing.T) {
+		cfg := model.Config{GitNamerUseWorktreeRoot: true, GitDirLength: 2}
+		n, _, mg := newSiblingWorktreeNamer(cfg)
+		path := "/Users/semi/work/path/bernoulli/dev/src/pkg"
+		mg.On("ShowTopLevel", path).Return(true, "/Users/semi/work/path/bernoulli/dev", nil)
+
+		name, err := gitRootName(n, path)
+		assert.NoError(t, err)
+		assert.Equal(t, "bernoulli/dev", name)
+	})
+
+	t.Run("git_namer_use_worktree_root on non-git directory", func(t *testing.T) {
+		cfg := model.Config{GitNamerUseWorktreeRoot: true}
+		n, _, mg := newSiblingWorktreeNamer(cfg)
+		path := "/Users/hansolo/.config/nvim"
+		mg.On("ShowTopLevel", path).Return(false, "", nil)
+
+		name, err := gitRootName(n, path)
+		assert.NoError(t, err)
+		assert.Equal(t, "", name)
+	})
+}

--- a/sesh.schema.json
+++ b/sesh.schema.json
@@ -42,6 +42,17 @@
       "minimum": 1,
       "default": 1
     },
+    "git_namer_use_worktree_root": {
+      "type": "boolean",
+      "description": "Derive git session names from the current worktree's top-level directory instead of the main repo root. Useful when worktrees are added as siblings of the main clone (e.g. `git worktree add ../feat`).",
+      "default": false
+    },
+    "git_dir_length": {
+      "type": "integer",
+      "description": "Number of directory components to use when naming git-detected sessions (minimum 1). Mirrors dir_length but applies to git strategies.",
+      "minimum": 1,
+      "default": 1
+    },
     "separator_aware": {
       "type": "boolean",
       "description": "Enable separator-aware configuration for the picker",


### PR DESCRIPTION
Closes #388

The existing git namer assumes the current path is nested under the main worktree's root, so sibling-worktree layouts (e.g. `git worktree add ../dev`) produced names like `master/Users/semi/work/path/bernoulli/dev` instead of just `dev`. `dir_length` also only applied to the directory-name strategy, leaving git-detected sessions without a way to expand the name to include the parent folder.

- Add `git_namer_use_worktree_root` config option that anchors git naming on the current worktree's top-level (`git rev-parse --show-toplevel`) instead of the main working tree, fixing sibling-worktree naming
- Add `git_dir_length` config option mirroring `dir_length` but scoped to git strategies, so a session in `~/work/bernoulli/dev` can be named `bernoulli/dev` instead of `dev`
- Extract `lastNComponents` helper out of `dirName` so both directory and git strategies share the same path-component logic
- Add `gitAnchor` and `anchorRepoName` helpers to centralize anchor selection and length-aware repo naming
- Add `sesh.schema.json` entries for both new options so TOML editors get completion and validation
- Add `namer/git_test.go` cases covering sibling-worktree layouts, the new options in isolation and combined, and the nested `.wk/` worktree layout
- Normalize `git_dir_length < 1` to `1` in `applyDefaults` so the runtime matches the schema's minimum/default of 1 (mirrors existing `dir_length` clamping)
- In `gitRootName`, swallow `ShowTopLevel` errors when `git_namer_use_worktree_root` is enabled so the strategy loop can fall back to `dirName` instead of aborting — matches the robustness of `gitAnchor`/`getGitRootPath`

## Testing

These are the steps to manually test the changes in this pull request:

- In a sibling-worktree layout (`git worktree add ../dev` next to a main clone), open a sesh session in the new worktree and confirm the session name is just the worktree directory (e.g. `dev`) and not `master/...`
- Set `git_namer_use_worktree_root = true` and `git_dir_length = 2` in `sesh.toml`, then open a session in the same sibling worktree and confirm the name is `<parent>/<worktree>` (e.g. `bernoulli/dev`)
- In a nested `.wk/` worktree layout, set `git_dir_length = 2` and confirm sessions are named `<parent>/<repo>/<relative-path>` (e.g. `project/nu/.wk/5969`)
- With both options unset, confirm existing behavior is unchanged (basename of main working tree + relative path)
- Set `git_dir_length = 0` (or omit it) and confirm it behaves the same as `git_dir_length = 1`
- Run `just test` and confirm `namer/` tests pass