### PR TITLE
fix: create wildcard windows when connecting from outside tmux

### DIFF
--- a/tmux/new_win.go
+++ b/tmux/new_win.go
@@ -3,7 +3,8 @@ package tmux
 func (t *RealTmux) NewWindowInSession(name string, startDir string, targetSession string) (string, error) {
 	args := []string{"new-window", "-n", name, "-c", startDir}
 	if targetSession != "" {
-		args = append(args, "-t", targetSession)
+		// trailing colon forces session (not window) target resolution
+		args = append(args, "-t", targetSession+":")
 	}
 	return t.shell.Cmd("tmux", args...)
 }

--- a/tmux/new_win_test.go
+++ b/tmux/new_win_test.go
@@ -1,0 +1,51 @@
+package tmux
+
+import (
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/shell"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewWindowInSession(t *testing.T) {
+	t.Run("targets the session unambiguously with a trailing colon", func(t *testing.T) {
+		mockShell := &shell.MockShell{}
+		tmux := &RealTmux{shell: mockShell, bin: "tmux"}
+		mockShell.EXPECT().
+			Cmd("tmux", "new-window", "-n", "agent", "-c", "/home/dev/project", "-t", "project:").
+			Return("", nil)
+
+		result, err := tmux.NewWindowInSession("agent", "/home/dev/project", "project")
+
+		assert.Nil(t, err)
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("omits the target when no session is provided", func(t *testing.T) {
+		mockShell := &shell.MockShell{}
+		tmux := &RealTmux{shell: mockShell, bin: "tmux"}
+		mockShell.EXPECT().
+			Cmd("tmux", "new-window", "-n", "agent", "-c", "/home/dev/project").
+			Return("", nil)
+
+		result, err := tmux.NewWindowInSession("agent", "/home/dev/project", "")
+
+		assert.Nil(t, err)
+		assert.Equal(t, "", result)
+	})
+}
+
+func TestNextWindowInSession(t *testing.T) {
+	t.Run("targets the session unambiguously with a trailing colon", func(t *testing.T) {
+		mockShell := &shell.MockShell{}
+		tmux := &RealTmux{shell: mockShell, bin: "tmux"}
+		mockShell.EXPECT().
+			Cmd("tmux", "next-window", "-t", "project:").
+			Return("", nil)
+
+		result, err := tmux.NextWindowInSession("project")
+
+		assert.Nil(t, err)
+		assert.Equal(t, "", result)
+	})
+}

--- a/tmux/tmux.go
+++ b/tmux/tmux.go
@@ -59,7 +59,8 @@ func (t *RealTmux) CapturePane(targetSession string) (string, error) {
 }
 
 func (t *RealTmux) NextWindowInSession(targetSession string) (string, error) {
-	return t.shell.Cmd(t.bin, "next-window", "-t", targetSession)
+	// trailing colon forces session (not window) target resolution
+	return t.shell.Cmd(t.bin, "next-window", "-t", targetSession+":")
 }
 
 func (t *RealTmux) IsAttached() bool {


### PR DESCRIPTION
## Summary
- Target the session with a trailing colon (`-t <name>:`) in `NewWindowInSession` and `NextWindowInSession` so tmux always resolves the target as a session and appends a new window.
- Add tests covering both methods (colon target + empty-target case).

## Why
Since #395, `new-window`/`next-window` targeted the session by bare name (`-t <name>`). When connecting from outside tmux, the target session is also the *current* session, so tmux resolved the bare name against that session's own windows and failed with "index in use" — creating no window. Connecting from inside a different session masked the bug. The trailing colon forces session resolution on all tmux versions.

Fixes #412

## Notes
- Verified: full suite (378 tests) green; end-to-end wildcard-connect from outside tmux now creates the window and emits the `<name>:` target form.