### PR TITLE
fix: remove placeholder debug log statements from main()

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,11 +17,6 @@ import (
 var version = "dev"
 
 func main() {
-	slog.Debug("Debug")
-	slog.Info("Information")
-	slog.Warn("Warning")
-	slog.Error("Error")
-
 	cmd := seshcli.NewRootCommand(version)
 	if err := fang.Execute(context.TODO(), cmd, fang.WithColorSchemeFunc(fang.AnsiColorScheme), fang.WithoutVersion()); err != nil {
 		slog.Error("main file: ", "error", err)


### PR DESCRIPTION
## Problem

`main()` unconditionally calls four hardcoded `slog` placeholders on **every** invocation:

```go
func main() {
	slog.Debug("Debug")
	slog.Info("Information")
	slog.Warn("Warning")
	slog.Error("Error")
	...
```

With the default log level (`LevelWarn`, set in `init()`), every single `sesh` call appends `{"level":"WARN","msg":"Warning"}` + `{"level":"ERROR","msg":"Error"}` to `$TMPDIR/.seshtmp/<date>.log`.

For setups that invoke `sesh` frequently — e.g. a picker/TUI that reloads `sesh list` on refresh — this accumulates fast. In one real-world case it produced **~1 GB/day** of pure noise and eventually filled the disk. No `ENV` value disables it: even `ENV=error` still writes `"Error"`, and additionally to stdout.

These four calls look like leftover debug scaffolding from when logging was introduced, not intentional output.

## Fix

Remove the four placeholder calls. The logging infrastructure in `init()` and the genuine `slog.Error("main file: ", ...)` on execution failure are untouched.