### PR TITLE
feat: configurable frecency backend via [frecency] config

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,23 @@ tmux_command = "psmux"
 
 This replaces the `tmux` binary in all commands sesh runs (session creation, switching, attaching, etc.). The configured multiplexer must support tmux's CLI interface.
 
+### Custom Frecency Backend (fasd, autojump, etc.)
+
+Sesh uses [zoxide](https://github.com/ajeetdsouza/zoxide) as its default frecency directory-jumping backend, but you can point it at an alternative such as [fasd](https://github.com/clvv/fasd), [fasder](https://github.com/khwang0/fasder), [autojump](https://github.com/wting/autojump), or [memy](https://github.com/xvello/memy) by overriding the commands in a `[frecency]` table. This is useful for tools that track files _and_ directories, unlike zoxide which tracks directories only.
+
+```toml
+[frecency]
+list_command  = "fasd -d -l -R"  # list all tracked entries
+query_command = "fasd -d {}"     # resolve one input to a path
+add_command   = "fasd -A {}"     # record a path after connecting
+```
+
+- The `{}` placeholder is replaced with the query string (`query_command`) or the path (`add_command`), the same substitution used by `preview_command`.
+- `list_command` output is parsed one path per line, most-frecent first. A leading numeric score is detected automatically when present (as with zoxide's `--score`); otherwise the score is `0`.
+- Any command runs as a single binary (no shell), so pipes/redirects aren't supported.
+- Any field you omit falls back to its zoxide default (`zoxide query --list --score`, `zoxide query {}`, `zoxide add {}`), so an absent `[frecency]` table leaves behavior unchanged.
+- The source label in `sesh list` output stays `zoxide`, so existing integrations that read the `--json` output keep working.
+
 ### Schema (Editor Autocomplete)
 
 Sesh provides a [JSON Schema](https://json-schema.org/) for `sesh.toml` that enables autocomplete, validation, and documentation in your editor. This works with any editor that supports the [taplo](https://taplo.tamasfe.dev/) TOML language server.

--- a/model/config.go
+++ b/model/config.go
@@ -16,10 +16,29 @@ type (
 		GitDirLength            int                  `toml:"git_dir_length"`
 		SeparatorAware          bool                 `toml:"separator_aware"`
 		TmuxCommand             string               `toml:"tmux_command"`
+		Frecency                FrecencyConfig       `toml:"frecency"`
 		TUI                     TUIConfig            `toml:"tui"`
 	}
 	Evaluation struct {
 		StrictMode bool `toml:"strict_mode"`
+	}
+
+	// FrecencyConfig overrides the commands used to drive the frecency
+	// directory-jumping backend (zoxide by default). Each command may be
+	// swapped for an alternative tool such as fasd, autojump, or memy.
+	// Empty fields fall back to the zoxide defaults, so an absent [frecency]
+	// table leaves behavior byte-identical to prior versions.
+	FrecencyConfig struct {
+		// ListCommand enumerates all tracked entries. Its output is parsed
+		// one path per line; a leading numeric score is detected and used
+		// when present (e.g. zoxide's `query --list --score`).
+		ListCommand string `toml:"list_command"`
+		// QueryCommand resolves a single input to a path. The `{}`
+		// placeholder is replaced with the query string.
+		QueryCommand string `toml:"query_command"`
+		// AddCommand records a path to bump its frecency after connecting.
+		// The `{}` placeholder is replaced with the path.
+		AddCommand string `toml:"add_command"`
 	}
 
 	DefaultSessionConfig struct {

--- a/sesh.schema.json
+++ b/sesh.schema.json
@@ -63,6 +63,28 @@
       "description": "Terminal multiplexer command to use instead of tmux (e.g. \"psmux\")",
       "default": "tmux"
     },
+    "frecency": {
+      "type": "object",
+      "description": "Override the frecency directory-jumping backend commands to use an alternative to zoxide (e.g. fasd, autojump, memy). Empty fields fall back to the zoxide defaults.",
+      "properties": {
+        "list_command": {
+          "type": "string",
+          "description": "Command that lists all tracked entries, one path per line. A leading numeric score is detected and used when present.",
+          "default": "zoxide query --list --score"
+        },
+        "query_command": {
+          "type": "string",
+          "description": "Command that resolves a single input to a path. The {} placeholder is replaced with the query string.",
+          "default": "zoxide query {}"
+        },
+        "add_command": {
+          "type": "string",
+          "description": "Command that records a path to bump its frecency after connecting. The {} placeholder is replaced with the path.",
+          "default": "zoxide add {}"
+        }
+      },
+      "additionalProperties": false
+    },
     "tui": {
       "type": "object",
       "description": "Settings for the Sesh Picker TUI",

--- a/seshcli/deps.go
+++ b/seshcli/deps.go
@@ -82,7 +82,6 @@ func NewBaseDeps() *BaseDeps {
 
 	g := git.NewGit(sh)
 	d := dir.NewDir(os, g, path)
-	z := zoxide.NewZoxide(sh)
 	ti := tmuxinator.NewTmuxinator(sh)
 
 	return &BaseDeps{
@@ -96,7 +95,6 @@ func NewBaseDeps() *BaseDeps {
 		Replacer:   r,
 		Git:        g,
 		Dir:        d,
-		Zoxide:     z,
 		Tmuxinator: ti,
 	}
 }
@@ -109,6 +107,10 @@ func (b *BaseDeps) BuildAll(configPath string) (*Deps, error) {
 	}
 
 	slog.Debug("deps: BuildAll", "config", config)
+
+	// Zoxide is the frecency backend; its commands come from config, so it
+	// is constructed here rather than in the config-free NewBaseDeps.
+	b.Zoxide = zoxide.NewZoxide(b.Shell, config.Frecency)
 
 	t := tmux.NewTmux(b.Os, b.Shell, config.TmuxCommand)
 

--- a/zoxide/add.go
+++ b/zoxide/add.go
@@ -1,8 +1,11 @@
 package zoxide
 
 func (z *RealZoxide) Add(path string) error {
-	_, err := z.shell.Cmd("zoxide", "add", path)
+	parts, err := z.shell.PrepareCmd(z.addCommand, map[string]string{"{}": path})
 	if err != nil {
+		return err
+	}
+	if _, err := z.shell.Cmd(parts[0], parts[1:]...); err != nil {
 		return err
 	}
 	return nil

--- a/zoxide/add_test.go
+++ b/zoxide/add_test.go
@@ -1,0 +1,35 @@
+package zoxide
+
+import (
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/shell"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdd(t *testing.T) {
+	t.Run("substitutes the path into the default zoxide command", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		zoxide := NewZoxide(mockShell, model.FrecencyConfig{})
+		mockShell.EXPECT().
+			PrepareCmd("zoxide add {}", map[string]string{"{}": "/Users/joshmedeski/c/sesh/v2"}).
+			Return([]string{"zoxide", "add", "/Users/joshmedeski/c/sesh/v2"}, nil)
+		mockShell.EXPECT().Cmd("zoxide", "add", "/Users/joshmedeski/c/sesh/v2").Return("", nil)
+		err := zoxide.Add("/Users/joshmedeski/c/sesh/v2")
+		assert.Nil(t, err)
+	})
+
+	t.Run("substitutes the path into a custom command", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		zoxide := NewZoxide(mockShell, model.FrecencyConfig{
+			AddCommand: "fasd -A {}",
+		})
+		mockShell.EXPECT().
+			PrepareCmd("fasd -A {}", map[string]string{"{}": "/Users/joshmedeski/c/sesh/v2"}).
+			Return([]string{"fasd", "-A", "/Users/joshmedeski/c/sesh/v2"}, nil)
+		mockShell.EXPECT().Cmd("fasd", "-A", "/Users/joshmedeski/c/sesh/v2").Return("", nil)
+		err := zoxide.Add("/Users/joshmedeski/c/sesh/v2")
+		assert.Nil(t, err)
+	})
+}

--- a/zoxide/list.go
+++ b/zoxide/list.go
@@ -8,25 +8,34 @@ import (
 )
 
 func (z *RealZoxide) ListResults() ([]*model.ZoxideResult, error) {
-	list, err := z.shell.ListCmd("zoxide", "query", "--list", "--score")
+	parts, err := z.shell.PrepareCmd(z.listCommand, map[string]string{})
+	if err != nil {
+		return nil, err
+	}
+	list, err := z.shell.ListCmd(parts[0], parts[1:]...)
 	if err != nil {
 		return nil, err
 	}
 	results := make([]*model.ZoxideResult, 0, len(list))
 	for _, result := range list {
-		if result == "" {
-			break
-		}
 		trimmedResult := strings.TrimSpace(result)
-		fields := strings.SplitN(trimmedResult, " ", 2)
-		score, err := convert.StringToFloat(fields[0])
-		if err != nil {
-			return nil, err
+		if trimmedResult == "" {
+			continue
 		}
-		results = append(results, &model.ZoxideResult{
-			Score: score,
-			Path:  fields[1],
-		})
+		results = append(results, parseResult(trimmedResult))
 	}
 	return results, nil
+}
+
+// parseResult auto-detects an optional leading numeric score. When the first
+// space-delimited field parses as a float it is used as the score and the
+// remainder is the path (zoxide's `--score` output). Otherwise the whole line
+// is treated as the path with a zero score (fasd, memy, plain paths).
+func parseResult(line string) *model.ZoxideResult {
+	if fields := strings.SplitN(line, " ", 2); len(fields) == 2 {
+		if score, err := convert.StringToFloat(fields[0]); err == nil {
+			return &model.ZoxideResult{Score: score, Path: fields[1]}
+		}
+	}
+	return &model.ZoxideResult{Score: 0, Path: line}
 }

--- a/zoxide/list_test.go
+++ b/zoxide/list_test.go
@@ -9,9 +9,12 @@ import (
 )
 
 func TestListResults(t *testing.T) {
-	t.Run("ListResults", func(t *testing.T) {
+	t.Run("parses zoxide scored output by default", func(t *testing.T) {
 		mockShell := new(shell.MockShell)
-		zoxide := &RealZoxide{shell: mockShell}
+		zoxide := NewZoxide(mockShell, model.FrecencyConfig{})
+		mockShell.EXPECT().
+			PrepareCmd("zoxide query --list --score", map[string]string{}).
+			Return([]string{"zoxide", "query", "--list", "--score"}, nil)
 		mockShell.EXPECT().ListCmd("zoxide", "query", "--list", "--score").Return([]string{
 			"100.0 /Users/joshmedeski/Downloads",
 			" 82.0 /Users/joshmedeski/c/dotfiles/.config/fish",
@@ -19,6 +22,7 @@ func TestListResults(t *testing.T) {
 			" 56.0 /Users/joshmedeski/c/sesh/v2",
 			" 51.5 /Users/joshmedeski/c/dotfiles/.config/sesh",
 			" 48.0 /Users/joshmedeski/c/sesh/main",
+			"",
 		}, nil)
 		expected := []*model.ZoxideResult{
 			{Path: "/Users/joshmedeski/Downloads", Score: 100.0},
@@ -27,6 +31,47 @@ func TestListResults(t *testing.T) {
 			{Path: "/Users/joshmedeski/c/sesh/v2", Score: 56.0},
 			{Path: "/Users/joshmedeski/c/dotfiles/.config/sesh", Score: 51.5},
 			{Path: "/Users/joshmedeski/c/sesh/main", Score: 48.0},
+		}
+		actual, err := zoxide.ListResults()
+		assert.Nil(t, err)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("parses paths-only output from a custom backend with zero score", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		zoxide := NewZoxide(mockShell, model.FrecencyConfig{
+			ListCommand: "fasd -d -l -R",
+		})
+		mockShell.EXPECT().
+			PrepareCmd("fasd -d -l -R", map[string]string{}).
+			Return([]string{"fasd", "-d", "-l", "-R"}, nil)
+		mockShell.EXPECT().ListCmd("fasd", "-d", "-l", "-R").Return([]string{
+			"/Users/joshmedeski/c/sesh/v2",
+			"/Users/joshmedeski/Downloads",
+			"",
+		}, nil)
+		expected := []*model.ZoxideResult{
+			{Path: "/Users/joshmedeski/c/sesh/v2", Score: 0},
+			{Path: "/Users/joshmedeski/Downloads", Score: 0},
+		}
+		actual, err := zoxide.ListResults()
+		assert.Nil(t, err)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("auto-detects score per line for mixed output", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		zoxide := NewZoxide(mockShell, model.FrecencyConfig{})
+		mockShell.EXPECT().
+			PrepareCmd("zoxide query --list --score", map[string]string{}).
+			Return([]string{"zoxide", "query", "--list", "--score"}, nil)
+		mockShell.EXPECT().ListCmd("zoxide", "query", "--list", "--score").Return([]string{
+			"42.0 /scored/path",
+			"/unscored/path",
+		}, nil)
+		expected := []*model.ZoxideResult{
+			{Path: "/scored/path", Score: 42.0},
+			{Path: "/unscored/path", Score: 0},
 		}
 		actual, err := zoxide.ListResults()
 		assert.Nil(t, err)

--- a/zoxide/query.go
+++ b/zoxide/query.go
@@ -3,8 +3,12 @@ package zoxide
 import "github.com/joshmedeski/sesh/v2/model"
 
 func (z *RealZoxide) Query(query string) (*model.ZoxideResult, error) {
-	result, err := z.shell.Cmd("zoxide", "query", query)
+	parts, err := z.shell.PrepareCmd(z.queryCommand, map[string]string{"{}": query})
+	if err != nil {
+		return nil, err
+	}
 	// TODO: handle no result found
+	result, err := z.shell.Cmd(parts[0], parts[1:]...)
 	if err != nil {
 		return nil, err
 	}

--- a/zoxide/query_test.go
+++ b/zoxide/query_test.go
@@ -1,0 +1,39 @@
+package zoxide
+
+import (
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/shell"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQuery(t *testing.T) {
+	t.Run("substitutes the query into the default zoxide command", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		zoxide := NewZoxide(mockShell, model.FrecencyConfig{})
+		mockShell.EXPECT().
+			PrepareCmd("zoxide query {}", map[string]string{"{}": "sesh"}).
+			Return([]string{"zoxide", "query", "sesh"}, nil)
+		mockShell.EXPECT().Cmd("zoxide", "query", "sesh").
+			Return("/Users/joshmedeski/c/sesh/v2", nil)
+		result, err := zoxide.Query("sesh")
+		assert.Nil(t, err)
+		assert.Equal(t, &model.ZoxideResult{Path: "/Users/joshmedeski/c/sesh/v2", Score: 0}, result)
+	})
+
+	t.Run("substitutes the query into a custom command", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		zoxide := NewZoxide(mockShell, model.FrecencyConfig{
+			QueryCommand: "fasd -d {}",
+		})
+		mockShell.EXPECT().
+			PrepareCmd("fasd -d {}", map[string]string{"{}": "sesh"}).
+			Return([]string{"fasd", "-d", "sesh"}, nil)
+		mockShell.EXPECT().Cmd("fasd", "-d", "sesh").
+			Return("/Users/joshmedeski/c/sesh/v2", nil)
+		result, err := zoxide.Query("sesh")
+		assert.Nil(t, err)
+		assert.Equal(t, &model.ZoxideResult{Path: "/Users/joshmedeski/c/sesh/v2", Score: 0}, result)
+	})
+}

--- a/zoxide/zoxide.go
+++ b/zoxide/zoxide.go
@@ -11,10 +11,35 @@ type Zoxide interface {
 	Query(path string) (*model.ZoxideResult, error)
 }
 
+// Default commands reproduce zoxide's behavior exactly, so an empty
+// [frecency] config leaves the backend byte-identical to prior versions.
+const (
+	defaultListCommand  = "zoxide query --list --score"
+	defaultQueryCommand = "zoxide query {}"
+	defaultAddCommand   = "zoxide add {}"
+)
+
 type RealZoxide struct {
-	shell shell.Shell
+	shell        shell.Shell
+	listCommand  string
+	queryCommand string
+	addCommand   string
 }
 
-func NewZoxide(shell shell.Shell) Zoxide {
-	return &RealZoxide{shell}
+// NewZoxide builds the frecency backend, falling back to the zoxide
+// defaults for any command the frecency config leaves empty.
+func NewZoxide(shell shell.Shell, frecency model.FrecencyConfig) Zoxide {
+	return &RealZoxide{
+		shell:        shell,
+		listCommand:  orDefault(frecency.ListCommand, defaultListCommand),
+		queryCommand: orDefault(frecency.QueryCommand, defaultQueryCommand),
+		addCommand:   orDefault(frecency.AddCommand, defaultAddCommand),
+	}
+}
+
+func orDefault(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	return value
 }


### PR DESCRIPTION
Closes #402

## Summary
- Add a `[frecency]` config table to override zoxide's `list`, `query`, and `add` commands, enabling alternative backends (fasd, autojump, etc.)
- Auto-detect an optional leading numeric score per line in list output, so paths-only backends work with a zero score
- Keep `model/config.go` and `sesh.schema.json` in sync; document the feature in the README

## Why
Zoxide tracks directories only. Users want to point sesh at frecency tools that track files *and* directories, or use whatever jump tool they already have installed. Empty fields fall back to zoxide defaults, so behavior is byte-identical when no `[frecency]` table is present.

## Notes
- Commands run as a single binary (no shell), so pipes/redirects aren't supported.
- The source label in `sesh list` output stays `zoxide`, so existing `--json` integrations keep working.
- Zoxide is now constructed in `BuildAll` (config-dependent) rather than `NewBaseDeps`.