### PR TITLE
add: `git flags` for `clone` command

### DIFF
--- a/cloner/cloner.go
+++ b/cloner/cloner.go
@@ -27,7 +27,7 @@ func NewCloner(connector connector.Connector, git git.Git) Cloner {
 }
 
 func (c *RealCloner) Clone(opts model.GitCloneOptions) (string, error) {
-	if _, err := c.git.Clone(opts.Repo, opts.CmdDir, opts.Dir); err != nil {
+	if _, err := c.git.Clone(opts.Repo, opts.CmdDir, opts.Dir, opts.GitFlags...); err != nil {
 		return "", err
 	}
 

--- a/git/git.go
+++ b/git/git.go
@@ -7,7 +7,7 @@ import (
 type Git interface {
 	ShowTopLevel(name string) (bool, string, error)
 	GitCommonDir(name string) (bool, string, error)
-	Clone(url string, cmdDir string, dir string) (string, error)
+	Clone(url string, cmdDir string, dir string, gitFlags ...string) (string, error)
 	WorktreeList(name string) (bool, string, error)
 }
 
@@ -35,11 +35,17 @@ func (g *RealGit) GitCommonDir(path string) (bool, string, error) {
 	return true, out, nil
 }
 
-func (g *RealGit) Clone(url string, cmdDir string, dir string) (string, error) {
-	args := []string{"clone", url}
+func (g *RealGit) Clone(url string, cmdDir string, dir string, gitFlags ...string) (string, error) {
+	args := []string{}
+
 	if cmdDir != "" {
-		args = append([]string{"-C", cmdDir}, args...)
+		args = append(args, "-C", cmdDir)
 	}
+
+	args = append(args, "clone")
+	args = append(args, gitFlags...)
+	args = append(args, url)
+
 	if dir != "" {
 		args = append(args, dir)
 	}

--- a/model/git.go
+++ b/model/git.go
@@ -4,4 +4,5 @@ type GitCloneOptions struct {
 	Dir    string
 	CmdDir string
 	Repo   string
+	GitFlags []string
 }

--- a/seshcli/clone.go
+++ b/seshcli/clone.go
@@ -10,12 +10,12 @@ import (
 
 func NewCloneCommand(base *BaseDeps) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "clone",
+		Use:     "clone <repo> [-- <extra git flags>]",
 		Aliases: []string{"cl"},
 		Short:   "Clone a git repo and connect to it as a session",
-		Args:    cobra.ExactArgs(1),
+		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
+			if len(args) < 1 {
 				return errors.New("please provide url to clone")
 			}
 			repo := args[0]
@@ -28,7 +28,13 @@ func NewCloneCommand(base *BaseDeps) *cobra.Command {
 			cmdDir, _ := cmd.Flags().GetString("cmdDir")
 			dir, _ := cmd.Flags().GetString("dir")
 
-			opts := model.GitCloneOptions{CmdDir: cmdDir, Repo: repo, Dir: dir}
+			var gitFlags []string
+			dashIdx := cmd.ArgsLenAtDash()
+			if dashIdx != -1 {
+				gitFlags = args[dashIdx:]
+			}
+
+			opts := model.GitCloneOptions{CmdDir: cmdDir, Repo: repo, Dir: dir, GitFlags: gitFlags}
 			if _, err := deps.Cloner.Clone(opts); err != nil {
 				return err
 			} else {


### PR DESCRIPTION
- add compatability for `git flags` for `clone command`.
- fixes #244.