### PR TITLE
feat(picker): add Emacs keybindings (Ctrl+P, Ctrl+N) for navigation

### DIFF
--- a/picker/tui.go
+++ b/picker/tui.go
@@ -161,11 +161,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.quit = true
 			return m, tea.Quit
 
-		case "up", "ctrl+k":
+		case "up", "ctrl+k", "ctrl+p":
 			m.cursorUp(1)
 			return m, nil
 
-		case "down", "ctrl+j":
+		case "down", "ctrl+j", "ctrl+n":
 			m.cursorDown(1)
 			return m, nil
 


### PR DESCRIPTION
While I use neovim, my brain has ^P & ^N as previous and next hardwired into it everywhere. This PR adds them.

Regarding tests, as there are no tests for the vim motions and as this change is so simple, I decided not to add a kinda pointless test to the codebase.  If you want me to return it to me and I'll add tests for the vim motions as well