### PR TITLE
Add `sesh cache refresh` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,6 +630,19 @@ The cache is also refreshed automatically after `sesh connect`.
 cache = true
 ```
 
+Sessions created or killed outside `sesh connect` (e.g. plain `tmux new-session`, closing a session's last window) are missing from the cache until the next stale-hit refresh. To keep the cache current, run `sesh cache refresh` when those events happen — it fetches live data and rewrites the cache, and does nothing when the cache is disabled. With tmux hooks this covers both events:
+
+```sh
+set-hook -g session-created 'run-shell -b "sesh cache refresh"'
+set-hook -g session-closed  'run-shell -b "sesh cache refresh"'
+```
+
+If you use a kill binding in an fzf picker (like `ctrl-d` in the example above), refresh the cache before reloading the list so the killed session disappears immediately:
+
+```sh
+--bind 'ctrl-d:execute(tmux kill-session -t {2..}; sesh cache refresh)+change-prompt(⚡  )+reload(sesh list --icons)' \
+```
+
 ### Picker TUI
 
 The Picker TUI can be configured with some options that help you customize it's behaviour, this picker is a useful replacement to external fuzzy pickers.

--- a/seshcli/cache.go
+++ b/seshcli/cache.go
@@ -1,0 +1,44 @@
+package seshcli
+
+import (
+	"log/slog"
+
+	"github.com/spf13/cobra"
+
+	"github.com/joshmedeski/sesh/v2/lister"
+)
+
+func NewCacheCommand(base *BaseDeps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cache",
+		Short: "Manage the session list cache",
+	}
+	cmd.AddCommand(newCacheRefreshCommand(base))
+	return cmd
+}
+
+func newCacheRefreshCommand(base *BaseDeps) *cobra.Command {
+	return &cobra.Command{
+		Use:   "refresh",
+		Short: "Rebuild the session list cache from live data",
+		Long: `Fetch live session data and rewrite the cache, so the next
+'sesh list' reflects sessions that were created or killed outside
+'sesh connect' (which refreshes the cache itself). Intended for tmux
+session-created/session-closed hooks and picker kill bindings.
+
+Does nothing when the cache is disabled.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			deps, err := buildDeps(cmd, base)
+			if err != nil {
+				return err
+			}
+			if deps.CachingLister == nil {
+				slog.Debug("cache refresh: cache is disabled, nothing to do")
+				return nil
+			}
+			deps.CachingLister.RefreshCache(lister.ListOptions{})
+			deps.CachingLister.Wait()
+			return nil
+		},
+	}
+}

--- a/seshcli/root_command.go
+++ b/seshcli/root_command.go
@@ -18,6 +18,7 @@ func NewRootCommand(version string) *cobra.Command {
 	rootCmd.PersistentFlags().StringP("config", "C", "", "path to config file")
 
 	rootCmd.AddCommand(
+		NewCacheCommand(base),
 		NewListCommand(base),
 		NewLastCommand(base),
 		NewConnectCommand(base),


### PR DESCRIPTION
This adds a `cache refresh` subcommand that fetches live session data and rewrites the cache. It's a thin wrapper around the existing `CachingLister.RefreshCache()` that already runs after `sesh connect`, so no new cache logic. When the cache is disabled it just does nothing and exits 0.

The reason I wanted this: I enabled the cache because `sesh list` was slow for me (my zoxide db contains directories on an SMB mount, and the existence checks turn every listing into a pile of network round trips, so the picker sat empty for up to a second). The cache fixed that nicely, but it left one gap: sessions created or killed outside of `sesh connect` don't show up (or keep lingering) until a stale hit happens to revalidate. Closing the last window of a session is the everyday case here.

tmux fires hooks for exactly these events, so with this command the cache can be kept current from the outside:

```sh
set-hook -g session-created 'run-shell -b "sesh cache refresh"'
set-hook -g session-closed  'run-shell -b "sesh cache refresh"'
```

For kill bindings inside an fzf picker (like the `ctrl-d` one from the README example) the hook alone isn't enough, because it races against fzf's `reload`. Putting the refresh between the kill and the reload fixes that:

```sh
--bind 'ctrl-d:execute(tmux kill-session -t {2..}; sesh cache refresh)+change-prompt(⚡  )+reload(sesh list --icons)'
```

I've been running this setup for a bit and the staleness issues are gone. The README cache section is updated with both snippets. Since the command is a no-op without `cache = true`, the hooks are safe to set unconditionally.

I went with a `cache` command group rather than a flat command to leave room for things like `cache clear` later, and with a silent no-op rather than an error when the cache is off, since hooks fire regardless of config. If you'd rather have either shaped differently, or anything else doesn't fit sesh's style or architecture, happy to rework it based on feedback.