### PR TITLE
Add `sesh status` for a dynamic tmux status bar (#400)

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,28 @@ Add the following to your `tmux.conf` to overwrite the default `last-session` co
 bind -N "last-session (via sesh) " L run-shell "sesh last"
 ```
 
+### Dynamic status bar
+
+`sesh status` prints a tmux-styled string describing the GitHub issue that
+matches the current session's branch — a state badge (green `OPEN` / red
+`CLOSED`) followed by the issue number and title. It is inspired by
+[gitmux](https://github.com/arl/gitmux).
+
+Add it to your `status-left` (or `status-right`):
+
+```sh
+set -g status-left "#[fg=blue,bold]#S #[fg=white,nobold]#(sesh status)"
+```
+
+The issue number is parsed from the branch name (`400` or `feat/400-status-bar`
+both resolve to issue `#400`), so it works best with a branch-per-issue
+workflow.
+
+**Requirements:** the [`gh` CLI](https://cli.github.com) must be installed and
+authenticated (`gh auth login`). When there is nothing to show — no number in
+the branch, no matching issue, or `gh` is unavailable — `sesh status` prints
+nothing, leaving the status bar clean.
+
 ### Connect to root
 
 While working in a nested session, you may way to connect to the root session of a git worktree or git repository. To do this, you can use the `--root` flag with the `sesh connect` command.

--- a/README.md
+++ b/README.md
@@ -465,8 +465,8 @@ bind -N "last-session (via sesh) " L run-shell "sesh last"
 
 `sesh status` prints a tmux-styled string describing the GitHub issue that
 matches the current session's branch — a state badge (green `OPEN` / red
-`CLOSED`) followed by the issue number and title. It is inspired by
-[gitmux](https://github.com/arl/gitmux).
+`CLOSED`), a magenta `Issue #<number>` label, and the issue title. It is
+inspired by [gitmux](https://github.com/arl/gitmux).
 
 Add it to your `status-left` (or `status-right`):
 

--- a/docs/superpowers/plans/2026-06-27-sesh-status.md
+++ b/docs/superpowers/plans/2026-06-27-sesh-status.md
@@ -1,0 +1,601 @@
+# `sesh status` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `sesh status` command that prints the current branch's GitHub issue (state badge + number + title) as a tmux-styled string for the status bar.
+
+**Architecture:** A new `git.CurrentBranch` method feeds a new `github` package that wraps the `gh` CLI and returns a structured `Issue`. A thin `sesh status` cobra command resolves the session path, calls `github.Issue`, and formats a tmux-markup line. The `github` dependency is config-free and wired into `BaseDeps`.
+
+**Tech Stack:** Go 1.25, cobra, testify mocks (mockery), `gh` CLI, tmux format markup.
+
+## Global Constraints
+
+- Module path: `github.com/joshmedeski/sesh/v2`.
+- All external tools are wrapped behind interfaces that depend on `shell.Shell`; dependencies are wired in `seshcli/deps.go`.
+- Mocks are generated, not committed (`.gitignore` ignores `mock_*`). Regenerate with `just mock` after any interface change.
+- Run `just test` (regenerates mocks, then `go test -cover -race ./...`) before considering work complete.
+- No-result behavior: `sesh status` prints nothing and exits `0` for every "nothing to show" case (no number in branch, not a git repo, `gh` missing/unauthenticated, issue not found, malformed output).
+- Status output uses tmux format markup (`#[fg=…,bold]…#[default]`), never ANSI escape codes.
+
+---
+
+### Task 1: Add `CurrentBranch` to the `git` package
+
+**Files:**
+- Modify: `git/git.go` (interface + implementation)
+- Test: `git/git_test.go` (create)
+- Regenerate: `git/mock_Git.go` (via `just mock`)
+
+**Interfaces:**
+- Consumes: `shell.Shell.Cmd(cmd string, arg ...string) (string, error)` (existing).
+- Produces: `git.Git.CurrentBranch(path string) (bool, string, error)` — `(true, branchName, nil)` on success; `(false, "", err)` when the directory is not a git repo or git fails.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `git/git_test.go`:
+
+```go
+package git
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/shell"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCurrentBranch(t *testing.T) {
+	t.Run("returns the branch name on success", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		g := NewGit(mockShell)
+		path := "/Users/josh/c/sesh"
+		mockShell.On("Cmd", "git", "-C", path, "rev-parse", "--abbrev-ref", "HEAD").
+			Return("400", nil)
+
+		ok, branch, err := g.CurrentBranch(path)
+
+		assert.True(t, ok)
+		assert.Equal(t, "400", branch)
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns false when not a git repo", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		g := NewGit(mockShell)
+		path := "/tmp/not-a-repo"
+		mockShell.On("Cmd", "git", "-C", path, "rev-parse", "--abbrev-ref", "HEAD").
+			Return("", fmt.Errorf("fatal: not a git repository"))
+
+		ok, branch, err := g.CurrentBranch(path)
+
+		assert.False(t, ok)
+		assert.Equal(t, "", branch)
+		assert.Error(t, err)
+	})
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `just mock && go test ./git/... -run TestCurrentBranch -v`
+Expected: compile error / FAIL — `g.CurrentBranch` undefined.
+
+- [ ] **Step 3: Add the method to the interface and implementation**
+
+In `git/git.go`, add to the `Git` interface (after `WorktreeList`):
+
+```go
+	WorktreeList(name string) (bool, string, error)
+	CurrentBranch(path string) (bool, string, error)
+```
+
+And add the implementation at the end of the file:
+
+```go
+func (g *RealGit) CurrentBranch(path string) (bool, string, error) {
+	out, err := g.shell.Cmd("git", "-C", path, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return false, "", err
+	}
+	return true, out, nil
+}
+```
+
+- [ ] **Step 4: Regenerate mocks and run the test**
+
+Run: `just mock && go test ./git/... -run TestCurrentBranch -v`
+Expected: PASS (both subtests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add git/git.go git/git_test.go
+git commit -m "feat(git): add CurrentBranch to read the branch for a path"
+```
+
+---
+
+### Task 2: Create the `github` package
+
+**Files:**
+- Create: `github/github.go`
+- Test: `github/github_test.go`
+- Regenerate: `github/mock_Github.go` (via `just mock`)
+
+**Interfaces:**
+- Consumes: `git.Git.CurrentBranch(path string) (bool, string, error)` (Task 1); `shell.Shell.Cmd(cmd string, arg ...string) (string, error)`.
+- Produces:
+  - `github.Issue` struct with fields `Number int`, `Title string`, `State string` (json tags `number`/`title`/`state`).
+  - `github.Github.Issue(path string) (Issue, bool, error)` — `(issue, true, nil)` when found; `(Issue{}, false, nil)` for every no-result case.
+  - `github.NewGithub(shell shell.Shell, git git.Git) Github`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `github/github_test.go`:
+
+```go
+package github
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/git"
+	"github.com/joshmedeski/sesh/v2/shell"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseIssueNumber(t *testing.T) {
+	cases := []struct {
+		branch string
+		want   string
+		ok     bool
+	}{
+		{"400", "400", true},
+		{"feat/400-status-bar", "400", true},
+		{"bugfix/issue-12", "12", true},
+		{"feat/400-then-401", "400", true},
+		{"main", "", false},
+		{"", "", false},
+	}
+	for _, c := range cases {
+		got, ok := parseIssueNumber(c.branch)
+		assert.Equal(t, c.ok, ok, c.branch)
+		assert.Equal(t, c.want, got, c.branch)
+	}
+}
+
+func TestIssue(t *testing.T) {
+	t.Run("returns the issue on success", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		mockGit := new(git.MockGit)
+		gh := NewGithub(mockShell, mockGit)
+		path := "/Users/josh/c/sesh"
+		mockGit.On("CurrentBranch", path).Return(true, "feat/400-status-bar", nil)
+		mockShell.On("Cmd", "gh", "issue", "view", "400", "--json", "number,title,state").
+			Return(`{"number":400,"state":"OPEN","title":"Dynamic tmux status bar"}`, nil)
+
+		issue, found, err := gh.Issue(path)
+
+		assert.True(t, found)
+		assert.NoError(t, err)
+		assert.Equal(t, Issue{Number: 400, Title: "Dynamic tmux status bar", State: "OPEN"}, issue)
+	})
+
+	t.Run("not found when branch has no number", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		mockGit := new(git.MockGit)
+		gh := NewGithub(mockShell, mockGit)
+		path := "/Users/josh/c/sesh"
+		mockGit.On("CurrentBranch", path).Return(true, "main", nil)
+
+		issue, found, err := gh.Issue(path)
+
+		assert.False(t, found)
+		assert.NoError(t, err)
+		assert.Equal(t, Issue{}, issue)
+		// No gh call is set up on mockShell; testify panics on an
+		// unexpected call, so reaching gh would fail this test.
+	})
+
+	t.Run("not found when not a git repo", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		mockGit := new(git.MockGit)
+		gh := NewGithub(mockShell, mockGit)
+		path := "/tmp/x"
+		mockGit.On("CurrentBranch", path).Return(false, "", fmt.Errorf("not a git repo"))
+
+		_, found, err := gh.Issue(path)
+
+		assert.False(t, found)
+		assert.NoError(t, err)
+	})
+
+	t.Run("not found when gh errors", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		mockGit := new(git.MockGit)
+		gh := NewGithub(mockShell, mockGit)
+		path := "/Users/josh/c/sesh"
+		mockGit.On("CurrentBranch", path).Return(true, "400", nil)
+		mockShell.On("Cmd", "gh", "issue", "view", "400", "--json", "number,title,state").
+			Return("", fmt.Errorf("gh: not found"))
+
+		_, found, err := gh.Issue(path)
+
+		assert.False(t, found)
+		assert.NoError(t, err)
+	})
+
+	t.Run("not found when gh returns malformed json", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		mockGit := new(git.MockGit)
+		gh := NewGithub(mockShell, mockGit)
+		path := "/Users/josh/c/sesh"
+		mockGit.On("CurrentBranch", path).Return(true, "400", nil)
+		mockShell.On("Cmd", "gh", "issue", "view", "400", "--json", "number,title,state").
+			Return("not json", nil)
+
+		_, found, err := gh.Issue(path)
+
+		assert.False(t, found)
+		assert.NoError(t, err)
+	})
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./github/... -v`
+Expected: compile error — package `github` does not exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `github/github.go`:
+
+```go
+package github
+
+import (
+	"encoding/json"
+	"regexp"
+
+	"github.com/joshmedeski/sesh/v2/git"
+	"github.com/joshmedeski/sesh/v2/shell"
+)
+
+// Issue is the subset of GitHub issue data sesh renders in the status bar.
+type Issue struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	State  string `json:"state"` // "OPEN" | "CLOSED"
+}
+
+type Github interface {
+	// Issue returns the GitHub issue for the branch checked out at path.
+	// The bool is false (with a nil error) for every "nothing to show" case.
+	Issue(path string) (Issue, bool, error)
+}
+
+type RealGithub struct {
+	shell shell.Shell
+	git   git.Git
+}
+
+func NewGithub(shell shell.Shell, git git.Git) Github {
+	return &RealGithub{shell, git}
+}
+
+var issueNumberRe = regexp.MustCompile(`\d+`)
+
+// parseIssueNumber returns the first run of digits in a branch name.
+func parseIssueNumber(branch string) (string, bool) {
+	match := issueNumberRe.FindString(branch)
+	if match == "" {
+		return "", false
+	}
+	return match, true
+}
+
+func (g *RealGithub) Issue(path string) (Issue, bool, error) {
+	ok, branch, err := g.git.CurrentBranch(path)
+	if err != nil || !ok {
+		return Issue{}, false, nil
+	}
+
+	number, ok := parseIssueNumber(branch)
+	if !ok {
+		return Issue{}, false, nil
+	}
+
+	out, err := g.shell.Cmd("gh", "issue", "view", number, "--json", "number,title,state")
+	if err != nil || out == "" {
+		return Issue{}, false, nil
+	}
+
+	var issue Issue
+	if err := json.Unmarshal([]byte(out), &issue); err != nil {
+		return Issue{}, false, nil
+	}
+	return issue, true, nil
+}
+```
+
+- [ ] **Step 4: Regenerate mocks and run the tests**
+
+Run: `just mock && go test ./github/... -v`
+Expected: PASS (all subtests, including `TestParseIssueNumber`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add github/github.go github/github_test.go
+git commit -m "feat(github): add Issue lookup via the gh CLI"
+```
+
+---
+
+### Task 3: Wire `github` into dependency injection
+
+**Files:**
+- Modify: `seshcli/deps.go`
+
+**Interfaces:**
+- Consumes: `github.NewGithub(shell.Shell, git.Git) github.Github` (Task 2).
+- Produces: `BaseDeps.Github github.Github`, available on `*Deps` (which embeds `BaseDeps`) for command code.
+
+> No new test — this is wiring covered by the build and by Task 4's command. The deliverable is a compiling dependency graph.
+
+- [ ] **Step 1: Add the import**
+
+In `seshcli/deps.go`, add to the import block (keep alphabetical, after `git`):
+
+```go
+	"github.com/joshmedeski/sesh/v2/git"
+	"github.com/joshmedeski/sesh/v2/github"
+	"github.com/joshmedeski/sesh/v2/home"
+```
+
+- [ ] **Step 2: Add the field to `BaseDeps`**
+
+In the `BaseDeps` struct, add after `Git git.Git`:
+
+```go
+	Git        git.Git
+	Github     github.Github
+	Dir        dir.Dir
+```
+
+- [ ] **Step 3: Construct and assign it in `NewBaseDeps`**
+
+In `NewBaseDeps`, after `g := git.NewGit(sh)`:
+
+```go
+	g := git.NewGit(sh)
+	gh := github.NewGithub(sh, g)
+```
+
+And add it to the returned `&BaseDeps{...}` literal, after the `Git: g,` line:
+
+```go
+		Git:        g,
+		Github:     gh,
+		Dir:        d,
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `go build ./...`
+Expected: builds with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add seshcli/deps.go
+git commit -m "feat(seshcli): wire github dependency into BaseDeps"
+```
+
+---
+
+### Task 4: Add the `sesh status` command
+
+**Files:**
+- Create: `seshcli/status.go`
+- Test: `seshcli/status_test.go` (create)
+- Modify: `seshcli/root_command.go` (register the command)
+
+**Interfaces:**
+- Consumes: `deps.Github.Issue(path string) (github.Issue, bool, error)` (Task 2/3); `deps.Lister.GetAttachedTmuxSession() (model.SeshSession, bool)` (existing); `buildDeps(cmd, base) (*Deps, error)` (existing).
+- Produces: `NewStatusCommand(base *BaseDeps) *cobra.Command`; `formatStatus(issue github.Issue) string`.
+
+- [ ] **Step 1: Write the failing test for `formatStatus`**
+
+Create `seshcli/status_test.go`:
+
+```go
+package seshcli
+
+import (
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/github"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatStatus(t *testing.T) {
+	t.Run("open issue gets a green OPEN badge", func(t *testing.T) {
+		got := formatStatus(github.Issue{Number: 400, Title: "Dynamic tmux status bar", State: "OPEN"})
+		assert.Equal(t, "#[fg=green,bold]OPEN#[default] #400 Dynamic tmux status bar", got)
+	})
+
+	t.Run("closed issue gets a red CLOSED badge", func(t *testing.T) {
+		got := formatStatus(github.Issue{Number: 400, Title: "Dynamic tmux status bar", State: "CLOSED"})
+		assert.Equal(t, "#[fg=red,bold]CLOSED#[default] #400 Dynamic tmux status bar", got)
+	})
+
+	t.Run("any non-OPEN state is treated as red", func(t *testing.T) {
+		got := formatStatus(github.Issue{Number: 7, Title: "x", State: "MERGED"})
+		assert.Equal(t, "#[fg=red,bold]MERGED#[default] #7 x", got)
+	})
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./seshcli/... -run TestFormatStatus -v`
+Expected: compile error — `formatStatus` undefined.
+
+- [ ] **Step 3: Write the command and helpers**
+
+Create `seshcli/status.go`:
+
+```go
+package seshcli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/joshmedeski/sesh/v2/github"
+)
+
+func NewStatusCommand(base *BaseDeps) *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show contextual status for the current session (for the tmux status bar)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			deps, err := buildDeps(cmd, base)
+			if err != nil {
+				return err
+			}
+
+			path := statusPath(deps)
+			if path == "" {
+				return nil
+			}
+
+			issue, found, _ := deps.Github.Issue(path)
+			if !found {
+				return nil
+			}
+
+			fmt.Print(formatStatus(issue))
+			return nil
+		},
+	}
+}
+
+// statusPath resolves the directory to inspect: the attached tmux session's
+// path when running inside tmux, otherwise the current working directory.
+func statusPath(deps *Deps) string {
+	if session, exists := deps.Lister.GetAttachedTmuxSession(); exists {
+		return session.Path
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	return cwd
+}
+
+// formatStatus renders an issue as a tmux-styled status line.
+func formatStatus(issue github.Issue) string {
+	color := "green"
+	if issue.State != "OPEN" {
+		color = "red"
+	}
+	return fmt.Sprintf("#[fg=%s,bold]%s#[default] #%d %s", color, issue.State, issue.Number, issue.Title)
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./seshcli/... -run TestFormatStatus -v`
+Expected: PASS (all three subtests).
+
+- [ ] **Step 5: Register the command**
+
+In `seshcli/root_command.go`, add to the `rootCmd.AddCommand(...)` call (after `NewRootSessionCommand(base),`):
+
+```go
+		NewRootSessionCommand(base),
+		NewStatusCommand(base),
+		NewPreviewCommand(base),
+```
+
+- [ ] **Step 6: Verify it builds and the command is registered**
+
+Run: `go build ./... && go run . status --help`
+Expected: builds; help shows "Show contextual status for the current session (for the tmux status bar)".
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add seshcli/status.go seshcli/status_test.go seshcli/root_command.go
+git commit -m "feat(seshcli): add sesh status command for the tmux status bar"
+```
+
+---
+
+### Task 5: Document `sesh status` in the README
+
+**Files:**
+- Modify: `README.md` (add a subsection under `## Bonus`)
+
+> No automated test; deliverable is accurate user-facing docs. Verify by reading.
+
+- [ ] **Step 1: Add the documentation section**
+
+In `README.md`, insert the following immediately before `### Connect to root` (after the `### Last` section's `bind` block, around line 463):
+
+````markdown
+### Dynamic status bar
+
+`sesh status` prints a tmux-styled string describing the GitHub issue that
+matches the current session's branch — a state badge (green `OPEN` / red
+`CLOSED`) followed by the issue number and title. It is inspired by
+[gitmux](https://github.com/arl/gitmux).
+
+Add it to your `status-left` (or `status-right`):
+
+```sh
+set -g status-left "#[fg=blue,bold]#S #[fg=white,nobold]#(sesh status)"
+```
+
+The issue number is parsed from the branch name (`400` or `feat/400-status-bar`
+both resolve to issue `#400`), so it works best with a branch-per-issue
+workflow.
+
+**Requirements:** the [`gh` CLI](https://cli.github.com) must be installed and
+authenticated (`gh auth login`). When there is nothing to show — no number in
+the branch, no matching issue, or `gh` is unavailable — `sesh status` prints
+nothing, leaving the status bar clean.
+````
+
+- [ ] **Step 2: Verify the rendered section reads correctly**
+
+Run: `grep -n "Dynamic status bar" README.md`
+Expected: one match; the surrounding section reads as written.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document sesh status for the tmux status bar"
+```
+
+---
+
+### Final verification
+
+- [ ] **Run the full suite**
+
+Run: `just test`
+Expected: mocks regenerate; all packages pass with `-race`, including `git`, `github`, and `seshcli`.
+
+- [ ] **Manual smoke test (this repo is on branch `400`)**
+
+Run: `go run . status`
+Expected: prints something like `#[fg=green,bold]OPEN#[default] #400 Dynamic tmux status bar` (requires `gh` authenticated; otherwise prints nothing and exits 0).

--- a/docs/superpowers/plans/2026-06-27-status-cache.md
+++ b/docs/superpowers/plans/2026-06-27-status-cache.md
@@ -1,0 +1,1173 @@
+# `sesh status` issue cache Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `sesh status` read GitHub issue title/state from a local, branch-keyed disk cache so every tmux status render is a sub-millisecond file read, while a detached background process keeps it fresh via `gh`.
+
+**Architecture:** A new `statuscache` package stores one gob file per `repoRoot+branch` key. A new `refresher` package spawns a detached `sesh status --refresh` child that performs the only live `gh` call and writes the cache. `sesh status` reads the cache and renders instantly, spawning a refresh only when the entry is missing or stale; `sesh connect` warms the cache on switch. Config gains a `[github]` section with `issue_ttl`.
+
+**Tech Stack:** Go 1.25, cobra, testify mocks (mockery), gob, `gh` CLI, tmux format markup.
+
+## Global Constraints
+
+- Module path: `github.com/joshmedeski/sesh/v2`, Go 1.25.
+- External tools are wrapped behind interfaces depending on `shell.Shell`; dependencies are wired in `seshcli/deps.go`. Config-free deps go on `BaseDeps`.
+- Mocks are gitignored (`mock_*`) and generated via `just mock` — never committed. Regenerate after any interface change.
+- Run `just test` (regenerates mocks, then `go test -cover -race ./...`) before considering work complete.
+- Cache key is `sha256(repoRoot + "\x00" + branch)` hex-encoded — branch-keyed, never issue-number-keyed.
+- `Entry` carries both `PR *Ref` and `Issue *Ref`; the MVP only ever fills `Issue`. The refresh **always** writes an entry (both refs nil = negative entry) so the hot path respects the TTL instead of re-spawning every tick.
+- No-result behavior: `sesh status` prints nothing and exits `0` for every nothing-to-show case (not a repo, no number, gh missing/unauthenticated, issue not found, malformed JSON, negative cache entry).
+- `issue_ttl` is a `*int`: `nil` → effective TTL 60; explicit `0` → cache disabled (live fetch, today's behavior); `N>0` → N seconds. Use `config.Github.EffectiveTTL()`; `== 0` means disabled.
+- Status output uses tmux format markup (`#[fg=…]`), never ANSI. `formatStatus` is unchanged from PR #401.
+- `statuscache` must not import `github` (the cache→issue conversion lives in `seshcli`).
+- Schema (`sesh.schema.json`) must stay in lockstep with the config struct (see the `config-schema-sync` skill).
+
+---
+
+### Task 1: Config `[github]` section + `EffectiveTTL` + schema
+
+**Files:**
+- Modify: `model/config.go`
+- Create: `model/config_test.go`
+- Modify: `sesh.schema.json`
+
+**Interfaces:**
+- Produces: `model.GithubConfig` with `IssueTTL *int` (`toml:"issue_ttl"`); `Config.Github GithubConfig` (`toml:"github"`); method `(GithubConfig) EffectiveTTL() int` — returns 60 when `IssueTTL` is nil, else `*IssueTTL`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `model/config_test.go`:
+
+```go
+package model
+
+import "testing"
+
+func TestGithubConfigEffectiveTTL(t *testing.T) {
+	thirty := 30
+	zero := 0
+	cases := []struct {
+		name string
+		ttl  *int
+		want int
+	}{
+		{"nil defaults to 60", nil, 60},
+		{"explicit zero disables", &zero, 0},
+		{"explicit value", &thirty, 30},
+	}
+	for _, c := range cases {
+		got := GithubConfig{IssueTTL: c.ttl}.EffectiveTTL()
+		if got != c.want {
+			t.Errorf("%s: EffectiveTTL() = %d, want %d", c.name, got, c.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./model/... -run TestGithubConfigEffectiveTTL`
+Expected: compile error — `GithubConfig` undefined.
+
+- [ ] **Step 3: Add the config struct, field, and method**
+
+In `model/config.go`, add `Github GithubConfig` to the `Config` struct (after the `TUI TUIConfig` field):
+
+```go
+	TUI                  TUIConfig            `toml:"tui"`
+	Github               GithubConfig         `toml:"github"`
+```
+
+And add (near the other config sub-structs, e.g. after `TUIConfig`):
+
+```go
+// GithubConfig holds settings for GitHub integration in the status bar.
+type GithubConfig struct {
+	// IssueTTL is the status cache lifetime in seconds. A pointer so an absent
+	// section (nil → default 60) is distinguishable from an explicit 0 (disable
+	// caching, always fetch live).
+	IssueTTL *int `toml:"issue_ttl"`
+}
+
+// EffectiveTTL returns the cache TTL in seconds: 60 when unset, otherwise the
+// configured value (0 means caching is disabled).
+func (g GithubConfig) EffectiveTTL() int {
+	if g.IssueTTL == nil {
+		return 60
+	}
+	return *g.IssueTTL
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./model/... -run TestGithubConfigEffectiveTTL -v`
+Expected: PASS.
+
+- [ ] **Step 5: Update the JSON schema**
+
+In `sesh.schema.json`, insert a `github` property into the top-level `properties` object, immediately after the `cache` block. Replace:
+
+```json
+    "cache": {
+      "type": "boolean",
+      "description": "Enable caching for improved performance",
+      "default": false
+    },
+```
+
+with:
+
+```json
+    "cache": {
+      "type": "boolean",
+      "description": "Enable caching for improved performance",
+      "default": false
+    },
+    "github": {
+      "type": "object",
+      "description": "GitHub integration settings for the status bar",
+      "properties": {
+        "issue_ttl": {
+          "type": "integer",
+          "description": "Status cache lifetime in seconds. 0 disables caching (always fetch live).",
+          "minimum": 0,
+          "default": 60
+        }
+      },
+      "additionalProperties": false
+    },
+```
+
+- [ ] **Step 6: Verify the schema is valid JSON**
+
+Run: `python3 -c "import json; json.load(open('sesh.schema.json')); print('valid')"`
+Expected: `valid`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add model/config.go model/config_test.go sesh.schema.json
+git commit -m "feat(config): add [github] issue_ttl setting"
+```
+
+---
+
+### Task 2: `statuscache` package
+
+**Files:**
+- Create: `statuscache/statuscache.go`
+- Test: `statuscache/statuscache_test.go`
+- Regenerate: `statuscache/mock_StatusCache.go` (via `just mock`)
+
+**Interfaces:**
+- Produces:
+  - `statuscache.Ref{ Number int; Title string; State string }`
+  - `statuscache.Entry{ PR *Ref; Issue *Ref; Timestamp time.Time }` with method `(Entry) Preferred() (*Ref, bool)` — returns `PR` if non-nil, else `Issue`, else `(nil, false)`.
+  - `statuscache.StatusCache` interface: `Read(key string) (Entry, bool, error)` and `Write(key string, entry Entry) error`.
+  - `statuscache.NewFileStatusCache() *FileStatusCache` implementing `StatusCache`, storing `<dir>/<key>.gob` under `$XDG_CACHE_HOME/sesh/status/` (fallback `~/.cache/sesh/status/`).
+  - `statuscache.Key(repoRoot, branch string) string` — `sha256(repoRoot + "\x00" + branch)` hex.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `statuscache/statuscache_test.go`:
+
+```go
+package statuscache
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCache(t *testing.T) *FileStatusCache {
+	t.Helper()
+	return NewFileStatusCacheWithDir(filepath.Join(t.TempDir(), "status"))
+}
+
+func TestKeyStableAndDistinct(t *testing.T) {
+	a := Key("/repo/one", "400")
+	assert.Equal(t, a, Key("/repo/one", "400"), "same inputs => same key")
+	assert.NotEqual(t, a, Key("/repo/two", "400"), "different repo => different key")
+	assert.NotEqual(t, a, Key("/repo/one", "401"), "different branch => different key")
+}
+
+func TestWriteReadRoundTrip(t *testing.T) {
+	c := newTestCache(t)
+	entry := Entry{Issue: &Ref{Number: 400, Title: "Dynamic tmux status bar", State: "OPEN"}}
+	require.NoError(t, c.Write("k1", entry))
+
+	got, found, err := c.Read("k1")
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Nil(t, got.PR)
+	assert.Equal(t, &Ref{Number: 400, Title: "Dynamic tmux status bar", State: "OPEN"}, got.Issue)
+}
+
+func TestNegativeEntryRoundTrips(t *testing.T) {
+	c := newTestCache(t)
+	require.NoError(t, c.Write("k2", Entry{}))
+
+	got, found, err := c.Read("k2")
+	require.NoError(t, err)
+	assert.True(t, found, "negative entry is still a hit")
+	assert.Nil(t, got.PR)
+	assert.Nil(t, got.Issue)
+}
+
+func TestMissingFileIsMiss(t *testing.T) {
+	c := newTestCache(t)
+	_, found, err := c.Read("does-not-exist")
+	assert.NoError(t, err)
+	assert.False(t, found)
+}
+
+func TestCorruptFileIsMiss(t *testing.T) {
+	c := newTestCache(t)
+	require.NoError(t, c.Write("k3", Entry{Issue: &Ref{Number: 1}}))
+	// Corrupt the file on disk.
+	require.NoError(t, writeRaw(c, "k3", []byte("not gob data")))
+
+	_, found, err := c.Read("k3")
+	assert.NoError(t, err)
+	assert.False(t, found)
+}
+
+func TestPreferred(t *testing.T) {
+	pr := &Ref{Number: 401, Title: "pr", State: "OPEN"}
+	iss := &Ref{Number: 400, Title: "iss", State: "OPEN"}
+
+	got, ok := Entry{PR: pr, Issue: iss}.Preferred()
+	assert.True(t, ok)
+	assert.Equal(t, pr, got, "PR preferred over issue")
+
+	got, ok = Entry{Issue: iss}.Preferred()
+	assert.True(t, ok)
+	assert.Equal(t, iss, got)
+
+	_, ok = Entry{}.Preferred()
+	assert.False(t, ok)
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./statuscache/...`
+Expected: compile error — package `statuscache` does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `statuscache/statuscache.go`:
+
+```go
+package statuscache
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/gob"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Ref is one GitHub entity (issue or PR) as rendered in the status bar.
+type Ref struct {
+	Number int
+	Title  string
+	State  string
+}
+
+// Entry is the cached status for one branch. Both pointers may be nil (a
+// "negative" entry: the branch has nothing to show), which still counts as a
+// cache hit so the reader respects the TTL instead of refreshing every tick.
+type Entry struct {
+	PR        *Ref
+	Issue     *Ref
+	Timestamp time.Time
+}
+
+// Preferred returns the entity to render: the PR if present, otherwise the
+// issue. ok is false for a negative entry.
+func (e Entry) Preferred() (*Ref, bool) {
+	if e.PR != nil {
+		return e.PR, true
+	}
+	if e.Issue != nil {
+		return e.Issue, true
+	}
+	return nil, false
+}
+
+// StatusCache reads and writes per-branch status entries.
+type StatusCache interface {
+	Read(key string) (Entry, bool, error) // bool=found; false (nil err) on miss/corrupt
+	Write(key string, entry Entry) error
+}
+
+// Key builds the cache key (and filename stem) for a repo root + branch.
+func Key(repoRoot, branch string) string {
+	sum := sha256.Sum256([]byte(repoRoot + "\x00" + branch))
+	return hex.EncodeToString(sum[:])
+}
+
+// FileStatusCache stores one gob file per key under a directory.
+type FileStatusCache struct {
+	dir string
+}
+
+// NewFileStatusCache stores entries under $XDG_CACHE_HOME/sesh/status
+// (falling back to ~/.cache/sesh/status).
+func NewFileStatusCache() *FileStatusCache {
+	dir := os.Getenv("XDG_CACHE_HOME")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			home = "."
+		}
+		dir = filepath.Join(home, ".cache")
+	}
+	return &FileStatusCache{dir: filepath.Join(dir, "sesh", "status")}
+}
+
+// NewFileStatusCacheWithDir stores entries under an explicit directory (tests).
+func NewFileStatusCacheWithDir(dir string) *FileStatusCache {
+	return &FileStatusCache{dir: dir}
+}
+
+func (c *FileStatusCache) path(key string) string {
+	return filepath.Join(c.dir, key+".gob")
+}
+
+func (c *FileStatusCache) Read(key string) (Entry, bool, error) {
+	data, err := os.ReadFile(c.path(key))
+	if err != nil {
+		return Entry{}, false, nil // missing → miss
+	}
+	var entry Entry
+	if err := gob.NewDecoder(bytes.NewReader(data)).Decode(&entry); err != nil {
+		return Entry{}, false, nil // corrupt → miss
+	}
+	return entry, true, nil
+}
+
+func (c *FileStatusCache) Write(key string, entry Entry) error {
+	if err := os.MkdirAll(c.dir, 0o755); err != nil {
+		return err
+	}
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(entry); err != nil {
+		return err
+	}
+	tmp := c.path(key) + ".tmp"
+	if err := os.WriteFile(tmp, buf.Bytes(), 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, c.path(key))
+}
+```
+
+Add a test-only raw-write helper at the bottom of `statuscache_test.go` (it needs package-internal access to `path`):
+
+```go
+func writeRaw(c *FileStatusCache, key string, data []byte) error {
+	return os.WriteFile(c.path(key), data, 0o644)
+}
+```
+
+And add `"os"` to that test file's imports.
+
+- [ ] **Step 4: Regenerate mocks and run the tests**
+
+Run: `just mock && go test ./statuscache/... -v`
+Expected: PASS (all subtests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add statuscache/statuscache.go statuscache/statuscache_test.go
+git commit -m "feat(statuscache): add branch-keyed gob cache for status entries"
+```
+
+---
+
+### Task 3: `github.Resolve` + refactor `Issue`
+
+**Files:**
+- Modify: `github/github.go`
+- Modify: `github/github_test.go`
+- Regenerate: `github/mock_Github.go` (via `just mock`)
+
+**Interfaces:**
+- Consumes: `git.Git.CurrentBranch(path) (bool, string, error)`, `git.Git.ShowTopLevel(path) (bool, string, error)` (both existing).
+- Produces:
+  - `github.BranchRef{ RepoRoot string; Branch string; Number int; HasNumber bool }`
+  - `github.Github.Resolve(path string) (BranchRef, bool)` — `ok` is true whenever `path` is in a git repo (number optional). Added to the `Github` interface.
+  - `github.Issue` refactored to call `Resolve` (unchanged external behavior).
+
+- [ ] **Step 1: Write the failing test for `Resolve`**
+
+Add to `github/github_test.go`:
+
+```go
+func TestResolve(t *testing.T) {
+	t.Run("numeric branch resolves repo, branch, and number", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		mockGit := new(git.MockGit)
+		gh := NewGithub(mockShell, mockGit)
+		path := "/Users/josh/c/sesh"
+		mockGit.On("CurrentBranch", path).Return(true, "feat/400-status-bar", nil)
+		mockGit.On("ShowTopLevel", path).Return(true, "/Users/josh/c/sesh", nil)
+
+		ref, ok := gh.Resolve(path)
+
+		assert.True(t, ok)
+		assert.Equal(t, BranchRef{RepoRoot: "/Users/josh/c/sesh", Branch: "feat/400-status-bar", Number: 400, HasNumber: true}, ref)
+	})
+
+	t.Run("non-numeric branch resolves with HasNumber false", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		mockGit := new(git.MockGit)
+		gh := NewGithub(mockShell, mockGit)
+		path := "/Users/josh/c/sesh"
+		mockGit.On("CurrentBranch", path).Return(true, "main", nil)
+		mockGit.On("ShowTopLevel", path).Return(true, "/Users/josh/c/sesh", nil)
+
+		ref, ok := gh.Resolve(path)
+
+		assert.True(t, ok)
+		assert.Equal(t, "main", ref.Branch)
+		assert.False(t, ref.HasNumber)
+		assert.Equal(t, 0, ref.Number)
+	})
+
+	t.Run("not a git repo => ok false", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		mockGit := new(git.MockGit)
+		gh := NewGithub(mockShell, mockGit)
+		path := "/tmp/x"
+		mockGit.On("CurrentBranch", path).Return(false, "", fmt.Errorf("not a git repo"))
+
+		_, ok := gh.Resolve(path)
+		assert.False(t, ok)
+	})
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `just mock && go test ./github/... -run TestResolve`
+Expected: FAIL — `gh.Resolve` undefined.
+
+- [ ] **Step 3: Add `Resolve` and refactor `Issue`**
+
+In `github/github.go`, add `strconv` to imports, add the type + method to the interface and impl, and refactor `Issue`:
+
+```go
+// BranchRef identifies the repo, branch, and (optional) issue number for a path.
+type BranchRef struct {
+	RepoRoot  string
+	Branch    string
+	Number    int
+	HasNumber bool
+}
+```
+
+Add to the `Github` interface:
+
+```go
+type Github interface {
+	Issue(path string) (Issue, bool, error)
+	// Resolve returns repo root, branch, and the issue number parsed from the
+	// branch (HasNumber=false if none). ok is false only when path is not a repo.
+	Resolve(path string) (BranchRef, bool)
+}
+```
+
+Add the implementation and refactor `Issue` (replace the existing `Issue` method):
+
+```go
+func (g *RealGithub) Resolve(path string) (BranchRef, bool) {
+	ok, branch, err := g.git.CurrentBranch(path)
+	if err != nil || !ok {
+		return BranchRef{}, false
+	}
+	topOk, repoRoot, err := g.git.ShowTopLevel(path)
+	if err != nil || !topOk {
+		return BranchRef{}, false
+	}
+	ref := BranchRef{RepoRoot: repoRoot, Branch: branch}
+	if numStr, has := parseIssueNumber(branch); has {
+		if n, err := strconv.Atoi(numStr); err == nil {
+			ref.Number = n
+			ref.HasNumber = true
+		}
+	}
+	return ref, true
+}
+
+func (g *RealGithub) Issue(path string) (Issue, bool, error) {
+	ref, ok := g.Resolve(path)
+	if !ok || !ref.HasNumber {
+		return Issue{}, false, nil
+	}
+
+	out, err := g.shell.Cmd("gh", "issue", "view", strconv.Itoa(ref.Number), "--json", "number,title,state")
+	if err != nil || out == "" {
+		return Issue{}, false, nil
+	}
+
+	var issue Issue
+	if err := json.Unmarshal([]byte(out), &issue); err != nil {
+		return Issue{}, false, nil
+	}
+	return issue, true, nil
+}
+```
+
+- [ ] **Step 4: Update existing `Issue` tests to mock `ShowTopLevel`**
+
+`Issue` now calls `Resolve`, which calls `ShowTopLevel` whenever `CurrentBranch` succeeds. In `github/github_test.go`'s `TestIssue`, add a `ShowTopLevel` expectation to every subtest where `CurrentBranch` returns `true`. For each such subtest add, right after its `CurrentBranch` mock line:
+
+```go
+		mockGit.On("ShowTopLevel", path).Return(true, "/Users/josh/c/sesh", nil)
+```
+
+This applies to: "returns the issue on success", "not found when branch has no number", "not found when gh errors", and "not found when gh returns malformed json". The "not found when not a git repo" subtest (where `CurrentBranch` returns `false`) needs no `ShowTopLevel` mock — `Resolve` returns before calling it.
+
+- [ ] **Step 5: Regenerate mocks and run the package tests**
+
+Run: `just mock && go test ./github/... -v`
+Expected: PASS (`TestResolve` + `TestParseIssueNumber` + all `TestIssue` subtests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add github/github.go github/github_test.go
+git commit -m "feat(github): add Resolve and route Issue through it"
+```
+
+---
+
+### Task 4: `refresher` package
+
+**Files:**
+- Create: `refresher/refresher.go`
+- Test: `refresher/refresher_test.go`
+- Regenerate: `refresher/mock_Refresher.go` (via `just mock`)
+
+**Interfaces:**
+- Produces:
+  - `refresher.Refresher` interface: `Spawn(path string) error`.
+  - `refresher.NewRefresher() Refresher` returning `*RealRefresher`.
+  - Internal `refreshArgs(path string) []string` — `["status", "--refresh"]`, with `path` appended only when non-empty.
+
+`RealRefresher.Spawn` launches `<self> status --refresh [path]` detached (`Setsid`) and does not wait, so it outlives the parent (tmux waits for the foreground `#(sesh status)` to exit). `Spawn` is thin glue over `os.Executable` + `exec`; the testable logic is `refreshArgs`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `refresher/refresher_test.go`:
+
+```go
+package refresher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRefreshArgs(t *testing.T) {
+	assert.Equal(t, []string{"status", "--refresh"}, refreshArgs(""))
+	assert.Equal(t, []string{"status", "--refresh", "/repo"}, refreshArgs("/repo"))
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./refresher/...`
+Expected: compile error — package `refresher` does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `refresher/refresher.go`:
+
+```go
+package refresher
+
+import (
+	"log/slog"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// Refresher launches a detached `sesh status --refresh` to repopulate the
+// status cache without blocking the caller.
+type Refresher interface {
+	// Spawn launches a detached refresh for path. An empty path lets the child
+	// resolve the directory itself (attached tmux session, then cwd).
+	Spawn(path string) error
+}
+
+type RealRefresher struct{}
+
+func NewRefresher() Refresher {
+	return &RealRefresher{}
+}
+
+func refreshArgs(path string) []string {
+	args := []string{"status", "--refresh"}
+	if path != "" {
+		args = append(args, path)
+	}
+	return args
+}
+
+func (r *RealRefresher) Spawn(path string) error {
+	self, err := os.Executable()
+	if err != nil {
+		slog.Debug("refresher: os.Executable failed", "error", err)
+		return err
+	}
+	cmd := exec.Command(self, refreshArgs(path)...)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	cmd.Stdin = nil
+	// Detach into its own session so it outlives this (foreground) process.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		slog.Debug("refresher: start failed", "error", err)
+		return err
+	}
+	// Do not Wait — release the child to run independently.
+	return cmd.Process.Release()
+}
+```
+
+- [ ] **Step 4: Regenerate mocks and run the test**
+
+Run: `just mock && go test ./refresher/... -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add refresher/refresher.go refresher/refresher_test.go
+git commit -m "feat(refresher): add detached sesh status --refresh spawner"
+```
+
+---
+
+### Task 5: Wire `StatusCache` and `Refresher` into DI
+
+**Files:**
+- Modify: `seshcli/deps.go`
+
+**Interfaces:**
+- Consumes: `statuscache.NewFileStatusCache()` (Task 2), `refresher.NewRefresher()` (Task 4).
+- Produces: `BaseDeps.StatusCache statuscache.StatusCache` and `BaseDeps.Refresher refresher.Refresher`, reachable as `deps.StatusCache` / `deps.Refresher`.
+
+> No new test — wiring is covered by the build and Tasks 6–7. Deliverable is a compiling dependency graph.
+
+- [ ] **Step 1: Add imports**
+
+In `seshcli/deps.go`, add to the import block (alphabetical):
+
+```go
+	"github.com/joshmedeski/sesh/v2/oswrap"
+	"github.com/joshmedeski/sesh/v2/pathwrap"
+	"github.com/joshmedeski/sesh/v2/picker"
+	"github.com/joshmedeski/sesh/v2/previewer"
+	"github.com/joshmedeski/sesh/v2/refresher"
+	"github.com/joshmedeski/sesh/v2/replacer"
+	"github.com/joshmedeski/sesh/v2/runtimewrap"
+	"github.com/joshmedeski/sesh/v2/shell"
+	"github.com/joshmedeski/sesh/v2/startup"
+	"github.com/joshmedeski/sesh/v2/statuscache"
+```
+
+(Place `refresher` after `previewer`/before `replacer`, and `statuscache` after `startup`, to keep alphabetical order — adjust to match the existing block.)
+
+- [ ] **Step 2: Add fields to `BaseDeps`**
+
+In the `BaseDeps` struct, after `Github github.Github`:
+
+```go
+	Github      github.Github
+	StatusCache statuscache.StatusCache
+	Refresher   refresher.Refresher
+```
+
+(Re-gofmt the struct so the field alignment is consistent.)
+
+- [ ] **Step 3: Construct and assign in `NewBaseDeps`**
+
+After `gh := github.NewGithub(sh, g)`:
+
+```go
+	gh := github.NewGithub(sh, g)
+	sc := statuscache.NewFileStatusCache()
+	rf := refresher.NewRefresher()
+```
+
+And in the returned `&BaseDeps{...}` literal, after `Github: gh,`:
+
+```go
+		Github:      gh,
+		StatusCache: sc,
+		Refresher:   rf,
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `go build ./...`
+Expected: builds with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add seshcli/deps.go
+git commit -m "feat(seshcli): wire StatusCache and Refresher into BaseDeps"
+```
+
+---
+
+### Task 6: `sesh status` cache logic + `--refresh` flag
+
+**Files:**
+- Modify: `seshcli/status.go`
+- Modify: `seshcli/status_test.go`
+
+**Interfaces:**
+- Consumes: `config.Github.EffectiveTTL()`, `deps.Github.Issue`/`Resolve`, `deps.StatusCache.Read`/`Write`, `deps.Refresher.Spawn`, `statuscache.Key`, `statuscache.Entry`/`Ref`, `formatStatus` (existing).
+- Produces (within `seshcli`):
+  - `computeStatus(deps *Deps, ttl int, path string) (output string, spawn bool)` — the pure decision: what to print and whether a refresh should be spawned.
+  - `runRefresh(deps *Deps, path string) error` — the `--refresh` handler: live fetch + cache write (always writes, even a negative entry).
+  - `toIssue(ref statuscache.Ref) github.Issue` — adapts a cache ref to the value `formatStatus` consumes.
+  - A `--refresh` bool flag and optional path arg on the `status` command.
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the body of `seshcli/status_test.go`'s imports/add new tests. Add these tests (keep the existing `TestStatusPath` and `TestFormatStatus`):
+
+```go
+func TestToIssue(t *testing.T) {
+	got := toIssue(statuscache.Ref{Number: 400, Title: "x", State: "OPEN"})
+	assert.Equal(t, github.Issue{Number: 400, Title: "x", State: "OPEN"}, got)
+}
+
+func TestComputeStatus(t *testing.T) {
+	path := "/repo"
+	ref := github.BranchRef{RepoRoot: "/repo", Branch: "400", Number: 400, HasNumber: true}
+	key := statuscache.Key("/repo", "400")
+
+	t.Run("fresh issue hit prints and does not spawn", func(t *testing.T) {
+		gh := new(github.MockGithub)
+		sc := new(statuscache.MockStatusCache)
+		gh.On("Resolve", path).Return(ref, true)
+		sc.On("Read", key).Return(statuscache.Entry{
+			Issue:     &statuscache.Ref{Number: 400, Title: "Dynamic tmux status bar", State: "OPEN"},
+			Timestamp: time.Now(),
+		}, true, nil)
+		deps := &Deps{}
+		deps.Github = gh
+		deps.StatusCache = sc
+
+		out, spawn := computeStatus(deps, 60, path)
+
+		assert.Equal(t, "#[fg=green,bold]OPEN#[default] #[fg=magenta]Issue #400#[default] Dynamic tmux status bar", out)
+		assert.False(t, spawn)
+	})
+
+	t.Run("fresh negative hit prints nothing and does not spawn", func(t *testing.T) {
+		gh := new(github.MockGithub)
+		sc := new(statuscache.MockStatusCache)
+		gh.On("Resolve", path).Return(ref, true)
+		sc.On("Read", key).Return(statuscache.Entry{Timestamp: time.Now()}, true, nil)
+		deps := &Deps{}
+		deps.Github = gh
+		deps.StatusCache = sc
+
+		out, spawn := computeStatus(deps, 60, path)
+
+		assert.Equal(t, "", out)
+		assert.False(t, spawn)
+	})
+
+	t.Run("stale hit prints and spawns", func(t *testing.T) {
+		gh := new(github.MockGithub)
+		sc := new(statuscache.MockStatusCache)
+		gh.On("Resolve", path).Return(ref, true)
+		sc.On("Read", key).Return(statuscache.Entry{
+			Issue:     &statuscache.Ref{Number: 400, Title: "T", State: "OPEN"},
+			Timestamp: time.Now().Add(-2 * time.Minute),
+		}, true, nil)
+		deps := &Deps{}
+		deps.Github = gh
+		deps.StatusCache = sc
+
+		out, spawn := computeStatus(deps, 60, path)
+
+		assert.NotEqual(t, "", out)
+		assert.True(t, spawn)
+	})
+
+	t.Run("miss prints nothing and spawns", func(t *testing.T) {
+		gh := new(github.MockGithub)
+		sc := new(statuscache.MockStatusCache)
+		gh.On("Resolve", path).Return(ref, true)
+		sc.On("Read", key).Return(statuscache.Entry{}, false, nil)
+		deps := &Deps{}
+		deps.Github = gh
+		deps.StatusCache = sc
+
+		out, spawn := computeStatus(deps, 60, path)
+
+		assert.Equal(t, "", out)
+		assert.True(t, spawn)
+	})
+
+	t.Run("ttl zero uses live Issue and never spawns", func(t *testing.T) {
+		gh := new(github.MockGithub)
+		gh.On("Issue", path).Return(github.Issue{Number: 400, Title: "T", State: "OPEN"}, true, nil)
+		deps := &Deps{}
+		deps.Github = gh
+
+		out, spawn := computeStatus(deps, 0, path)
+
+		assert.NotEqual(t, "", out)
+		assert.False(t, spawn)
+		gh.AssertNotCalled(t, "Resolve", path)
+	})
+}
+
+func TestRunRefresh(t *testing.T) {
+	path := "/repo"
+	ref := github.BranchRef{RepoRoot: "/repo", Branch: "400", Number: 400, HasNumber: true}
+	key := statuscache.Key("/repo", "400")
+
+	t.Run("writes issue entry on success", func(t *testing.T) {
+		gh := new(github.MockGithub)
+		sc := new(statuscache.MockStatusCache)
+		gh.On("Resolve", path).Return(ref, true)
+		gh.On("Issue", path).Return(github.Issue{Number: 400, Title: "T", State: "OPEN"}, true, nil)
+		sc.On("Write", key, mock.MatchedBy(func(e statuscache.Entry) bool {
+			return e.Issue != nil && e.Issue.Number == 400 && e.PR == nil
+		})).Return(nil)
+		deps := &Deps{}
+		deps.Github = gh
+		deps.StatusCache = sc
+
+		assert.NoError(t, runRefresh(deps, path))
+		sc.AssertExpectations(t)
+	})
+
+	t.Run("writes negative entry when no issue", func(t *testing.T) {
+		gh := new(github.MockGithub)
+		sc := new(statuscache.MockStatusCache)
+		gh.On("Resolve", path).Return(github.BranchRef{RepoRoot: "/repo", Branch: "main"}, true)
+		sc.On("Write", statuscache.Key("/repo", "main"), mock.MatchedBy(func(e statuscache.Entry) bool {
+			return e.Issue == nil && e.PR == nil
+		})).Return(nil)
+		deps := &Deps{}
+		deps.Github = gh
+		deps.StatusCache = sc
+
+		assert.NoError(t, runRefresh(deps, path))
+		sc.AssertExpectations(t)
+	})
+
+	t.Run("not a repo writes nothing", func(t *testing.T) {
+		gh := new(github.MockGithub)
+		sc := new(statuscache.MockStatusCache)
+		gh.On("Resolve", path).Return(github.BranchRef{}, false)
+		deps := &Deps{}
+		deps.Github = gh
+		deps.StatusCache = sc
+
+		assert.NoError(t, runRefresh(deps, path))
+		sc.AssertNotCalled(t, "Write", mock.Anything, mock.Anything)
+	})
+}
+```
+
+Update the imports of `seshcli/status_test.go` to include `"time"`, `"github.com/joshmedeski/sesh/v2/statuscache"`, and `"github.com/stretchr/testify/mock"` (alongside the existing `github`, `assert`, etc.).
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `just mock && go test ./seshcli/... -run 'TestToIssue|TestComputeStatus|TestRunRefresh'`
+Expected: FAIL — `computeStatus`, `runRefresh`, `toIssue` undefined.
+
+- [ ] **Step 3: Implement the logic and flag in `seshcli/status.go`**
+
+Rewrite `seshcli/status.go` to:
+
+```go
+package seshcli
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/joshmedeski/sesh/v2/github"
+	"github.com/joshmedeski/sesh/v2/statuscache"
+)
+
+func NewStatusCommand(base *BaseDeps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show contextual status for the current session (for the tmux status bar)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			deps, err := buildDeps(cmd, base)
+			if err != nil {
+				return err
+			}
+
+			path := statusPath(deps)
+			if len(args) > 0 && args[0] != "" {
+				path = args[0]
+			}
+			if path == "" {
+				return nil
+			}
+
+			refresh, _ := cmd.Flags().GetBool("refresh")
+			if refresh {
+				return runRefresh(deps, path)
+			}
+
+			ttl := deps.Config.Github.EffectiveTTL()
+			out, spawn := computeStatus(deps, ttl, path)
+			if out != "" {
+				fmt.Print(out)
+			}
+			if spawn {
+				_ = deps.Refresher.Spawn(path)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().Bool("refresh", false, "Internal: fetch live data and update the status cache (used for background refresh)")
+	_ = cmd.Flags().MarkHidden("refresh")
+	return cmd
+}
+
+// statusPath resolves the directory to inspect: the attached tmux session's
+// path when running inside tmux, otherwise the current working directory.
+func statusPath(deps *Deps) string {
+	if session, exists := deps.Lister.GetAttachedTmuxSession(); exists {
+		return session.Path
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	return cwd
+}
+
+// computeStatus decides what to print and whether a background refresh should
+// be spawned. With ttl==0 the cache is bypassed and gh is queried live.
+func computeStatus(deps *Deps, ttl int, path string) (string, bool) {
+	if ttl == 0 {
+		issue, found, _ := deps.Github.Issue(path)
+		if found {
+			return formatStatus(issue), false
+		}
+		return "", false
+	}
+
+	ref, ok := deps.Github.Resolve(path)
+	if !ok {
+		return "", false
+	}
+
+	key := statuscache.Key(ref.RepoRoot, ref.Branch)
+	entry, found, _ := deps.StatusCache.Read(key)
+
+	out := ""
+	if found {
+		if r, ok := entry.Preferred(); ok {
+			out = formatStatus(toIssue(*r))
+		}
+	}
+	stale := !found || time.Since(entry.Timestamp) > time.Duration(ttl)*time.Second
+	return out, stale
+}
+
+// runRefresh performs the live gh fetch and always writes a cache entry
+// (a negative entry when there is nothing to show), so the reader respects
+// the TTL instead of re-spawning every tick.
+func runRefresh(deps *Deps, path string) error {
+	ref, ok := deps.Github.Resolve(path)
+	if !ok {
+		return nil // not a repo — nothing to cache
+	}
+
+	var entry statuscache.Entry
+	if issue, found, _ := deps.Github.Issue(path); found {
+		entry.Issue = &statuscache.Ref{Number: issue.Number, Title: issue.Title, State: issue.State}
+	}
+	entry.Timestamp = time.Now()
+	return deps.StatusCache.Write(statuscache.Key(ref.RepoRoot, ref.Branch), entry)
+}
+
+// formatStatus renders an issue as a tmux-styled status line.
+func formatStatus(issue github.Issue) string {
+	color := "green"
+	if issue.State != "OPEN" {
+		color = "red"
+	}
+	return fmt.Sprintf("#[fg=%s,bold]%s#[default] #[fg=magenta]Issue #%d#[default] %s", color, issue.State, issue.Number, issue.Title)
+}
+
+// toIssue adapts a cache Ref into the github.Issue value formatStatus consumes.
+func toIssue(ref statuscache.Ref) github.Issue {
+	return github.Issue{Number: ref.Number, Title: ref.Title, State: ref.State}
+}
+```
+
+(The `formatStatus` body is unchanged from PR #401 — it is reproduced here only because the file is being rewritten.)
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./seshcli/... -run 'TestToIssue|TestComputeStatus|TestRunRefresh|TestFormatStatus|TestStatusPath' -v`
+Expected: PASS (all subtests).
+
+- [ ] **Step 5: Verify the command still builds and registers**
+
+Run: `go build ./... && go run . status --help`
+Expected: builds; help shows the short description. `--refresh` is hidden (not listed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add seshcli/status.go seshcli/status_test.go
+git commit -m "feat(seshcli): read status from cache and refresh in the background"
+```
+
+---
+
+### Task 7: Warm the cache on `sesh connect`
+
+**Files:**
+- Modify: `seshcli/connect.go`
+- Modify/Create: `seshcli/connect_test.go`
+
+**Interfaces:**
+- Consumes: `deps.Config.Github.EffectiveTTL()`, `deps.Refresher.Spawn`.
+- Produces (within `seshcli`): `maybeWarmStatus(deps *Deps)` — spawns a path-less background refresh when caching is enabled (the child resolves the now-attached session via `statusPath`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `seshcli/connect_test.go`:
+
+```go
+package seshcli
+
+import (
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/refresher"
+)
+
+func TestMaybeWarmStatus(t *testing.T) {
+	t.Run("spawns when caching enabled", func(t *testing.T) {
+		rf := new(refresher.MockRefresher)
+		rf.On("Spawn", "").Return(nil)
+		deps := &Deps{}
+		deps.Refresher = rf
+		deps.Config = model.Config{} // IssueTTL nil → EffectiveTTL 60
+
+		maybeWarmStatus(deps)
+
+		rf.AssertExpectations(t)
+	})
+
+	t.Run("does not spawn when issue_ttl is zero", func(t *testing.T) {
+		rf := new(refresher.MockRefresher)
+		deps := &Deps{}
+		deps.Refresher = rf
+		zero := 0
+		deps.Config = model.Config{Github: model.GithubConfig{IssueTTL: &zero}}
+
+		maybeWarmStatus(deps)
+
+		rf.AssertNotCalled(t, "Spawn", "")
+	})
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `just mock && go test ./seshcli/... -run TestMaybeWarmStatus`
+Expected: FAIL — `maybeWarmStatus` undefined.
+
+- [ ] **Step 3: Add the helper and call it from connect**
+
+In `seshcli/connect.go`, add the helper (above or below `NewConnectCommand`):
+
+```go
+// maybeWarmStatus spawns a background status refresh after a connect so the
+// status bar is warm before its first render. The child resolves the
+// (now-attached) session path itself. No-op when caching is disabled.
+func maybeWarmStatus(deps *Deps) {
+	if deps.Config.Github.EffectiveTTL() == 0 {
+		return
+	}
+	_ = deps.Refresher.Spawn("")
+}
+```
+
+And call it after the existing post-connect cache refresh block (right before `return nil` at the end of `RunE`):
+
+```go
+		// Refresh cache in background so next sesh list has fresh data
+		if deps.CachingLister != nil {
+			deps.CachingLister.RefreshCache(lister.ListOptions{})
+			deps.CachingLister.Wait()
+		}
+		maybeWarmStatus(deps)
+		return nil
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./seshcli/... -run TestMaybeWarmStatus -v`
+Expected: PASS (both subtests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add seshcli/connect.go seshcli/connect_test.go
+git commit -m "feat(seshcli): warm the status cache on connect"
+```
+
+---
+
+### Final verification
+
+- [ ] **Run the full suite**
+
+Run: `just test`
+Expected: mocks regenerate; all packages pass with `-race`, including `model`, `statuscache`, `github`, `refresher`, and `seshcli`.
+
+- [ ] **Manual smoke test (this repo is on branch `400`)**
+
+```bash
+go build -o /tmp/sesh-cache-test .
+rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/sesh/status"
+/tmp/sesh-cache-test status        # cold: prints nothing, spawns a refresh
+sleep 2
+/tmp/sesh-cache-test status        # warm: prints the magenta "Issue #400" badge instantly
+```
+
+Expected: the first call is silent (cold miss, background refresh kicked off); after a moment the cache file exists under `…/sesh/status/` and the second call prints the formatted badge with no network wait. (Requires `gh` authenticated; otherwise both print nothing.)

--- a/docs/superpowers/specs/2026-06-27-sesh-status-design.md
+++ b/docs/superpowers/specs/2026-06-27-sesh-status-design.md
@@ -1,0 +1,121 @@
+# `sesh status` — Dynamic tmux status bar (MVP)
+
+Issue: [#400](https://github.com/joshmedeski/sesh/issues/400)
+Date: 2026-06-27
+
+## Goal
+
+Add a `sesh status` command that prints the GitHub issue title associated with the
+current session's git branch. It is designed to be embedded in a tmux status bar:
+
+```sh
+set -g status-left "#[fg=blue,bold]#S #[fg=white,nobold]#(sesh status)"
+```
+
+This is the MVP slice of the larger "dynamic tmux status bar" vision (gitmux-inspired).
+Only the GitHub issue title is in scope here.
+
+## Behavior
+
+- Resolve the directory for the current session.
+- Determine the git branch of that directory.
+- Parse the first run of digits out of the branch name as an issue number
+  (e.g. `feat/400-status-bar` → `400`, `400` → `400`, `bugfix/issue-12` → `12`).
+- Look up the issue title via the `gh` CLI: `gh issue view <n> --json title -q .title`.
+- Print the title to stdout.
+
+### No-result behavior
+
+Print nothing and exit `0` for **every** "nothing to show" case:
+
+- branch name contains no number
+- directory is not a git repository
+- `gh` is not installed or not authenticated
+- the issue does not exist
+
+This keeps `#(sesh status)` visually blank rather than leaking error text into the
+status bar.
+
+## Architecture
+
+Follows existing repo conventions: each external tool is wrapped behind an interface
+that depends on `shell.Shell`, and dependencies are wired in `seshcli/deps.go`.
+
+### 1. `git` package — add `CurrentBranch`
+
+Add to the existing `git.Git` interface:
+
+```go
+CurrentBranch(path string) (bool, string, error)
+```
+
+Implementation runs `git -C <path> rev-parse --abbrev-ref HEAD`. Mirrors the existing
+`ShowTopLevel` / `GitCommonDir` methods. Mock regenerated via `just mock`.
+
+### 2. New `github` package (`github/github.go`)
+
+```go
+type Github interface {
+    IssueTitle(path string) (string, error)
+}
+
+type RealGithub struct {
+    shell shell.Shell
+    git   git.Git
+}
+
+func NewGithub(shell shell.Shell, git git.Git) Github
+```
+
+`IssueTitle` flow:
+
+1. `git.CurrentBranch(path)` → branch.
+2. `parseIssueNumber(branch) (string, bool)` — pure helper, extracts the first
+   contiguous run of digits. Unit-testable in isolation.
+3. `gh issue view <n> --json title -q .title` via `shell.Cmd`.
+4. Return the trimmed title.
+
+Returns `("", nil)` for all no-result cases above — graceful, never an error the
+caller has to suppress.
+
+### 3. `sesh status` command (`seshcli/status.go`)
+
+```go
+func NewStatusCommand(base *BaseDeps) *cobra.Command
+```
+
+- Build deps via `buildDeps`.
+- Resolve path: `deps.Lister.GetAttachedTmuxSession()` (same approach as `sesh root`);
+  fall back to `os.Getwd()` when not attached to a tmux session.
+- `title, _ := deps.Github.IssueTitle(path)` — error intentionally ignored.
+- `fmt.Print(title)`; return `nil`.
+
+Registered in `seshcli/root_command.go` alongside the other commands.
+
+### Dependency injection
+
+`github` is config-free, so it joins `BaseDeps`:
+
+- Add `Github github.Github` field to `BaseDeps`.
+- Wire `github.NewGithub(sh, g)` in `NewBaseDeps()`.
+
+## Testing
+
+- `parseIssueNumber` — table test: plain number, prefixed/suffixed branch, no number,
+  multiple number groups (takes the first).
+- `github.IssueTitle` — against mocked `shell.Shell` + `git.Git`: success path,
+  no-number branch (empty, no shell call), `gh` error (empty), not-a-repo (empty).
+- Run `just test` (regenerates mocks, runs with coverage + race) before completion.
+
+## README
+
+Add a "tmux status bar" section under usage documenting the `status-left` snippet,
+the `gh` install + auth requirement, and the current behavior (issue title matching
+the branch number).
+
+## Out of scope (deferred, tracked in #400)
+
+- Pull request titles and draft/open/merged/closed state.
+- GitHub issue open/closed state.
+- Claude Code / Pi conversation titles and state.
+- User configuration of priority/format.

--- a/docs/superpowers/specs/2026-06-27-sesh-status-design.md
+++ b/docs/superpowers/specs/2026-06-27-sesh-status-design.md
@@ -13,7 +13,7 @@ set -g status-left "#[fg=blue,bold]#S #[fg=white,nobold]#(sesh status)"
 ```
 
 This is the MVP slice of the larger "dynamic tmux status bar" vision (gitmux-inspired).
-Only the GitHub issue title is in scope here.
+The GitHub issue **title and open/closed state** are in scope here.
 
 ## Behavior
 
@@ -21,8 +21,22 @@ Only the GitHub issue title is in scope here.
 - Determine the git branch of that directory.
 - Parse the first run of digits out of the branch name as an issue number
   (e.g. `feat/400-status-bar` → `400`, `400` → `400`, `bugfix/issue-12` → `12`).
-- Look up the issue title via the `gh` CLI: `gh issue view <n> --json title -q .title`.
-- Print the title to stdout.
+- Look up the issue via the `gh` CLI: `gh issue view <n> --json number,title,state`.
+- Format and print a tmux-styled status line to stdout (see Output format).
+
+### Output format
+
+The status line uses **tmux format markup** (`#[fg=…]` … `#[default]`), which tmux
+re-interprets in `#()` output — the same mechanism gitmux relies on. (ANSI escape
+codes, as used by the `icon` package for the picker, do **not** render in the status
+bar, so they are not used here.)
+
+A leading colored state badge is always shown, followed by `#<number> <title>`:
+
+```
+OPEN:    #[fg=green,bold]OPEN#[default] #400 Dynamic tmux status bar
+CLOSED:  #[fg=red,bold]CLOSED#[default] #400 Dynamic tmux status bar
+```
 
 ### No-result behavior
 
@@ -55,8 +69,14 @@ Implementation runs `git -C <path> rev-parse --abbrev-ref HEAD`. Mirrors the exi
 ### 2. New `github` package (`github/github.go`)
 
 ```go
+type Issue struct {
+    Number int    `json:"number"`
+    Title  string `json:"title"`
+    State  string `json:"state"` // "OPEN" | "CLOSED"
+}
+
 type Github interface {
-    IssueTitle(path string) (string, error)
+    Issue(path string) (Issue, bool, error) // bool = found
 }
 
 type RealGithub struct {
@@ -67,16 +87,18 @@ type RealGithub struct {
 func NewGithub(shell shell.Shell, git git.Git) Github
 ```
 
-`IssueTitle` flow:
+`Issue` flow:
 
 1. `git.CurrentBranch(path)` → branch.
 2. `parseIssueNumber(branch) (string, bool)` — pure helper, extracts the first
    contiguous run of digits. Unit-testable in isolation.
-3. `gh issue view <n> --json title -q .title` via `shell.Cmd`.
-4. Return the trimmed title.
+3. `gh issue view <n> --json number,title,state` via `shell.Cmd`.
+4. Unmarshal the JSON into `Issue` with `encoding/json` and return `(issue, true, nil)`.
 
-Returns `("", nil)` for all no-result cases above — graceful, never an error the
-caller has to suppress.
+Returns `(Issue{}, false, nil)` for all no-result cases above — graceful, never an
+error the caller has to suppress. Returning a struct (rather than a bare title) keeps
+the API open to additional fields later (labels, assignee, PR data) without reshaping
+the signature.
 
 ### 3. `sesh status` command (`seshcli/status.go`)
 
@@ -87,8 +109,13 @@ func NewStatusCommand(base *BaseDeps) *cobra.Command
 - Build deps via `buildDeps`.
 - Resolve path: `deps.Lister.GetAttachedTmuxSession()` (same approach as `sesh root`);
   fall back to `os.Getwd()` when not attached to a tmux session.
-- `title, _ := deps.Github.IssueTitle(path)` — error intentionally ignored.
-- `fmt.Print(title)`; return `nil`.
+- `issue, found, _ := deps.Github.Issue(path)` — error intentionally ignored.
+- If `!found`, print nothing and return `nil`.
+- Otherwise `fmt.Print(formatStatus(issue))`; return `nil`.
+
+`formatStatus(issue Issue) string` is a small pure helper in the `seshcli` package
+(unit-testable) that builds the tmux-styled line. The badge color is green for
+`OPEN`, red for `CLOSED` (red for any non-`OPEN` state, defensively).
 
 Registered in `seshcli/root_command.go` alongside the other commands.
 
@@ -103,19 +130,21 @@ Registered in `seshcli/root_command.go` alongside the other commands.
 
 - `parseIssueNumber` — table test: plain number, prefixed/suffixed branch, no number,
   multiple number groups (takes the first).
-- `github.IssueTitle` — against mocked `shell.Shell` + `git.Git`: success path,
-  no-number branch (empty, no shell call), `gh` error (empty), not-a-repo (empty).
+- `github.Issue` — against mocked `shell.Shell` + `git.Git`: success path (JSON →
+  struct), no-number branch (`found=false`, no shell call), `gh` error
+  (`found=false`), not-a-repo (`found=false`), malformed JSON (`found=false`).
+- `formatStatus` — open → green `OPEN` badge; closed → red `CLOSED` badge; non-`OPEN`
+  state → red badge.
 - Run `just test` (regenerates mocks, runs with coverage + race) before completion.
 
 ## README
 
 Add a "tmux status bar" section under usage documenting the `status-left` snippet,
-the `gh` install + auth requirement, and the current behavior (issue title matching
-the branch number).
+the `gh` install + auth requirement, and the current behavior (state badge + issue
+number + title matching the branch number).
 
 ## Out of scope (deferred, tracked in #400)
 
 - Pull request titles and draft/open/merged/closed state.
-- GitHub issue open/closed state.
 - Claude Code / Pi conversation titles and state.
 - User configuration of priority/format.

--- a/docs/superpowers/specs/2026-06-27-status-cache-design.md
+++ b/docs/superpowers/specs/2026-06-27-status-cache-design.md
@@ -1,0 +1,253 @@
+# Cache GitHub issue title/state for `sesh status`
+
+Follow-up to: [#400](https://github.com/joshmedeski/sesh/issues/400) / PR #401
+Date: 2026-06-27
+
+## Problem
+
+`sesh status` runs `gh issue view` (a network round-trip, typically 200ms–1s+)
+synchronously every time the tmux status line refreshes. tmux re-runs `#()`
+status commands on the `status-interval` timer (default 15s; this user runs `3`)
+and forces a status refresh on session switch/attach. The result is a visible
+delay when switching sessions and repeated `gh` calls (≈20/min/session at
+`status-interval 3`), which also risks GitHub API rate-limit throttling.
+
+## Goal
+
+Make `sesh status` read from a local cache so every render is a sub-millisecond
+file read, while a detached background process keeps the cache fresh by calling
+`gh`. The `gh` call never blocks a tmux redraw.
+
+## Behavior overview
+
+- `sesh status` resolves path → branch → issue number (all local, cheap), then
+  reads the cache entry for that issue and prints the formatted badge
+  immediately. It never calls `gh` itself.
+- Whenever the entry is missing or older than `issue_ttl`, `sesh status` spawns
+  a detached `sesh status --refresh <path>` child that performs the live `gh`
+  fetch and writes the cache, then the parent exits without waiting.
+- `sesh connect` spawns the same detached refresh for the connected session's
+  path, so the entry is warm before the first redraw after a switch.
+- This is stale-while-revalidate: renders are always instant; data is at most
+  `issue_ttl` seconds plus one refresh stale.
+
+## Configuration — new `[github]` section
+
+Added to `sesh.toml`:
+
+```toml
+[github]
+issue_ttl = 60   # seconds; default 60. 0 = disable caching (always fetch live)
+```
+
+In `model/config.go`, mirroring the existing nested-section pattern (`TUI
+TUIConfig` / `DefaultSessionConfig`):
+
+```go
+type Config struct {
+    // ... existing fields ...
+    Github GithubConfig `toml:"github"`
+}
+
+type GithubConfig struct {
+    IssueTTL *int `toml:"issue_ttl"` // pointer: distinguishes absent from explicit 0
+}
+```
+
+`IssueTTL` is a `*int` to disambiguate three states that a plain `int` cannot,
+because an absent section and an explicit `issue_ttl = 0` both decode to the
+Go zero value:
+
+- `nil` (section or key absent) → effective TTL **60** (default).
+- `0` (explicit `issue_ttl = 0`) → cache **disabled**: `sesh status` skips the
+  cache read and performs a live `gh` fetch inline (today's behavior), and
+  `sesh connect` performs no warm.
+- `N > 0` → effective TTL `N` seconds.
+
+A single helper `config.Github.EffectiveTTL() int` (returns 60 for nil,
+otherwise the value) centralizes this so command code never dereferences the
+pointer directly. `EffectiveTTL() == 0` is the "disabled" check.
+- `sesh.schema.json` gains a matching `github` object with `issue_ttl`
+  (integer, default 60) so TOML editors autocomplete it. (See the
+  `config-schema-sync` skill — schema must stay in lockstep with the struct.)
+
+## Storage — new `statuscache` package
+
+A new package `statuscache/` storing one gob file per cache key under
+`$XDG_CACHE_HOME/sesh/status/` (falling back to `~/.cache/sesh/status/`),
+mirroring `cache.FileCache`'s XDG resolution and atomic tmp+rename write.
+
+```go
+type Entry struct {
+    Number    int
+    Title     string
+    State     string
+    Timestamp time.Time
+}
+
+type StatusCache interface {
+    Read(key string) (Entry, bool, error) // bool=found (false on missing/corrupt)
+    Write(key string, entry Entry) error
+}
+
+// Key builds the cache key (and on-disk filename stem) for a repo+issue.
+func Key(repoRoot string, number int) string
+```
+
+- **Key:** `sha256(repoRoot + "#" + strconv.Itoa(number))` hex-encoded, used as
+  the filename (`<hash>.gob`). Keying on repo root + issue number (not branch)
+  means two branches pointing at the same issue share an entry and the same
+  branch name across different repos/worktrees never collides.
+- **One file per key** so concurrent refreshes from different sessions never
+  write the same file — no locking, no last-writer-wins clobbering.
+- A read error (missing file, decode failure) returns `(Entry{}, false, nil)` —
+  treated as a cache miss, never surfaced as an error to the status bar.
+- The directory is created on first write (`os.MkdirAll`).
+
+`repoRoot` is obtained from the existing `git` package (`ShowTopLevel` /
+`GitCommonDir`), so the key is stable across subdirectories of a repo.
+
+## The refresh entrypoint
+
+`sesh status` gains a hidden boolean flag `--refresh`. When set, the command:
+
+1. Resolves path → branch → issue number (reusing the existing logic).
+2. Calls `deps.Github.Issue(path)` (the live `gh` path).
+3. On success, writes the `statuscache` entry for the key and prints nothing.
+4. On any failure (no number, gh missing/unauthenticated, not found, etc.),
+   writes nothing and prints nothing — the existing graceful-empty contract.
+
+This is the only code path that invokes `gh`. It runs synchronously *within the
+detached child*, so it can take as long as the network needs without affecting
+any tmux redraw.
+
+### Spawning detached refreshes
+
+A small injectable component spawns the refresh child detached from the parent
+so it outlives the parent process (required because tmux waits for the
+foreground `#(sesh status)` process to exit):
+
+```go
+type Refresher interface {
+    Spawn(path string) error // launches `sesh status --refresh <path>` detached
+}
+```
+
+Implementation uses `os.Executable()` for the binary path and
+`exec.Command(self, "status", "--refresh", path)` with `SysProcAttr{Setsid:
+true}` and no waiting (the parent does not call `Wait`). Stdout/stderr are
+discarded. Spawn failures are logged via `slog` and otherwise ignored — a failed
+spawn just means the cache stays stale until the next tick.
+
+`Refresher` is wired into `BaseDeps` (config-free) so both the status command
+and the connect command can use it. Behind the interface, tests assert a spawn
+was requested without launching a process.
+
+## Data flow
+
+### `sesh status` (no `--refresh`)
+
+```
+ttl := config.Github.EffectiveTTL()   // 60 when unset
+path := statusPath(deps)               // existing helper
+if path == "" { return nil }
+
+if ttl == 0 {                          // cache disabled
+    issue, found, _ := deps.Github.Issue(path)   // live fetch (today's path)
+    if found { print(formatStatus(issue)) }
+    return nil
+}
+
+ref, ok := deps.Github.Resolve(path)   // local: {RepoRoot, Number}; ok=false if none
+if !ok { return nil }                  // nothing to show
+
+key := statuscache.Key(ref.RepoRoot, ref.Number)
+entry, found, _ := deps.StatusCache.Read(key)
+if found {
+    print(formatStatus(github.Issue{
+        Number: entry.Number, Title: entry.Title, State: entry.State,
+    }))
+}
+if !found || time.Since(entry.Timestamp) > time.Duration(ttl)*time.Second {
+    deps.Refresher.Spawn(path)         // detached; never blocks
+}
+return nil
+```
+
+To avoid duplicating the branch→number→repoRoot parsing that currently lives
+inside `github.Issue`, the `github` package exposes it as a reusable method:
+
+```go
+type IssueRef struct {
+    RepoRoot string
+    Number   int
+}
+
+// Resolve returns the repo root and issue number for the branch at path.
+// ok is false when path is not a repo or the branch has no issue number.
+Resolve(path string) (ref IssueRef, ok bool)
+```
+
+`github.Issue` is refactored to call `Resolve` internally (then `gh issue
+view`), so the parsing exists in exactly one place. `statuscache.Key(repoRoot
+string, number int) string` builds the hashed key. `formatStatus` is unchanged
+(the magenta `Issue #<n>` format from PR #401); the cache `Entry` is converted to
+a `github.Issue` inline in the `seshcli` command (which already imports both
+packages), keeping `statuscache` free of any dependency on `github`.
+
+### `sesh connect` (warm-on-switch)
+
+After a successful connect/switch, and only when `issue_ttl != 0`:
+
+```go
+deps.Refresher.Spawn(connectedPath)
+```
+
+Fire-and-forget, added alongside the existing background
+`CachingLister.RefreshCache` call. Never blocks the connect.
+
+## Error handling
+
+- gh/network/not-found failures during refresh: cache untouched, nothing
+  printed. Identical to the current contract.
+- Corrupt or unreadable cache file: treated as a miss.
+- Spawn failure: logged at debug, ignored; cache self-heals on a later tick.
+- `issue_ttl = 0`: cache bypassed entirely, restoring pre-cache live behavior.
+
+## Testing
+
+- **`statuscache`:** write→read round-trip; missing file → `(_, false, nil)`;
+  corrupt file → `(_, false, nil)`; key hashing is stable and collision-free for
+  distinct repo/number pairs; write creates the directory.
+- **`github.Resolve`:** mocked `git.Git` → returns `{RepoRoot, Number}` for a
+  numeric branch; `ok=false` for a non-repo path or a branch with no number.
+  (`github.Issue` tests continue to pass via the refactor.)
+- **`config.EffectiveTTL`:** nil → 60; explicit 0 → 0; explicit N → N.
+- **`--refresh` path:** with mocked `github.Github` + `statuscache`, a successful
+  `Issue` writes the expected `Entry`; a not-found/error `Issue` writes nothing.
+- **`sesh status` decision logic** (mocked `StatusCache` + `Refresher`):
+  - fresh hit → prints, no spawn
+  - stale hit → prints, spawns
+  - miss → prints nothing, spawns
+  - `issue_ttl = 0` → no cache read, live `Github.Issue` used
+- **`sesh connect`:** spawns a refresh for the connected path when caching is
+  enabled; no spawn when `issue_ttl = 0`.
+- Run `just test` (regenerates mocks, `-race`) before completion. New interfaces
+  (`StatusCache`, `Refresher`) get mockery mocks.
+
+## Out of scope
+
+- Caching pull-request data or AI-conversation state (those features don't exist
+  yet — tracked in #400).
+- Cross-machine or shared cache.
+- A manual `sesh status --clear-cache` command (cache self-expires; can be added
+  later if needed).
+
+## Expected benefit
+
+| | Today | With cache (`issue_ttl = 60`) |
+|---|---|---|
+| Per-render cost | 1 `gh` network call (≈200ms–1s+) | 1 local gob read (sub-ms–few ms) |
+| Session switch | Blocks on `gh` | Instant (warmed on connect) |
+| `gh` calls/min/session (`status-interval 3`) | ≈20 | ≈1 |
+| Staleness | Always live | ≤ `issue_ttl` + one refresh |

--- a/docs/superpowers/specs/2026-06-27-status-cache-design.md
+++ b/docs/superpowers/specs/2026-06-27-status-cache-design.md
@@ -20,8 +20,8 @@ file read, while a detached background process keeps the cache fresh by calling
 
 ## Behavior overview
 
-- `sesh status` resolves path → branch → issue number (all local, cheap), then
-  reads the cache entry for that issue and prints the formatted badge
+- `sesh status` resolves path → repo root + branch (all local, cheap), reads the
+  cache entry **keyed on the branch**, and prints the formatted badge
   immediately. It never calls `gh` itself.
 - Whenever the entry is missing or older than `issue_ttl`, `sesh status` spawns
   a detached `sesh status --refresh <path>` child that performs the live `gh`
@@ -30,6 +30,12 @@ file read, while a detached background process keeps the cache fresh by calling
   path, so the entry is warm before the first redraw after a switch.
 - This is stale-while-revalidate: renders are always instant; data is at most
   `issue_ttl` seconds plus one refresh stale.
+
+The cache is keyed on **repo root + branch**, not the issue number. A session
+always knows its branch locally, and a branch maps to at most one PR — so
+branch-keying is what the hot path can resolve without a network call, and it is
+the foundation that makes future PR support (see *Forward compatibility* below)
+purely additive.
 
 ## Configuration — new `[github]` section
 
@@ -78,10 +84,19 @@ A new package `statuscache/` storing one gob file per cache key under
 mirroring `cache.FileCache`'s XDG resolution and atomic tmp+rename write.
 
 ```go
+// Ref is one GitHub entity (issue or PR) as rendered in the status bar.
+type Ref struct {
+    Number int
+    Title  string
+    State  string // issue: OPEN|CLOSED ; PR: OPEN|DRAFT|MERGED|CLOSED
+}
+
+// Entry is the resolved status for one branch. Both pointers may be nil
+// (a "negative" entry — branch has nothing to show — which still suppresses
+// re-spawning a refresh until the TTL expires).
 type Entry struct {
-    Number    int
-    Title     string
-    State     string
+    PR        *Ref // this branch's pull request; nil if none. Unused in the MVP.
+    Issue     *Ref // the linked issue; nil if none.
     Timestamp time.Time
 }
 
@@ -90,36 +105,46 @@ type StatusCache interface {
     Write(key string, entry Entry) error
 }
 
-// Key builds the cache key (and on-disk filename stem) for a repo+issue.
-func Key(repoRoot string, number int) string
+// Key builds the cache key (and on-disk filename stem) for a repo+branch.
+func Key(repoRoot, branch string) string
 ```
 
-- **Key:** `sha256(repoRoot + "#" + strconv.Itoa(number))` hex-encoded, used as
-  the filename (`<hash>.gob`). Keying on repo root + issue number (not branch)
-  means two branches pointing at the same issue share an entry and the same
-  branch name across different repos/worktrees never collides.
+- **Key:** `sha256(repoRoot + "\x00" + branch)` hex-encoded, used as the filename
+  (`<hash>.gob`). The NUL separator avoids any ambiguity between repo root and
+  branch. Keying on repo root + branch means each session resolves its own key
+  locally, the same branch name across different repos/worktrees never collides,
+  and multiple branches targeting the same issue each get their own entry — so
+  the cache naturally holds the several PRs of one issue (one per branch).
 - **One file per key** so concurrent refreshes from different sessions never
   write the same file — no locking, no last-writer-wins clobbering.
+- **Negative entries:** the refresh always writes an `Entry` even when the branch
+  has nothing to show (both pointers nil). Without this, a branch with no issue
+  number (and, later, no PR) would miss on every render and re-spawn a refresh
+  every tick; a negative entry makes the hot path respect the TTL instead.
 - A read error (missing file, decode failure) returns `(Entry{}, false, nil)` —
   treated as a cache miss, never surfaced as an error to the status bar.
 - The directory is created on first write (`os.MkdirAll`).
 
 `repoRoot` is obtained from the existing `git` package (`ShowTopLevel` /
-`GitCommonDir`), so the key is stable across subdirectories of a repo.
+`GitCommonDir`) and `branch` from `git.CurrentBranch`, so the key is stable
+across subdirectories of a repo.
 
 ## The refresh entrypoint
 
 `sesh status` gains a hidden boolean flag `--refresh`. When set, the command:
 
-1. Resolves path → branch → issue number (reusing the existing logic).
-2. Calls `deps.Github.Issue(path)` (the live `gh` path).
-3. On success, writes the `statuscache` entry for the key and prints nothing.
-4. On any failure (no number, gh missing/unauthenticated, not found, etc.),
-   writes nothing and prints nothing — the existing graceful-empty contract.
+1. Resolves path → repo root + branch + (optional) issue number via
+   `github.Resolve`. If `path` is not a git repo, it writes nothing and returns.
+2. If the branch has an issue number, calls `deps.Github.Issue(path)` (the live
+   `gh` path) and, on success, sets `Entry.Issue`. On a gh failure or no number,
+   `Entry.Issue` stays nil. (Future: also set `Entry.PR` from `gh pr view`.)
+3. Writes the `statuscache` entry under `Key(repoRoot, branch)` — **always**,
+   even when both refs are nil (a negative entry, per the storage rules), and
+   prints nothing.
 
 This is the only code path that invokes `gh`. It runs synchronously *within the
 detached child*, so it can take as long as the network needs without affecting
-any tmux redraw.
+any tmux redraw. Failures never propagate to the foreground status render.
 
 ### Spawning detached refreshes
 
@@ -158,15 +183,18 @@ if ttl == 0 {                          // cache disabled
     return nil
 }
 
-ref, ok := deps.Github.Resolve(path)   // local: {RepoRoot, Number}; ok=false if none
-if !ok { return nil }                  // nothing to show
+ref, ok := deps.Github.Resolve(path)   // local: {RepoRoot, Branch, Number, HasNumber}
+if !ok { return nil }                  // not a git repo → nothing to show, no spawn
 
-key := statuscache.Key(ref.RepoRoot, ref.Number)
+key := statuscache.Key(ref.RepoRoot, ref.Branch)
 entry, found, _ := deps.StatusCache.Read(key)
 if found {
-    print(formatStatus(github.Issue{
-        Number: entry.Number, Title: entry.Title, State: entry.State,
-    }))
+    // PR-first, issue-fallback. PR is always nil in the MVP.
+    switch {
+    case entry.PR != nil:    print(formatStatus(toIssue("pr", *entry.PR)))
+    case entry.Issue != nil: print(formatStatus(toIssue("issue", *entry.Issue)))
+    // both nil: negative entry → print nothing
+    }
 }
 if !found || time.Since(entry.Timestamp) > time.Duration(ttl)*time.Second {
     deps.Refresher.Spawn(path)         // detached; never blocks
@@ -174,26 +202,36 @@ if !found || time.Since(entry.Timestamp) > time.Duration(ttl)*time.Second {
 return nil
 ```
 
-To avoid duplicating the branch→number→repoRoot parsing that currently lives
+`Resolve` succeeds (`ok == true`) whenever `path` is inside a git repo, so the
+hot path can build the branch key even when the branch carries no issue number
+(the refresh will write a negative entry, suppressing re-spawns until the TTL).
+
+To avoid duplicating the repo-root/branch/number resolution that currently lives
 inside `github.Issue`, the `github` package exposes it as a reusable method:
 
 ```go
-type IssueRef struct {
-    RepoRoot string
-    Number   int
+type BranchRef struct {
+    RepoRoot  string
+    Branch    string
+    Number    int  // issue number parsed from the branch; 0 if none
+    HasNumber bool
 }
 
-// Resolve returns the repo root and issue number for the branch at path.
-// ok is false when path is not a repo or the branch has no issue number.
-Resolve(path string) (ref IssueRef, ok bool)
+// Resolve returns the repo root and branch for path, plus the issue number
+// parsed from the branch name if present. ok is false only when path is not a
+// git repo.
+Resolve(path string) (ref BranchRef, ok bool)
 ```
 
-`github.Issue` is refactored to call `Resolve` internally (then `gh issue
-view`), so the parsing exists in exactly one place. `statuscache.Key(repoRoot
-string, number int) string` builds the hashed key. `formatStatus` is unchanged
-(the magenta `Issue #<n>` format from PR #401); the cache `Entry` is converted to
-a `github.Issue` inline in the `seshcli` command (which already imports both
-packages), keeping `statuscache` free of any dependency on `github`.
+`github.Issue` is refactored to call `Resolve` internally (then `gh issue view`
+when `HasNumber`), so the parsing exists in exactly one place. `formatStatus` is
+unchanged (the magenta `Issue #<n>` / future `PR #<n>` format); `toIssue(kind,
+ref)` is a small `seshcli` helper that adapts a cache `Ref` to the
+`github.Issue` value `formatStatus` consumes — keeping `statuscache` free of any
+dependency on `github`. In the MVP `kind` is always `"issue"` and is ignored;
+it is threaded through now so that adding PR support later means only extending
+`formatStatus` to branch on `kind` (rendering `PR #<n>` with merged→purple),
+with no change to the call sites.
 
 ### `sesh connect` (warm-on-switch)
 
@@ -216,17 +254,22 @@ Fire-and-forget, added alongside the existing background
 
 ## Testing
 
-- **`statuscache`:** write→read round-trip; missing file → `(_, false, nil)`;
-  corrupt file → `(_, false, nil)`; key hashing is stable and collision-free for
-  distinct repo/number pairs; write creates the directory.
-- **`github.Resolve`:** mocked `git.Git` → returns `{RepoRoot, Number}` for a
-  numeric branch; `ok=false` for a non-repo path or a branch with no number.
+- **`statuscache`:** write→read round-trip (incl. a negative entry — both refs
+  nil — which round-trips as `found=true`); missing file → `(_, false, nil)`;
+  corrupt file → `(_, false, nil)`; `Key` is stable and collision-free for
+  distinct repo/branch pairs; write creates the directory.
+- **`github.Resolve`:** mocked `git.Git` → `{RepoRoot, Branch, Number,
+  HasNumber=true}` for a numeric branch; `{…, HasNumber=false}` for a branch with
+  no number (still `ok=true`); `ok=false` for a non-repo path.
   (`github.Issue` tests continue to pass via the refactor.)
 - **`config.EffectiveTTL`:** nil → 60; explicit 0 → 0; explicit N → N.
-- **`--refresh` path:** with mocked `github.Github` + `statuscache`, a successful
-  `Issue` writes the expected `Entry`; a not-found/error `Issue` writes nothing.
+- **`--refresh` path** (mocked `github.Github` + `statuscache`): a numeric branch
+  with a successful `Issue` writes an `Entry` with `Issue` set; a gh failure or a
+  no-number branch writes a negative `Entry` (both refs nil); a non-repo path
+  writes nothing.
 - **`sesh status` decision logic** (mocked `StatusCache` + `Refresher`):
-  - fresh hit → prints, no spawn
+  - fresh issue hit → prints, no spawn
+  - fresh negative hit → prints nothing, no spawn
   - stale hit → prints, spawns
   - miss → prints nothing, spawns
   - `issue_ttl = 0` → no cache read, live `Github.Issue` used
@@ -235,10 +278,35 @@ Fire-and-forget, added alongside the existing background
 - Run `just test` (regenerates mocks, `-race`) before completion. New interfaces
   (`StatusCache`, `Refresher`) get mockery mocks.
 
+## Forward compatibility: PR support
+
+This design is shaped so that the future PR work from #400 (PR title + number +
+draft/open/merged/closed state, with PRs taking priority over the issue, and one
+issue tracking several PRs across branches) is **purely additive** — no key
+change, no hot-path change, no cache migration:
+
+- **Branch key** already models "branch → its one PR." Each branch's session
+  reads its own entry; multiple PRs of one issue are simply multiple branch
+  entries that share an `Issue.Number`. "All PRs for issue N" is reconstructable
+  by scanning entries whose `Issue.Number == N` (not needed for rendering, but
+  available).
+- **`Entry`** already carries both `PR` and `Issue` refs; the MVP leaves `PR`
+  nil. Adding PR support means the refresh additionally runs `gh pr view --json
+  number,title,state,isDraft` for the branch and sets `Entry.PR`.
+- **Render priority** (`PR != nil` first, else `Issue`) is already in the hot
+  path. Only `formatStatus` needs extending to render `PR #<n>` and map PR
+  states (e.g. merged → purple) — the `kind` is already threaded through
+  `toIssue`.
+- Because the cache is disposable, even unforeseen `Entry` additions cost
+  nothing: old files read as misses and re-fetch.
+
+What is **not** built now: the `gh pr view` call, the PR state→color mapping, and
+the `PR #<n>` format branch. Those land with the PR feature.
+
 ## Out of scope
 
-- Caching pull-request data or AI-conversation state (those features don't exist
-  yet — tracked in #400).
+- Fetching pull-request or AI-conversation data (the storage model accommodates
+  PRs per *Forward compatibility* above, but no PR fetching is implemented here).
 - Cross-machine or shared cache.
 - A manual `sesh status --clear-cache` command (cache self-expires; can be added
   later if needed).

--- a/git/git.go
+++ b/git/git.go
@@ -9,6 +9,7 @@ type Git interface {
 	GitCommonDir(name string) (bool, string, error)
 	Clone(url string, cmdDir string, dir string) (string, error)
 	WorktreeList(name string) (bool, string, error)
+	CurrentBranch(path string) (bool, string, error)
 }
 
 type RealGit struct {
@@ -53,6 +54,14 @@ func (g *RealGit) Clone(url string, cmdDir string, dir string) (string, error) {
 
 func (g *RealGit) WorktreeList(path string) (bool, string, error) {
 	out, err := g.shell.Cmd("git", "-C", path, "worktree", "list", "--porcelain")
+	if err != nil {
+		return false, "", err
+	}
+	return true, out, nil
+}
+
+func (g *RealGit) CurrentBranch(path string) (bool, string, error) {
+	out, err := g.shell.Cmd("git", "-C", path, "rev-parse", "--abbrev-ref", "HEAD")
 	if err != nil {
 		return false, "", err
 	}

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -1,0 +1,39 @@
+package git
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/shell"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCurrentBranch(t *testing.T) {
+	t.Run("returns the branch name on success", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		g := NewGit(mockShell)
+		path := "/Users/josh/c/sesh"
+		mockShell.On("Cmd", "git", "-C", path, "rev-parse", "--abbrev-ref", "HEAD").
+			Return("400", nil)
+
+		ok, branch, err := g.CurrentBranch(path)
+
+		assert.True(t, ok)
+		assert.Equal(t, "400", branch)
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns false when not a git repo", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		g := NewGit(mockShell)
+		path := "/tmp/not-a-repo"
+		mockShell.On("Cmd", "git", "-C", path, "rev-parse", "--abbrev-ref", "HEAD").
+			Return("", fmt.Errorf("fatal: not a git repository"))
+
+		ok, branch, err := g.CurrentBranch(path)
+
+		assert.False(t, ok)
+		assert.Equal(t, "", branch)
+		assert.Error(t, err)
+	})
+}

--- a/github/github.go
+++ b/github/github.go
@@ -1,0 +1,65 @@
+package github
+
+import (
+	"encoding/json"
+	"regexp"
+
+	"github.com/joshmedeski/sesh/v2/git"
+	"github.com/joshmedeski/sesh/v2/shell"
+)
+
+// Issue is the subset of GitHub issue data sesh renders in the status bar.
+type Issue struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	State  string `json:"state"` // "OPEN" | "CLOSED"
+}
+
+type Github interface {
+	// Issue returns the GitHub issue for the branch checked out at path.
+	// The bool is false (with a nil error) for every "nothing to show" case.
+	Issue(path string) (Issue, bool, error)
+}
+
+type RealGithub struct {
+	shell shell.Shell
+	git   git.Git
+}
+
+func NewGithub(shell shell.Shell, git git.Git) Github {
+	return &RealGithub{shell, git}
+}
+
+var issueNumberRe = regexp.MustCompile(`\d+`)
+
+// parseIssueNumber returns the first run of digits in a branch name.
+func parseIssueNumber(branch string) (string, bool) {
+	match := issueNumberRe.FindString(branch)
+	if match == "" {
+		return "", false
+	}
+	return match, true
+}
+
+func (g *RealGithub) Issue(path string) (Issue, bool, error) {
+	ok, branch, err := g.git.CurrentBranch(path)
+	if err != nil || !ok {
+		return Issue{}, false, nil
+	}
+
+	number, ok := parseIssueNumber(branch)
+	if !ok {
+		return Issue{}, false, nil
+	}
+
+	out, err := g.shell.Cmd("gh", "issue", "view", number, "--json", "number,title,state")
+	if err != nil || out == "" {
+		return Issue{}, false, nil
+	}
+
+	var issue Issue
+	if err := json.Unmarshal([]byte(out), &issue); err != nil {
+		return Issue{}, false, nil
+	}
+	return issue, true, nil
+}

--- a/github/github.go
+++ b/github/github.go
@@ -3,6 +3,7 @@ package github
 import (
 	"encoding/json"
 	"regexp"
+	"strconv"
 
 	"github.com/joshmedeski/sesh/v2/git"
 	"github.com/joshmedeski/sesh/v2/shell"
@@ -15,10 +16,21 @@ type Issue struct {
 	State  string `json:"state"` // "OPEN" | "CLOSED"
 }
 
+// BranchRef identifies the repo, branch, and (optional) issue number for a path.
+type BranchRef struct {
+	RepoRoot  string
+	Branch    string
+	Number    int
+	HasNumber bool
+}
+
 type Github interface {
 	// Issue returns the GitHub issue for the branch checked out at path.
 	// The bool is false (with a nil error) for every "nothing to show" case.
 	Issue(path string) (Issue, bool, error)
+	// Resolve returns repo root, branch, and the issue number parsed from the
+	// branch (HasNumber=false if none). ok is false only when path is not a repo.
+	Resolve(path string) (BranchRef, bool)
 }
 
 type RealGithub struct {
@@ -41,18 +53,32 @@ func parseIssueNumber(branch string) (string, bool) {
 	return match, true
 }
 
-func (g *RealGithub) Issue(path string) (Issue, bool, error) {
+func (g *RealGithub) Resolve(path string) (BranchRef, bool) {
 	ok, branch, err := g.git.CurrentBranch(path)
 	if err != nil || !ok {
+		return BranchRef{}, false
+	}
+	topOk, repoRoot, err := g.git.ShowTopLevel(path)
+	if err != nil || !topOk {
+		return BranchRef{}, false
+	}
+	ref := BranchRef{RepoRoot: repoRoot, Branch: branch}
+	if numStr, has := parseIssueNumber(branch); has {
+		if n, err := strconv.Atoi(numStr); err == nil {
+			ref.Number = n
+			ref.HasNumber = true
+		}
+	}
+	return ref, true
+}
+
+func (g *RealGithub) Issue(path string) (Issue, bool, error) {
+	ref, ok := g.Resolve(path)
+	if !ok || !ref.HasNumber {
 		return Issue{}, false, nil
 	}
 
-	number, ok := parseIssueNumber(branch)
-	if !ok {
-		return Issue{}, false, nil
-	}
-
-	out, err := g.shell.Cmd("gh", "issue", "view", number, "--json", "number,title,state")
+	out, err := g.shell.Cmd("gh", "issue", "view", strconv.Itoa(ref.Number), "--json", "number,title,state")
 	if err != nil || out == "" {
 		return Issue{}, false, nil
 	}

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -1,0 +1,107 @@
+package github
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/git"
+	"github.com/joshmedeski/sesh/v2/shell"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseIssueNumber(t *testing.T) {
+	cases := []struct {
+		branch string
+		want   string
+		ok     bool
+	}{
+		{"400", "400", true},
+		{"feat/400-status-bar", "400", true},
+		{"bugfix/issue-12", "12", true},
+		{"feat/400-then-401", "400", true},
+		{"main", "", false},
+		{"", "", false},
+	}
+	for _, c := range cases {
+		got, ok := parseIssueNumber(c.branch)
+		assert.Equal(t, c.ok, ok, c.branch)
+		assert.Equal(t, c.want, got, c.branch)
+	}
+}
+
+func TestIssue(t *testing.T) {
+	t.Run("returns the issue on success", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		mockGit := new(git.MockGit)
+		gh := NewGithub(mockShell, mockGit)
+		path := "/Users/josh/c/sesh"
+		mockGit.On("CurrentBranch", path).Return(true, "feat/400-status-bar", nil)
+		mockShell.On("Cmd", "gh", "issue", "view", "400", "--json", "number,title,state").
+			Return(`{"number":400,"state":"OPEN","title":"Dynamic tmux status bar"}`, nil)
+
+		issue, found, err := gh.Issue(path)
+
+		assert.True(t, found)
+		assert.NoError(t, err)
+		assert.Equal(t, Issue{Number: 400, Title: "Dynamic tmux status bar", State: "OPEN"}, issue)
+	})
+
+	t.Run("not found when branch has no number", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		mockGit := new(git.MockGit)
+		gh := NewGithub(mockShell, mockGit)
+		path := "/Users/josh/c/sesh"
+		mockGit.On("CurrentBranch", path).Return(true, "main", nil)
+
+		issue, found, err := gh.Issue(path)
+
+		assert.False(t, found)
+		assert.NoError(t, err)
+		assert.Equal(t, Issue{}, issue)
+		// No gh call is set up on mockShell; testify panics on an
+		// unexpected call, so reaching gh would fail this test.
+	})
+
+	t.Run("not found when not a git repo", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		mockGit := new(git.MockGit)
+		gh := NewGithub(mockShell, mockGit)
+		path := "/tmp/x"
+		mockGit.On("CurrentBranch", path).Return(false, "", fmt.Errorf("not a git repo"))
+
+		_, found, err := gh.Issue(path)
+
+		assert.False(t, found)
+		assert.NoError(t, err)
+	})
+
+	t.Run("not found when gh errors", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		mockGit := new(git.MockGit)
+		gh := NewGithub(mockShell, mockGit)
+		path := "/Users/josh/c/sesh"
+		mockGit.On("CurrentBranch", path).Return(true, "400", nil)
+		mockShell.On("Cmd", "gh", "issue", "view", "400", "--json", "number,title,state").
+			Return("", fmt.Errorf("gh: not found"))
+
+		_, found, err := gh.Issue(path)
+
+		assert.False(t, found)
+		assert.NoError(t, err)
+	})
+
+	t.Run("not found when gh returns malformed json", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		mockGit := new(git.MockGit)
+		gh := NewGithub(mockShell, mockGit)
+		path := "/Users/josh/c/sesh"
+		mockGit.On("CurrentBranch", path).Return(true, "400", nil)
+		mockShell.On("Cmd", "gh", "issue", "view", "400", "--json", "number,title,state").
+			Return("not json", nil)
+
+		_, found, err := gh.Issue(path)
+
+		assert.False(t, found)
+		assert.NoError(t, err)
+	})
+}

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -29,6 +29,49 @@ func TestParseIssueNumber(t *testing.T) {
 	}
 }
 
+func TestResolve(t *testing.T) {
+	t.Run("numeric branch resolves repo, branch, and number", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		mockGit := new(git.MockGit)
+		gh := NewGithub(mockShell, mockGit)
+		path := "/Users/josh/c/sesh"
+		mockGit.On("CurrentBranch", path).Return(true, "feat/400-status-bar", nil)
+		mockGit.On("ShowTopLevel", path).Return(true, "/Users/josh/c/sesh", nil)
+
+		ref, ok := gh.Resolve(path)
+
+		assert.True(t, ok)
+		assert.Equal(t, BranchRef{RepoRoot: "/Users/josh/c/sesh", Branch: "feat/400-status-bar", Number: 400, HasNumber: true}, ref)
+	})
+
+	t.Run("non-numeric branch resolves with HasNumber false", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		mockGit := new(git.MockGit)
+		gh := NewGithub(mockShell, mockGit)
+		path := "/Users/josh/c/sesh"
+		mockGit.On("CurrentBranch", path).Return(true, "main", nil)
+		mockGit.On("ShowTopLevel", path).Return(true, "/Users/josh/c/sesh", nil)
+
+		ref, ok := gh.Resolve(path)
+
+		assert.True(t, ok)
+		assert.Equal(t, "main", ref.Branch)
+		assert.False(t, ref.HasNumber)
+		assert.Equal(t, 0, ref.Number)
+	})
+
+	t.Run("not a git repo => ok false", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		mockGit := new(git.MockGit)
+		gh := NewGithub(mockShell, mockGit)
+		path := "/tmp/x"
+		mockGit.On("CurrentBranch", path).Return(false, "", fmt.Errorf("not a git repo"))
+
+		_, ok := gh.Resolve(path)
+		assert.False(t, ok)
+	})
+}
+
 func TestIssue(t *testing.T) {
 	t.Run("returns the issue on success", func(t *testing.T) {
 		mockShell := new(shell.MockShell)
@@ -36,6 +79,7 @@ func TestIssue(t *testing.T) {
 		gh := NewGithub(mockShell, mockGit)
 		path := "/Users/josh/c/sesh"
 		mockGit.On("CurrentBranch", path).Return(true, "feat/400-status-bar", nil)
+		mockGit.On("ShowTopLevel", path).Return(true, "/Users/josh/c/sesh", nil)
 		mockShell.On("Cmd", "gh", "issue", "view", "400", "--json", "number,title,state").
 			Return(`{"number":400,"state":"OPEN","title":"Dynamic tmux status bar"}`, nil)
 
@@ -52,6 +96,7 @@ func TestIssue(t *testing.T) {
 		gh := NewGithub(mockShell, mockGit)
 		path := "/Users/josh/c/sesh"
 		mockGit.On("CurrentBranch", path).Return(true, "main", nil)
+		mockGit.On("ShowTopLevel", path).Return(true, "/Users/josh/c/sesh", nil)
 
 		issue, found, err := gh.Issue(path)
 
@@ -81,6 +126,7 @@ func TestIssue(t *testing.T) {
 		gh := NewGithub(mockShell, mockGit)
 		path := "/Users/josh/c/sesh"
 		mockGit.On("CurrentBranch", path).Return(true, "400", nil)
+		mockGit.On("ShowTopLevel", path).Return(true, "/Users/josh/c/sesh", nil)
 		mockShell.On("Cmd", "gh", "issue", "view", "400", "--json", "number,title,state").
 			Return("", fmt.Errorf("gh: not found"))
 
@@ -96,6 +142,7 @@ func TestIssue(t *testing.T) {
 		gh := NewGithub(mockShell, mockGit)
 		path := "/Users/josh/c/sesh"
 		mockGit.On("CurrentBranch", path).Return(true, "400", nil)
+		mockGit.On("ShowTopLevel", path).Return(true, "/Users/josh/c/sesh", nil)
 		mockShell.On("Cmd", "gh", "issue", "view", "400", "--json", "number,title,state").
 			Return("not json", nil)
 

--- a/model/config.go
+++ b/model/config.go
@@ -15,6 +15,7 @@ type (
 		SeparatorAware       bool                 `toml:"separator_aware"`
 		TmuxCommand          string               `toml:"tmux_command"`
 		TUI                  TUIConfig            `toml:"tui"`
+		Github               GithubConfig         `toml:"github"`
 	}
 	Evaluation struct {
 		StrictMode bool `toml:"strict_mode"`
@@ -50,6 +51,14 @@ type (
 		Placeholder string `toml:"placeholder"`
 	}
 
+	// GithubConfig holds settings for GitHub integration in the status bar.
+	GithubConfig struct {
+		// IssueTTL is the status cache lifetime in seconds. A pointer so an absent
+		// section (nil → default 60) is distinguishable from an explicit 0 (disable
+		// caching, always fetch live).
+		IssueTTL *int `toml:"issue_ttl"`
+	}
+
 	WildcardConfig struct {
 		Pattern             string   `toml:"pattern"`
 		StartupCommand      string   `toml:"startup_command"`
@@ -58,3 +67,12 @@ type (
 		Windows             []string `toml:"windows"`
 	}
 )
+
+// EffectiveTTL returns the cache TTL in seconds: 60 when unset, otherwise the
+// configured value (0 means caching is disabled).
+func (g GithubConfig) EffectiveTTL() int {
+	if g.IssueTTL == nil {
+		return 60
+	}
+	return *g.IssueTTL
+}

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -1,0 +1,23 @@
+package model
+
+import "testing"
+
+func TestGithubConfigEffectiveTTL(t *testing.T) {
+	thirty := 30
+	zero := 0
+	cases := []struct {
+		name string
+		ttl  *int
+		want int
+	}{
+		{"nil defaults to 60", nil, 60},
+		{"explicit zero disables", &zero, 0},
+		{"explicit value", &thirty, 30},
+	}
+	for _, c := range cases {
+		got := GithubConfig{IssueTTL: c.ttl}.EffectiveTTL()
+		if got != c.want {
+			t.Errorf("%s: EffectiveTTL() = %d, want %d", c.name, got, c.want)
+		}
+	}
+}

--- a/refresher/refresher.go
+++ b/refresher/refresher.go
@@ -1,0 +1,50 @@
+package refresher
+
+import (
+	"log/slog"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// Refresher launches a detached `sesh status --refresh` to repopulate the
+// status cache without blocking the caller.
+type Refresher interface {
+	// Spawn launches a detached refresh for path. An empty path lets the child
+	// resolve the directory itself (attached tmux session, then cwd).
+	Spawn(path string) error
+}
+
+type RealRefresher struct{}
+
+func NewRefresher() Refresher {
+	return &RealRefresher{}
+}
+
+func refreshArgs(path string) []string {
+	args := []string{"status", "--refresh"}
+	if path != "" {
+		args = append(args, path)
+	}
+	return args
+}
+
+func (r *RealRefresher) Spawn(path string) error {
+	self, err := os.Executable()
+	if err != nil {
+		slog.Debug("refresher: os.Executable failed", "error", err)
+		return err
+	}
+	cmd := exec.Command(self, refreshArgs(path)...)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	cmd.Stdin = nil
+	// Detach into its own session so it outlives this (foreground) process.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		slog.Debug("refresher: start failed", "error", err)
+		return err
+	}
+	// Do not Wait — release the child to run independently.
+	return cmd.Process.Release()
+}

--- a/refresher/refresher_test.go
+++ b/refresher/refresher_test.go
@@ -1,0 +1,12 @@
+package refresher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRefreshArgs(t *testing.T) {
+	assert.Equal(t, []string{"status", "--refresh"}, refreshArgs(""))
+	assert.Equal(t, []string{"status", "--refresh", "/repo"}, refreshArgs("/repo"))
+}

--- a/sesh.schema.json
+++ b/sesh.schema.json
@@ -10,6 +10,19 @@
       "description": "Enable caching for improved performance",
       "default": false
     },
+    "github": {
+      "type": "object",
+      "description": "GitHub integration settings for the status bar",
+      "properties": {
+        "issue_ttl": {
+          "type": "integer",
+          "description": "Status cache lifetime in seconds. 0 disables caching (always fetch live).",
+          "minimum": 0,
+          "default": 60
+        }
+      },
+      "additionalProperties": false
+    },
     "strict_mode": {
       "type": "boolean",
       "description": "Disallow unknown fields in the configuration file",

--- a/seshcli/connect.go
+++ b/seshcli/connect.go
@@ -10,6 +10,16 @@ import (
 	"github.com/joshmedeski/sesh/v2/model"
 )
 
+// maybeWarmStatus spawns a background status refresh after a connect so the
+// status bar is warm before its first render. The child resolves the
+// (now-attached) session path itself. No-op when caching is disabled.
+func maybeWarmStatus(deps *Deps) {
+	if deps.Config.Github.EffectiveTTL() == 0 {
+		return
+	}
+	_ = deps.Refresher.Spawn("")
+}
+
 func NewConnectCommand(base *BaseDeps) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "connect",
@@ -53,6 +63,7 @@ func NewConnectCommand(base *BaseDeps) *cobra.Command {
 				deps.CachingLister.RefreshCache(lister.ListOptions{})
 				deps.CachingLister.Wait()
 			}
+			maybeWarmStatus(deps)
 			return nil
 		},
 	}

--- a/seshcli/connect_test.go
+++ b/seshcli/connect_test.go
@@ -1,0 +1,34 @@
+package seshcli
+
+import (
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/refresher"
+)
+
+func TestMaybeWarmStatus(t *testing.T) {
+	t.Run("spawns when caching enabled", func(t *testing.T) {
+		rf := new(refresher.MockRefresher)
+		rf.On("Spawn", "").Return(nil)
+		deps := &Deps{}
+		deps.Refresher = rf
+		deps.Config = model.Config{} // IssueTTL nil → EffectiveTTL 60
+
+		maybeWarmStatus(deps)
+
+		rf.AssertExpectations(t)
+	})
+
+	t.Run("does not spawn when issue_ttl is zero", func(t *testing.T) {
+		rf := new(refresher.MockRefresher)
+		deps := &Deps{}
+		deps.Refresher = rf
+		zero := 0
+		deps.Config = model.Config{Github: model.GithubConfig{IssueTTL: &zero}}
+
+		maybeWarmStatus(deps)
+
+		rf.AssertNotCalled(t, "Spawn", "")
+	})
+}

--- a/seshcli/deps.go
+++ b/seshcli/deps.go
@@ -26,10 +26,12 @@ import (
 	"github.com/joshmedeski/sesh/v2/pathwrap"
 	"github.com/joshmedeski/sesh/v2/picker"
 	"github.com/joshmedeski/sesh/v2/previewer"
+	"github.com/joshmedeski/sesh/v2/refresher"
 	"github.com/joshmedeski/sesh/v2/replacer"
 	"github.com/joshmedeski/sesh/v2/runtimewrap"
 	"github.com/joshmedeski/sesh/v2/shell"
 	"github.com/joshmedeski/sesh/v2/startup"
+	"github.com/joshmedeski/sesh/v2/statuscache"
 	"github.com/joshmedeski/sesh/v2/tmux"
 	"github.com/joshmedeski/sesh/v2/tmuxinator"
 	"github.com/joshmedeski/sesh/v2/zoxide"
@@ -37,19 +39,21 @@ import (
 
 // BaseDeps holds config-free dependencies that can be constructed eagerly.
 type BaseDeps struct {
-	Exec       execwrap.Exec
-	Os         oswrap.Os
-	Path       pathwrap.Path
-	Runtime    runtimewrap.Runtime
-	Home       home.Home
-	Shell      shell.Shell
-	Json       json.Json
-	Replacer   replacer.Replacer
-	Git        git.Git
-	Github     github.Github
-	Dir        dir.Dir
-	Zoxide     zoxide.Zoxide
-	Tmuxinator tmuxinator.Tmuxinator
+	Exec        execwrap.Exec
+	Os          oswrap.Os
+	Path        pathwrap.Path
+	Runtime     runtimewrap.Runtime
+	Home        home.Home
+	Shell       shell.Shell
+	Json        json.Json
+	Replacer    replacer.Replacer
+	Git         git.Git
+	Github      github.Github
+	Dir         dir.Dir
+	Zoxide      zoxide.Zoxide
+	Tmuxinator  tmuxinator.Tmuxinator
+	StatusCache statuscache.StatusCache
+	Refresher   refresher.Refresher
 }
 
 // Deps holds all dependencies including config-dependent ones.
@@ -85,21 +89,25 @@ func NewBaseDeps() *BaseDeps {
 	d := dir.NewDir(os, g, path)
 	z := zoxide.NewZoxide(sh)
 	ti := tmuxinator.NewTmuxinator(sh)
+	sc := statuscache.NewFileStatusCache()
+	rf := refresher.NewRefresher()
 
 	return &BaseDeps{
-		Exec:       exec,
-		Os:         os,
-		Path:       path,
-		Runtime:    runtime,
-		Home:       h,
-		Shell:      sh,
-		Json:       j,
-		Replacer:   r,
-		Git:        g,
-		Github:     gh,
-		Dir:        d,
-		Zoxide:     z,
-		Tmuxinator: ti,
+		Exec:        exec,
+		Os:          os,
+		Path:        path,
+		Runtime:     runtime,
+		Home:        h,
+		Shell:       sh,
+		Json:        j,
+		Replacer:    r,
+		Git:         g,
+		Github:      gh,
+		Dir:         d,
+		Zoxide:      z,
+		Tmuxinator:  ti,
+		StatusCache: sc,
+		Refresher:   rf,
 	}
 }
 

--- a/seshcli/deps.go
+++ b/seshcli/deps.go
@@ -14,6 +14,7 @@ import (
 	"github.com/joshmedeski/sesh/v2/dir"
 	"github.com/joshmedeski/sesh/v2/execwrap"
 	"github.com/joshmedeski/sesh/v2/git"
+	"github.com/joshmedeski/sesh/v2/github"
 	"github.com/joshmedeski/sesh/v2/home"
 	"github.com/joshmedeski/sesh/v2/icon"
 	"github.com/joshmedeski/sesh/v2/json"
@@ -45,6 +46,7 @@ type BaseDeps struct {
 	Json       json.Json
 	Replacer   replacer.Replacer
 	Git        git.Git
+	Github     github.Github
 	Dir        dir.Dir
 	Zoxide     zoxide.Zoxide
 	Tmuxinator tmuxinator.Tmuxinator
@@ -79,6 +81,7 @@ func NewBaseDeps() *BaseDeps {
 	r := replacer.NewReplacer()
 
 	g := git.NewGit(sh)
+	gh := github.NewGithub(sh, g)
 	d := dir.NewDir(os, g, path)
 	z := zoxide.NewZoxide(sh)
 	ti := tmuxinator.NewTmuxinator(sh)
@@ -93,6 +96,7 @@ func NewBaseDeps() *BaseDeps {
 		Json:       j,
 		Replacer:   r,
 		Git:        g,
+		Github:     gh,
 		Dir:        d,
 		Zoxide:     z,
 		Tmuxinator: ti,

--- a/seshcli/root_command.go
+++ b/seshcli/root_command.go
@@ -23,6 +23,7 @@ func NewRootCommand(version string) *cobra.Command {
 		NewConnectCommand(base),
 		NewCloneCommand(base),
 		NewRootSessionCommand(base),
+		NewStatusCommand(base),
 		NewPreviewCommand(base),
 		NewPickerCommand(base),
 		NewWindowCommand(base),

--- a/seshcli/status.go
+++ b/seshcli/status.go
@@ -54,5 +54,5 @@ func formatStatus(issue github.Issue) string {
 	if issue.State != "OPEN" {
 		color = "red"
 	}
-	return fmt.Sprintf("#[fg=%s,bold]%s#[default] #%d %s", color, issue.State, issue.Number, issue.Title)
+	return fmt.Sprintf("#[fg=%s,bold]%s#[default] #[fg=magenta]Issue #%d#[default] %s", color, issue.State, issue.Number, issue.Title)
 }

--- a/seshcli/status.go
+++ b/seshcli/status.go
@@ -3,14 +3,16 @@ package seshcli
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/joshmedeski/sesh/v2/github"
+	"github.com/joshmedeski/sesh/v2/statuscache"
 )
 
 func NewStatusCommand(base *BaseDeps) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Show contextual status for the current session (for the tmux status bar)",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -20,19 +22,32 @@ func NewStatusCommand(base *BaseDeps) *cobra.Command {
 			}
 
 			path := statusPath(deps)
+			if len(args) > 0 && args[0] != "" {
+				path = args[0]
+			}
 			if path == "" {
 				return nil
 			}
 
-			issue, found, _ := deps.Github.Issue(path)
-			if !found {
-				return nil
+			refresh, _ := cmd.Flags().GetBool("refresh")
+			if refresh {
+				return runRefresh(deps, path)
 			}
 
-			fmt.Print(formatStatus(issue))
+			ttl := deps.Config.Github.EffectiveTTL()
+			out, spawn := computeStatus(deps, ttl, path)
+			if out != "" {
+				fmt.Print(out)
+			}
+			if spawn {
+				_ = deps.Refresher.Spawn(path)
+			}
 			return nil
 		},
 	}
+	cmd.Flags().Bool("refresh", false, "Internal: fetch live data and update the status cache (used for background refresh)")
+	_ = cmd.Flags().MarkHidden("refresh")
+	return cmd
 }
 
 // statusPath resolves the directory to inspect: the attached tmux session's
@@ -48,6 +63,54 @@ func statusPath(deps *Deps) string {
 	return cwd
 }
 
+// computeStatus decides what to print and whether a background refresh should
+// be spawned. With ttl==0 the cache is bypassed and gh is queried live.
+func computeStatus(deps *Deps, ttl int, path string) (string, bool) {
+	if ttl == 0 {
+		issue, found, _ := deps.Github.Issue(path)
+		if found {
+			return formatStatus(issue), false
+		}
+		return "", false
+	}
+
+	ref, ok := deps.Github.Resolve(path)
+	if !ok {
+		return "", false
+	}
+
+	key := statuscache.Key(ref.RepoRoot, ref.Branch)
+	entry, found, _ := deps.StatusCache.Read(key)
+
+	out := ""
+	if found {
+		if r, ok := entry.Preferred(); ok {
+			out = formatStatus(toIssue(*r))
+		}
+	}
+	stale := !found || time.Since(entry.Timestamp) > time.Duration(ttl)*time.Second
+	return out, stale
+}
+
+// runRefresh performs the live gh fetch and always writes a cache entry
+// (a negative entry when there is nothing to show), so the reader respects
+// the TTL instead of re-spawning every tick.
+func runRefresh(deps *Deps, path string) error {
+	ref, ok := deps.Github.Resolve(path)
+	if !ok {
+		return nil // not a repo — nothing to cache
+	}
+
+	var entry statuscache.Entry
+	if ref.HasNumber {
+		if issue, found, _ := deps.Github.Issue(path); found {
+			entry.Issue = &statuscache.Ref{Number: issue.Number, Title: issue.Title, State: issue.State}
+		}
+	}
+	entry.Timestamp = time.Now()
+	return deps.StatusCache.Write(statuscache.Key(ref.RepoRoot, ref.Branch), entry)
+}
+
 // formatStatus renders an issue as a tmux-styled status line.
 func formatStatus(issue github.Issue) string {
 	color := "green"
@@ -55,4 +118,9 @@ func formatStatus(issue github.Issue) string {
 		color = "red"
 	}
 	return fmt.Sprintf("#[fg=%s,bold]%s#[default] #[fg=magenta]Issue #%d#[default] %s", color, issue.State, issue.Number, issue.Title)
+}
+
+// toIssue adapts a cache Ref into the github.Issue value formatStatus consumes.
+func toIssue(ref statuscache.Ref) github.Issue {
+	return github.Issue{Number: ref.Number, Title: ref.Title, State: ref.State}
 }

--- a/seshcli/status.go
+++ b/seshcli/status.go
@@ -1,0 +1,58 @@
+package seshcli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/joshmedeski/sesh/v2/github"
+)
+
+func NewStatusCommand(base *BaseDeps) *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show contextual status for the current session (for the tmux status bar)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			deps, err := buildDeps(cmd, base)
+			if err != nil {
+				return err
+			}
+
+			path := statusPath(deps)
+			if path == "" {
+				return nil
+			}
+
+			issue, found, _ := deps.Github.Issue(path)
+			if !found {
+				return nil
+			}
+
+			fmt.Print(formatStatus(issue))
+			return nil
+		},
+	}
+}
+
+// statusPath resolves the directory to inspect: the attached tmux session's
+// path when running inside tmux, otherwise the current working directory.
+func statusPath(deps *Deps) string {
+	if session, exists := deps.Lister.GetAttachedTmuxSession(); exists {
+		return session.Path
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	return cwd
+}
+
+// formatStatus renders an issue as a tmux-styled status line.
+func formatStatus(issue github.Issue) string {
+	color := "green"
+	if issue.State != "OPEN" {
+		color = "red"
+	}
+	return fmt.Sprintf("#[fg=%s,bold]%s#[default] #%d %s", color, issue.State, issue.Number, issue.Title)
+}

--- a/seshcli/status_test.go
+++ b/seshcli/status_test.go
@@ -1,0 +1,25 @@
+package seshcli
+
+import (
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/github"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatStatus(t *testing.T) {
+	t.Run("open issue gets a green OPEN badge", func(t *testing.T) {
+		got := formatStatus(github.Issue{Number: 400, Title: "Dynamic tmux status bar", State: "OPEN"})
+		assert.Equal(t, "#[fg=green,bold]OPEN#[default] #400 Dynamic tmux status bar", got)
+	})
+
+	t.Run("closed issue gets a red CLOSED badge", func(t *testing.T) {
+		got := formatStatus(github.Issue{Number: 400, Title: "Dynamic tmux status bar", State: "CLOSED"})
+		assert.Equal(t, "#[fg=red,bold]CLOSED#[default] #400 Dynamic tmux status bar", got)
+	})
+
+	t.Run("any non-OPEN state is treated as red", func(t *testing.T) {
+		got := formatStatus(github.Issue{Number: 7, Title: "x", State: "MERGED"})
+		assert.Equal(t, "#[fg=red,bold]MERGED#[default] #7 x", got)
+	})
+}

--- a/seshcli/status_test.go
+++ b/seshcli/status_test.go
@@ -1,11 +1,38 @@
 package seshcli
 
 import (
+	"os"
 	"testing"
 
 	"github.com/joshmedeski/sesh/v2/github"
+	"github.com/joshmedeski/sesh/v2/lister"
+	"github.com/joshmedeski/sesh/v2/model"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestStatusPath(t *testing.T) {
+	t.Run("returns the attached session path", func(t *testing.T) {
+		mockLister := new(lister.MockLister)
+		session := model.SeshSession{Path: "/Users/josh/c/sesh"}
+		mockLister.On("GetAttachedTmuxSession").Return(session, true)
+
+		deps := &Deps{Lister: mockLister}
+		got := statusPath(deps)
+
+		assert.Equal(t, "/Users/josh/c/sesh", got)
+	})
+
+	t.Run("falls back to cwd when not attached", func(t *testing.T) {
+		mockLister := new(lister.MockLister)
+		mockLister.On("GetAttachedTmuxSession").Return(model.SeshSession{}, false)
+
+		deps := &Deps{Lister: mockLister}
+		expectedCwd, _ := os.Getwd()
+		got := statusPath(deps)
+
+		assert.Equal(t, expectedCwd, got)
+	})
+}
 
 func TestFormatStatus(t *testing.T) {
 	t.Run("open issue gets a green OPEN badge", func(t *testing.T) {

--- a/seshcli/status_test.go
+++ b/seshcli/status_test.go
@@ -3,11 +3,14 @@ package seshcli
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/joshmedeski/sesh/v2/github"
 	"github.com/joshmedeski/sesh/v2/lister"
 	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/statuscache"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestStatusPath(t *testing.T) {
@@ -48,5 +51,144 @@ func TestFormatStatus(t *testing.T) {
 	t.Run("any non-OPEN state is treated as red", func(t *testing.T) {
 		got := formatStatus(github.Issue{Number: 7, Title: "x", State: "MERGED"})
 		assert.Equal(t, "#[fg=red,bold]MERGED#[default] #[fg=magenta]Issue #7#[default] x", got)
+	})
+}
+
+func TestToIssue(t *testing.T) {
+	got := toIssue(statuscache.Ref{Number: 400, Title: "x", State: "OPEN"})
+	assert.Equal(t, github.Issue{Number: 400, Title: "x", State: "OPEN"}, got)
+}
+
+func TestComputeStatus(t *testing.T) {
+	path := "/repo"
+	ref := github.BranchRef{RepoRoot: "/repo", Branch: "400", Number: 400, HasNumber: true}
+	key := statuscache.Key("/repo", "400")
+
+	t.Run("fresh issue hit prints and does not spawn", func(t *testing.T) {
+		gh := new(github.MockGithub)
+		sc := new(statuscache.MockStatusCache)
+		gh.On("Resolve", path).Return(ref, true)
+		sc.On("Read", key).Return(statuscache.Entry{
+			Issue:     &statuscache.Ref{Number: 400, Title: "Dynamic tmux status bar", State: "OPEN"},
+			Timestamp: time.Now(),
+		}, true, nil)
+		deps := &Deps{}
+		deps.Github = gh
+		deps.StatusCache = sc
+
+		out, spawn := computeStatus(deps, 60, path)
+
+		assert.Equal(t, "#[fg=green,bold]OPEN#[default] #[fg=magenta]Issue #400#[default] Dynamic tmux status bar", out)
+		assert.False(t, spawn)
+	})
+
+	t.Run("fresh negative hit prints nothing and does not spawn", func(t *testing.T) {
+		gh := new(github.MockGithub)
+		sc := new(statuscache.MockStatusCache)
+		gh.On("Resolve", path).Return(ref, true)
+		sc.On("Read", key).Return(statuscache.Entry{Timestamp: time.Now()}, true, nil)
+		deps := &Deps{}
+		deps.Github = gh
+		deps.StatusCache = sc
+
+		out, spawn := computeStatus(deps, 60, path)
+
+		assert.Equal(t, "", out)
+		assert.False(t, spawn)
+	})
+
+	t.Run("stale hit prints and spawns", func(t *testing.T) {
+		gh := new(github.MockGithub)
+		sc := new(statuscache.MockStatusCache)
+		gh.On("Resolve", path).Return(ref, true)
+		sc.On("Read", key).Return(statuscache.Entry{
+			Issue:     &statuscache.Ref{Number: 400, Title: "T", State: "OPEN"},
+			Timestamp: time.Now().Add(-2 * time.Minute),
+		}, true, nil)
+		deps := &Deps{}
+		deps.Github = gh
+		deps.StatusCache = sc
+
+		out, spawn := computeStatus(deps, 60, path)
+
+		assert.NotEqual(t, "", out)
+		assert.True(t, spawn)
+	})
+
+	t.Run("miss prints nothing and spawns", func(t *testing.T) {
+		gh := new(github.MockGithub)
+		sc := new(statuscache.MockStatusCache)
+		gh.On("Resolve", path).Return(ref, true)
+		sc.On("Read", key).Return(statuscache.Entry{}, false, nil)
+		deps := &Deps{}
+		deps.Github = gh
+		deps.StatusCache = sc
+
+		out, spawn := computeStatus(deps, 60, path)
+
+		assert.Equal(t, "", out)
+		assert.True(t, spawn)
+	})
+
+	t.Run("ttl zero uses live Issue and never spawns", func(t *testing.T) {
+		gh := new(github.MockGithub)
+		gh.On("Issue", path).Return(github.Issue{Number: 400, Title: "T", State: "OPEN"}, true, nil)
+		deps := &Deps{}
+		deps.Github = gh
+
+		out, spawn := computeStatus(deps, 0, path)
+
+		assert.NotEqual(t, "", out)
+		assert.False(t, spawn)
+		gh.AssertNotCalled(t, "Resolve", path)
+	})
+}
+
+func TestRunRefresh(t *testing.T) {
+	path := "/repo"
+	ref := github.BranchRef{RepoRoot: "/repo", Branch: "400", Number: 400, HasNumber: true}
+	key := statuscache.Key("/repo", "400")
+
+	t.Run("writes issue entry on success", func(t *testing.T) {
+		gh := new(github.MockGithub)
+		sc := new(statuscache.MockStatusCache)
+		gh.On("Resolve", path).Return(ref, true)
+		gh.On("Issue", path).Return(github.Issue{Number: 400, Title: "T", State: "OPEN"}, true, nil)
+		sc.On("Write", key, mock.MatchedBy(func(e statuscache.Entry) bool {
+			return e.Issue != nil && e.Issue.Number == 400 && e.PR == nil
+		})).Return(nil)
+		deps := &Deps{}
+		deps.Github = gh
+		deps.StatusCache = sc
+
+		assert.NoError(t, runRefresh(deps, path))
+		sc.AssertExpectations(t)
+	})
+
+	t.Run("writes negative entry when no issue", func(t *testing.T) {
+		gh := new(github.MockGithub)
+		sc := new(statuscache.MockStatusCache)
+		gh.On("Resolve", path).Return(github.BranchRef{RepoRoot: "/repo", Branch: "main"}, true)
+		sc.On("Write", statuscache.Key("/repo", "main"), mock.MatchedBy(func(e statuscache.Entry) bool {
+			return e.Issue == nil && e.PR == nil
+		})).Return(nil)
+		deps := &Deps{}
+		deps.Github = gh
+		deps.StatusCache = sc
+
+		assert.NoError(t, runRefresh(deps, path))
+		sc.AssertExpectations(t)
+	})
+
+	t.Run("not a repo writes nothing", func(t *testing.T) {
+		gh := new(github.MockGithub)
+		sc := new(statuscache.MockStatusCache)
+		gh.On("Resolve", path).Return(github.BranchRef{}, false)
+		deps := &Deps{}
+		deps.Github = gh
+		deps.StatusCache = sc
+
+		assert.NoError(t, runRefresh(deps, path))
+		sc.AssertNotCalled(t, "Write", mock.Anything, mock.Anything)
 	})
 }

--- a/seshcli/status_test.go
+++ b/seshcli/status_test.go
@@ -35,18 +35,18 @@ func TestStatusPath(t *testing.T) {
 }
 
 func TestFormatStatus(t *testing.T) {
-	t.Run("open issue gets a green OPEN badge", func(t *testing.T) {
+	t.Run("open issue gets a green OPEN badge and magenta issue label", func(t *testing.T) {
 		got := formatStatus(github.Issue{Number: 400, Title: "Dynamic tmux status bar", State: "OPEN"})
-		assert.Equal(t, "#[fg=green,bold]OPEN#[default] #400 Dynamic tmux status bar", got)
+		assert.Equal(t, "#[fg=green,bold]OPEN#[default] #[fg=magenta]Issue #400#[default] Dynamic tmux status bar", got)
 	})
 
-	t.Run("closed issue gets a red CLOSED badge", func(t *testing.T) {
+	t.Run("closed issue gets a red CLOSED badge and magenta issue label", func(t *testing.T) {
 		got := formatStatus(github.Issue{Number: 400, Title: "Dynamic tmux status bar", State: "CLOSED"})
-		assert.Equal(t, "#[fg=red,bold]CLOSED#[default] #400 Dynamic tmux status bar", got)
+		assert.Equal(t, "#[fg=red,bold]CLOSED#[default] #[fg=magenta]Issue #400#[default] Dynamic tmux status bar", got)
 	})
 
 	t.Run("any non-OPEN state is treated as red", func(t *testing.T) {
 		got := formatStatus(github.Issue{Number: 7, Title: "x", State: "MERGED"})
-		assert.Equal(t, "#[fg=red,bold]MERGED#[default] #7 x", got)
+		assert.Equal(t, "#[fg=red,bold]MERGED#[default] #[fg=magenta]Issue #7#[default] x", got)
 	})
 }

--- a/statuscache/statuscache.go
+++ b/statuscache/statuscache.go
@@ -1,0 +1,106 @@
+package statuscache
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/gob"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Ref is one GitHub entity (issue or PR) as rendered in the status bar.
+type Ref struct {
+	Number int
+	Title  string
+	State  string
+}
+
+// Entry is the cached status for one branch. Both pointers may be nil (a
+// "negative" entry: the branch has nothing to show), which still counts as a
+// cache hit so the reader respects the TTL instead of refreshing every tick.
+type Entry struct {
+	PR        *Ref
+	Issue     *Ref
+	Timestamp time.Time
+}
+
+// Preferred returns the entity to render: the PR if present, otherwise the
+// issue. ok is false for a negative entry.
+func (e Entry) Preferred() (*Ref, bool) {
+	if e.PR != nil {
+		return e.PR, true
+	}
+	if e.Issue != nil {
+		return e.Issue, true
+	}
+	return nil, false
+}
+
+// StatusCache reads and writes per-branch status entries.
+type StatusCache interface {
+	Read(key string) (Entry, bool, error) // bool=found; false (nil err) on miss/corrupt
+	Write(key string, entry Entry) error
+}
+
+// Key builds the cache key (and filename stem) for a repo root + branch.
+func Key(repoRoot, branch string) string {
+	sum := sha256.Sum256([]byte(repoRoot + "\x00" + branch))
+	return hex.EncodeToString(sum[:])
+}
+
+// FileStatusCache stores one gob file per key under a directory.
+type FileStatusCache struct {
+	dir string
+}
+
+// NewFileStatusCache stores entries under $XDG_CACHE_HOME/sesh/status
+// (falling back to ~/.cache/sesh/status).
+func NewFileStatusCache() *FileStatusCache {
+	dir := os.Getenv("XDG_CACHE_HOME")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			home = "."
+		}
+		dir = filepath.Join(home, ".cache")
+	}
+	return &FileStatusCache{dir: filepath.Join(dir, "sesh", "status")}
+}
+
+// NewFileStatusCacheWithDir stores entries under an explicit directory (tests).
+func NewFileStatusCacheWithDir(dir string) *FileStatusCache {
+	return &FileStatusCache{dir: dir}
+}
+
+func (c *FileStatusCache) path(key string) string {
+	return filepath.Join(c.dir, key+".gob")
+}
+
+func (c *FileStatusCache) Read(key string) (Entry, bool, error) {
+	data, err := os.ReadFile(c.path(key))
+	if err != nil {
+		return Entry{}, false, nil // missing → miss
+	}
+	var entry Entry
+	if err := gob.NewDecoder(bytes.NewReader(data)).Decode(&entry); err != nil {
+		return Entry{}, false, nil // corrupt → miss
+	}
+	return entry, true, nil
+}
+
+func (c *FileStatusCache) Write(key string, entry Entry) error {
+	if err := os.MkdirAll(c.dir, 0o755); err != nil {
+		return err
+	}
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(entry); err != nil {
+		return err
+	}
+	tmp := c.path(key) + ".tmp"
+	if err := os.WriteFile(tmp, buf.Bytes(), 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, c.path(key))
+}

--- a/statuscache/statuscache_test.go
+++ b/statuscache/statuscache_test.go
@@ -1,0 +1,83 @@
+package statuscache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCache(t *testing.T) *FileStatusCache {
+	t.Helper()
+	return NewFileStatusCacheWithDir(filepath.Join(t.TempDir(), "status"))
+}
+
+func TestKeyStableAndDistinct(t *testing.T) {
+	a := Key("/repo/one", "400")
+	assert.Equal(t, a, Key("/repo/one", "400"), "same inputs => same key")
+	assert.NotEqual(t, a, Key("/repo/two", "400"), "different repo => different key")
+	assert.NotEqual(t, a, Key("/repo/one", "401"), "different branch => different key")
+}
+
+func TestWriteReadRoundTrip(t *testing.T) {
+	c := newTestCache(t)
+	entry := Entry{Issue: &Ref{Number: 400, Title: "Dynamic tmux status bar", State: "OPEN"}}
+	require.NoError(t, c.Write("k1", entry))
+
+	got, found, err := c.Read("k1")
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Nil(t, got.PR)
+	assert.Equal(t, &Ref{Number: 400, Title: "Dynamic tmux status bar", State: "OPEN"}, got.Issue)
+}
+
+func TestNegativeEntryRoundTrips(t *testing.T) {
+	c := newTestCache(t)
+	require.NoError(t, c.Write("k2", Entry{}))
+
+	got, found, err := c.Read("k2")
+	require.NoError(t, err)
+	assert.True(t, found, "negative entry is still a hit")
+	assert.Nil(t, got.PR)
+	assert.Nil(t, got.Issue)
+}
+
+func TestMissingFileIsMiss(t *testing.T) {
+	c := newTestCache(t)
+	_, found, err := c.Read("does-not-exist")
+	assert.NoError(t, err)
+	assert.False(t, found)
+}
+
+func TestCorruptFileIsMiss(t *testing.T) {
+	c := newTestCache(t)
+	require.NoError(t, c.Write("k3", Entry{Issue: &Ref{Number: 1}}))
+	// Corrupt the file on disk.
+	require.NoError(t, writeRaw(c, "k3", []byte("not gob data")))
+
+	_, found, err := c.Read("k3")
+	assert.NoError(t, err)
+	assert.False(t, found)
+}
+
+func TestPreferred(t *testing.T) {
+	pr := &Ref{Number: 401, Title: "pr", State: "OPEN"}
+	iss := &Ref{Number: 400, Title: "iss", State: "OPEN"}
+
+	got, ok := Entry{PR: pr, Issue: iss}.Preferred()
+	assert.True(t, ok)
+	assert.Equal(t, pr, got, "PR preferred over issue")
+
+	got, ok = Entry{Issue: iss}.Preferred()
+	assert.True(t, ok)
+	assert.Equal(t, iss, got)
+
+	_, ok = Entry{}.Preferred()
+	assert.False(t, ok)
+}
+
+func writeRaw(c *FileStatusCache, key string, data []byte) error {
+	return os.WriteFile(c.path(key), data, 0o644)
+}


### PR DESCRIPTION
## Summary

Implements the MVP for #400: a new `sesh status` command that prints a tmux-styled status line for the GitHub issue matching the current session's branch. Inspired by [gitmux](https://github.com/arl/gitmux).

```sh
set -g status-left "#[fg=blue,bold]#S #[fg=white,nobold]#(sesh status)"
```

Output is a leading colored state badge followed by `#<number> <title>`:

```
#[fg=green,bold]OPEN#[default] #400 Dynamic tmux status bar
#[fg=red,bold]CLOSED#[default] #400 Dynamic tmux status bar
```

## How it works

1. Resolves the current session's directory (attached tmux session path, falling back to `cwd`).
2. Reads the git branch and parses the first run of digits as an issue number (`400` or `feat/400-status-bar` → `#400`).
3. Looks up the issue via `gh issue view <n> --json number,title,state`.
4. Formats a tmux-markup line (green `OPEN` / red `CLOSED` badge).

Graceful by design: prints nothing and exits `0` for every no-result case — no number in the branch, not a git repo, `gh` missing/unauthenticated, issue not found, or malformed output — so the status bar stays clean.

## Changes

- `git.CurrentBranch(path)` — read the branch for a directory.
- New `github` package — `Issue(path) (Issue, bool, error)` wrapping the `gh` CLI.
- DI wiring of `github` into `BaseDeps`.
- `sesh status` command (`seshcli/status.go`) + registration.
- README "Dynamic status bar" section.
- Design spec + implementation plan under `docs/superpowers/`.

## Testing

`just test` — all packages pass with `-race`. New tests cover `parseIssueNumber`, `github.Issue` (success + all no-result paths), `formatStatus` (open/closed/other state), and `statusPath` (session path + cwd fallback).

## Out of scope (deferred, tracked in #400)

PR titles + draft/open/merged/closed state, Claude Code / Pi conversation titles, and user configuration of priority/format.

Addresses the MVP in #400 (the broader roadmap — PR titles, AI conversation titles, configuration — remains open and tracked there).


---

## Update: status issue cache

`sesh status` now reads from a local, branch-keyed disk cache so every tmux status render is a sub-millisecond file read instead of a blocking `gh` call. A detached background process (`sesh status --refresh`, hidden) does the only live `gh` fetch and writes the cache; `sesh connect` warms it on switch. This removes the lag when switching sessions (especially at low `status-interval` values).

**Config** — new `[github]` section:

```toml
[github]
issue_ttl = 60   # cache lifetime in seconds; default 60; 0 disables caching (always live)
```

**How it works**
- `sesh status` resolves repo root + branch (local), reads the cache entry, and prints instantly. It spawns a detached refresh only when the entry is missing or older than `issue_ttl` — stale-while-revalidate.
- The refresh always writes an entry (a "negative" entry when there's nothing to show) so the reader respects the TTL instead of re-spawning every tick.
- Cache is one gob file per `sha256(repoRoot + branch)` under `$XDG_CACHE_HOME/sesh/status/` — no locking, no clobbering across concurrent sessions.

**Forward-compatible for PRs:** the cache key is branch-based and each `Entry` carries both PR and Issue refs (MVP fills only Issue), so the future PR work from #400 is additive — no key change, no migration.

**Benefit (at `status-interval 3`):** `gh` calls drop from ~20/min/session to ~1, and session switches become instant.

**Testing:** `just test` green with `-race` across `model`, `statuscache`, `github`, `refresher`, and `seshcli`. Covers `EffectiveTTL`, cache round-trip/negative/corrupt entries, `Resolve`, the stale/miss/disabled decision logic, the refresh worker, and the connect warm.
