### PR TITLE
Add `sesh mkdir` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Sesh is a CLI that helps you create and manage tmux sessions quickly and easily 
 - **Wildcard configs** - apply settings to all projects matching a glob pattern
 - **Built-in picker** - interactive session selector, or integrate with fzf, television, or gum
 - **Clone and connect** - clone a git repo and start a session in one step
+- **Mkdir and connect** - create a new directory (relative or absolute path) and start a session in one step
 - **Last session switching** - seamlessly bounce between your two most recent sessions
 - **Root session navigation** - jump to the root of a git worktree or repository
 - **Nerd Font icons** - display session type icons in your picker
@@ -388,6 +389,22 @@ Or as a tmux keybind:
 
 ```sh
 bind-key "W" run-shell "sesh window \"$(sesh window | fzf-tmux -p 60%,50% --prompt '🪟  ')\""
+```
+
+### Create a directory and connect
+
+`sesh mkdir` (alias `md`) combines `mkdir` and `sesh connect` into a single step: it creates the directory if it doesn't already exist, then connects to it as a session — no need to `cd` into it first or wait for zoxide to pick it up.
+
+```sh
+sesh mkdir my-new-project
+```
+
+`<path>` accepts both **relative** paths (resolved against your current working directory) and **absolute** paths, as well as `~` for your home directory:
+
+```sh
+sesh mkdir my-new-project        # relative to the current directory
+sesh mkdir ~/projects/my-app     # relative to your home directory
+sesh mkdir /Users/josh/dev/api   # absolute path
 ```
 
 ## gum + tmux

--- a/configurator/configurator_test.go
+++ b/configurator/configurator_test.go
@@ -65,6 +65,10 @@ func (o *testOs) Stat(name string) (os.FileInfo, error) {
 	return nil, nil
 }
 
+func (o *testOs) MkdirAll(path string, perm os.FileMode) error {
+	return nil
+}
+
 func testdataPath(name string) string {
 	abs, _ := filepath.Abs(filepath.Join("testdata", name))
 	return abs

--- a/mkdirer/mkdirer.go
+++ b/mkdirer/mkdirer.go
@@ -1,0 +1,41 @@
+package mkdirer
+
+import (
+	"github.com/joshmedeski/sesh/v2/connector"
+	"github.com/joshmedeski/sesh/v2/home"
+	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/oswrap"
+)
+
+type Mkdirer interface {
+	// Creates a directory (relative or absolute path) if it doesn't already
+	// exist, then connects to it as a session.
+	Mkdir(path string, opts model.ConnectOpts) (string, error)
+}
+
+type RealMkdirer struct {
+	os        oswrap.Os
+	home      home.Home
+	connector connector.Connector
+}
+
+func NewMkdirer(os oswrap.Os, home home.Home, connector connector.Connector) Mkdirer {
+	return &RealMkdirer{
+		os:        os,
+		home:      home,
+		connector: connector,
+	}
+}
+
+func (m *RealMkdirer) Mkdir(path string, opts model.ConnectOpts) (string, error) {
+	expandedPath, err := m.home.ExpandPath(path)
+	if err != nil {
+		return "", err
+	}
+
+	if err := m.os.MkdirAll(expandedPath, 0o755); err != nil {
+		return "", err
+	}
+
+	return m.connector.Connect(expandedPath, opts)
+}

--- a/mkdirer/mkdirer_test.go
+++ b/mkdirer/mkdirer_test.go
@@ -1,0 +1,105 @@
+package mkdirer
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/connector"
+	"github.com/joshmedeski/sesh/v2/home"
+	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/oswrap"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMkdir(t *testing.T) {
+	t.Run("creates a relative path directory and connects to it", func(t *testing.T) {
+		mockOs := new(oswrap.MockOs)
+		mockHome := new(home.MockHome)
+		mockConnector := new(connector.MockConnector)
+
+		mockHome.EXPECT().ExpandPath("my-project").Return("my-project", nil)
+		mockOs.EXPECT().MkdirAll("my-project", os.FileMode(0o755)).Return(nil)
+		mockConnector.EXPECT().Connect("my-project", model.ConnectOpts{}).Return("session", nil)
+
+		m := NewMkdirer(mockOs, mockHome, mockConnector)
+		name, err := m.Mkdir("my-project", model.ConnectOpts{})
+
+		assert.NoError(t, err)
+		assert.Equal(t, "session", name)
+	})
+
+	t.Run("creates an absolute path directory and connects to it", func(t *testing.T) {
+		mockOs := new(oswrap.MockOs)
+		mockHome := new(home.MockHome)
+		mockConnector := new(connector.MockConnector)
+
+		mockHome.EXPECT().ExpandPath("/tmp/my-project").Return("/tmp/my-project", nil)
+		mockOs.EXPECT().MkdirAll("/tmp/my-project", os.FileMode(0o755)).Return(nil)
+		mockConnector.EXPECT().Connect("/tmp/my-project", model.ConnectOpts{}).Return("session", nil)
+
+		m := NewMkdirer(mockOs, mockHome, mockConnector)
+		name, err := m.Mkdir("/tmp/my-project", model.ConnectOpts{})
+
+		assert.NoError(t, err)
+		assert.Equal(t, "session", name)
+	})
+
+	t.Run("expands a tilde path before creating the directory", func(t *testing.T) {
+		mockOs := new(oswrap.MockOs)
+		mockHome := new(home.MockHome)
+		mockConnector := new(connector.MockConnector)
+
+		mockHome.EXPECT().ExpandPath("~/my-project").Return("/home/user/my-project", nil)
+		mockOs.EXPECT().MkdirAll("/home/user/my-project", os.FileMode(0o755)).Return(nil)
+		mockConnector.EXPECT().Connect("/home/user/my-project", model.ConnectOpts{}).Return("session", nil)
+
+		m := NewMkdirer(mockOs, mockHome, mockConnector)
+		name, err := m.Mkdir("~/my-project", model.ConnectOpts{})
+
+		assert.NoError(t, err)
+		assert.Equal(t, "session", name)
+	})
+
+	t.Run("returns error when ExpandPath fails", func(t *testing.T) {
+		mockOs := new(oswrap.MockOs)
+		mockHome := new(home.MockHome)
+		mockConnector := new(connector.MockConnector)
+
+		mockHome.EXPECT().ExpandPath("my-project").Return("", errors.New("no home"))
+
+		m := NewMkdirer(mockOs, mockHome, mockConnector)
+		_, err := m.Mkdir("my-project", model.ConnectOpts{})
+
+		assert.Error(t, err)
+	})
+
+	t.Run("returns error when MkdirAll fails", func(t *testing.T) {
+		mockOs := new(oswrap.MockOs)
+		mockHome := new(home.MockHome)
+		mockConnector := new(connector.MockConnector)
+
+		mockHome.EXPECT().ExpandPath("my-project").Return("my-project", nil)
+		mockOs.EXPECT().MkdirAll("my-project", os.FileMode(0o755)).Return(errors.New("permission denied"))
+
+		m := NewMkdirer(mockOs, mockHome, mockConnector)
+		_, err := m.Mkdir("my-project", model.ConnectOpts{})
+
+		assert.Error(t, err)
+	})
+
+	t.Run("returns error when Connect fails", func(t *testing.T) {
+		mockOs := new(oswrap.MockOs)
+		mockHome := new(home.MockHome)
+		mockConnector := new(connector.MockConnector)
+
+		mockHome.EXPECT().ExpandPath("my-project").Return("my-project", nil)
+		mockOs.EXPECT().MkdirAll("my-project", os.FileMode(0o755)).Return(nil)
+		mockConnector.EXPECT().Connect("my-project", model.ConnectOpts{}).Return("", errors.New("connect failed"))
+
+		m := NewMkdirer(mockOs, mockHome, mockConnector)
+		_, err := m.Mkdir("my-project", model.ConnectOpts{})
+
+		assert.Error(t, err)
+	})
+}

--- a/oswrap/oswrap.go
+++ b/oswrap/oswrap.go
@@ -11,6 +11,7 @@ type Os interface {
 	Getenv(key string) string
 	ExpandEnv(s string) string
 	Stat(name string) (os.FileInfo, error)
+	MkdirAll(path string, perm os.FileMode) error
 }
 
 type RealOs struct{}
@@ -41,4 +42,8 @@ func (o *RealOs) ExpandEnv(s string) string {
 
 func (o *RealOs) Stat(name string) (os.FileInfo, error) {
 	return os.Stat(name)
+}
+
+func (o *RealOs) MkdirAll(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
 }

--- a/seshcli/deps.go
+++ b/seshcli/deps.go
@@ -19,6 +19,7 @@ import (
 	"github.com/joshmedeski/sesh/v2/json"
 	"github.com/joshmedeski/sesh/v2/lister"
 	"github.com/joshmedeski/sesh/v2/ls"
+	"github.com/joshmedeski/sesh/v2/mkdirer"
 	"github.com/joshmedeski/sesh/v2/model"
 	"github.com/joshmedeski/sesh/v2/namer"
 	"github.com/joshmedeski/sesh/v2/oswrap"
@@ -64,6 +65,7 @@ type Deps struct {
 	Icon          icon.Icon
 	Previewer     previewer.Previewer
 	Cloner        cloner.Cloner
+	Mkdirer       mkdirer.Mkdirer
 }
 
 // NewBaseDeps constructs all config-free dependencies.
@@ -128,6 +130,7 @@ func (b *BaseDeps) BuildAll(configPath string) (*Deps, error) {
 	p := previewer.NewPreviewer(usedLister, t, ic, b.Dir, b.Home, l, config, b.Shell)
 	cl := cloner.NewCloner(c, b.Git)
 	pk := picker.NewPicker(config)
+	mk := mkdirer.NewMkdirer(b.Os, b.Home, c)
 
 	return &Deps{
 		BaseDeps:      *b,
@@ -142,6 +145,7 @@ func (b *BaseDeps) BuildAll(configPath string) (*Deps, error) {
 		Icon:          ic,
 		Previewer:     p,
 		Cloner:        cl,
+		Mkdirer:       mk,
 	}, nil
 }
 

--- a/seshcli/mkdir.go
+++ b/seshcli/mkdir.go
@@ -1,0 +1,52 @@
+package seshcli
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/joshmedeski/sesh/v2/lister"
+	"github.com/joshmedeski/sesh/v2/model"
+)
+
+func NewMkdirCommand(base *BaseDeps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "mkdir <path>",
+		Aliases: []string{"md"},
+		Short:   "Create a directory and connect to it as a session",
+		Long: "Create a directory and connect to it as a session, combining `mkdir` and `sesh connect` into a single step.\n\n" +
+			"The <path> can be relative (resolved against the current working directory) or absolute, and may use `~` for the home directory.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := args[0]
+			if path == "" {
+				return errors.New("please provide a directory path")
+			}
+
+			deps, err := buildDeps(cmd, base)
+			if err != nil {
+				return err
+			}
+
+			switchFlag, _ := cmd.Flags().GetBool("switch")
+			command, _ := cmd.Flags().GetString("command")
+
+			opts := model.ConnectOpts{Switch: switchFlag, Command: command}
+			if _, err := deps.Mkdirer.Mkdir(path, opts); err != nil {
+				// TODO: add to logging
+				return err
+			}
+			// Refresh cache in background so next sesh list has fresh data
+			if deps.CachingLister != nil {
+				deps.CachingLister.RefreshCache(lister.ListOptions{})
+				deps.CachingLister.Wait()
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolP("switch", "s", false, "Switch the session (rather than attach). This is useful for actions triggered outside the terminal.")
+	cmd.Flags().StringP("command", "c", "", "Execute a command when connecting to the new session.")
+
+	return cmd
+}

--- a/seshcli/root_command.go
+++ b/seshcli/root_command.go
@@ -22,6 +22,7 @@ func NewRootCommand(version string) *cobra.Command {
 		NewLastCommand(base),
 		NewConnectCommand(base),
 		NewCloneCommand(base),
+		NewMkdirCommand(base),
 		NewRootSessionCommand(base),
 		NewPreviewCommand(base),
 		NewPickerCommand(base),


### PR DESCRIPTION
## Summary
- Add `sesh mkdir <path>` (alias `md`) that creates a directory and connects to it as a session in one step, replacing the previous `mkdir <dir> && sesh connect <dir>` workaround
- Support relative, absolute, and `~`-prefixed paths via a new `mkdirer` package that reuses the existing `connector.Connect` logic
- Document the new command in the README and CLI help/man text, calling out relative vs. absolute path support

## Why
Closes #404. Directories created outside of sesh haven't been visited by zoxide yet, so `sesh connect` can't find them and the zoxide picker won't surface them either — this collapses directory creation and session connection into a single command.

## Notes
- Added `MkdirAll` to the `oswrap.Os` interface (and updated the test fake in `configurator/configurator_test.go` accordingly)
- Man page and `--help` text are generated automatically from the cobra command struct, no manual doc file to edit