### PR TITLE
fix(shell): run preview_command through the shell so operators like && work

### DIFF
--- a/ls/ls.go
+++ b/ls/ls.go
@@ -24,12 +24,7 @@ func (g *RealLs) ListDirectory(path string) (string, error) {
 		command = "ls {}"
 	}
 
-	cmdParts, err := g.shell.PrepareCmd(command, map[string]string{"{}": path})
-	if err != nil {
-		return "", err
-	}
-
-	cmdOutput, err := g.shell.Cmd(cmdParts[0], cmdParts[1:]...)
+	cmdOutput, err := g.shell.ShellCmd(command, map[string]string{"{}": path})
 	if err != nil {
 		return "", err
 	}

--- a/previewer/config.go
+++ b/previewer/config.go
@@ -27,12 +27,7 @@ func (s *ConfigPreviewStrategy) Execute(name string) (string, error) {
 	replacements := map[string]string{
 		"{}": session.Path,
 	}
-	cmdParts, err := s.shell.PrepareCmd(session.PreviewCommand, replacements)
-	if err != nil {
-		return "", err
-	}
-
-	cmdOutput, err := s.shell.Cmd(cmdParts[0], cmdParts[1:]...)
+	cmdOutput, err := s.shell.ShellCmd(session.PreviewCommand, replacements)
 	if err != nil {
 		return "", err
 	}

--- a/previewer/previewer_test.go
+++ b/previewer/previewer_test.go
@@ -213,8 +213,7 @@ func (suite *PreviewerTestSuite) setupConfigMocks(inputName string, trimmedName 
 		Path:           expectedPath,
 		PreviewCommand: previewCommand,
 	}, true)
-	suite.mockShell.On("PrepareCmd", previewCommand, map[string]string{"{}": expectedPath}).Return(previewCommandParts, nil)
-	suite.mockShell.On("Cmd", "ls", "-la").Return(expectedOutput, nil)
+	suite.mockShell.On("ShellCmd", previewCommand, map[string]string{"{}": expectedPath}).Return(expectedOutput, nil)
 }
 
 func (suite *PreviewerTestSuite) setupDirectoryMocks(inputName, trimmedName, expectedPath, expectedOutput string) {

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -15,6 +15,15 @@ type Shell interface {
 	CmdWithOutput(cmd string, arg ...string) (string, error)
 	ListCmd(cmd string, arg ...string) ([]string, error)
 	PrepareCmd(cmd string, replacements map[string]string) ([]string, error)
+	// ShellCmd runs cmd through the user's shell (honoring $SHELL, falling
+	// back to /bin/sh) instead of splitting it into argv and exec'ing it
+	// directly. This lets config commands such as preview_command use
+	// shell operators (&&, ||, |, ;) and other shell syntax that a naive
+	// space-split + exec.Command call cannot support. Each key in
+	// replacements is substituted in cmd with its value, shell-quoted so
+	// that values containing spaces or shell metacharacters are treated
+	// as a single literal argument.
+	ShellCmd(cmd string, replacements map[string]string) (string, error)
 }
 
 type RealShell struct {
@@ -89,4 +98,53 @@ func (c *RealShell) PrepareCmd(cmd string, replacements map[string]string) ([]st
 	}
 
 	return result, nil
+}
+
+// userShell returns the shell binary to run script commands with. It
+// prefers $SHELL (the user's configured login shell) so aliases, functions
+// and syntax the user expects are honored, and falls back to /bin/sh when
+// $SHELL is unset (e.g. minimal/CI environments).
+func userShell() string {
+	if sh := os.Getenv("SHELL"); sh != "" {
+		return sh
+	}
+	return "/bin/sh"
+}
+
+// shellQuote wraps s in single quotes so it is treated as one literal shell
+// argument, escaping any single quotes it contains. This is the standard
+// POSIX-shell-safe quoting technique: close the quote, emit an escaped
+// quote, reopen the quote.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+func (c *RealShell) ShellCmd(cmd string, replacements map[string]string) (string, error) {
+	for placeholder, value := range replacements {
+		cmd = strings.ReplaceAll(cmd, placeholder, shellQuote(value))
+	}
+
+	sh := userShell()
+	foundCmd, err := c.exec.LookPath(sh)
+	if err != nil {
+		return "", err
+	}
+
+	var stdout, stderr bytes.Buffer
+	command := exec.Command(foundCmd, "-c", cmd)
+	command.Stdin = os.Stdin
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	if err := command.Start(); err != nil {
+		return "", err
+	}
+	if err := command.Wait(); err != nil {
+		errString := strings.TrimSpace(stderr.String())
+		if strings.HasPrefix(errString, "no server running on") {
+			return "", nil
+		}
+		return "", err
+	}
+	trimmedOutput := strings.TrimSuffix(stdout.String(), "\n")
+	return trimmedOutput, nil
 }

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -78,3 +78,48 @@ func TestShellPrepareCmd(t *testing.T) {
 		assert.Equal(t, []string{"/opt/tool", "--flag"}, cmdParts)
 	})
 }
+
+func TestShellShellCmd(t *testing.T) {
+	t.Run("runs compound commands with shell operators (&&, ||, |, ;)", func(t *testing.T) {
+		mockExec := new(execwrap.MockExec)
+		mockExec.On("LookPath", mock.Anything).Return("/bin/sh", nil)
+		shell := &RealShell{exec: mockExec}
+
+		out, err := shell.ShellCmd("echo one && echo two", map[string]string{})
+		assert.Nil(t, err)
+		assert.Equal(t, "one\ntwo", out)
+	})
+
+	t.Run("substitutes placeholders with shell-quoted values", func(t *testing.T) {
+		mockExec := new(execwrap.MockExec)
+		mockExec.On("LookPath", mock.Anything).Return("/bin/sh", nil)
+		shell := &RealShell{exec: mockExec}
+
+		// A path containing a space and a shell metacharacter must be
+		// treated as a single literal argument, not split or interpreted.
+		out, err := shell.ShellCmd(`echo {} && echo done`, map[string]string{
+			"{}": "hello world && rm -rf /tmp/should-not-run",
+		})
+		assert.Nil(t, err)
+		assert.Equal(t, "hello world && rm -rf /tmp/should-not-run\ndone", out)
+	})
+
+	t.Run("returns an error when the command fails", func(t *testing.T) {
+		mockExec := new(execwrap.MockExec)
+		mockExec.On("LookPath", mock.Anything).Return("/bin/sh", nil)
+		shell := &RealShell{exec: mockExec}
+
+		_, err := shell.ShellCmd("exit 1", map[string]string{})
+		assert.Error(t, err)
+	})
+}
+
+func TestShellQuote(t *testing.T) {
+	t.Run("wraps plain values in single quotes", func(t *testing.T) {
+		assert.Equal(t, "'hello'", shellQuote("hello"))
+	})
+
+	t.Run("escapes embedded single quotes", func(t *testing.T) {
+		assert.Equal(t, `'it'\''s'`, shellQuote("it's"))
+	})
+}


### PR DESCRIPTION
## What / Why

`preview_command` failed on compound shell commands (e.g. `eza {} && git -C {} status`) as reported in #418: the operator `&&` showed up as `ERROR: Exit status 1` instead of being interpreted.

Root cause: `preview_command` was split on spaces with `strings.Split` and each token was exec'd directly (`exec.Command(argv[0], argv[1:]...)`). Shell operators (`&&`, `||`, `|`, `;`) have no meaning to `exec.Command` - they're just passed as literal arguments to whatever binary happens to be `argv[0]`.

## Fix

- Added `shell.Shell.ShellCmd(cmd, replacements)`, which:
  1. Shell-quotes each replacement value (so a path with spaces or metacharacters stays one literal argument, can't be used for injection) and substitutes `{}`-style placeholders into `cmd`.
  2. Runs the resulting command string through the user's shell (`$SHELL`, falling back to `/bin/sh`) via `sh -c "..."`, instead of naive argv-splitting.
- `previewer.ConfigPreviewStrategy.Execute` (the `[session].preview_command` path) and `ls.RealLs.ListDirectory` (the `default_session.preview_command` path used for the built-in directory listing) now call `ShellCmd`.
- `PrepareCmd` is untouched and still used by zoxide/tmuxinator, which build simple argv commands and don't need shell interpretation - this PR only changes the two config-driven preview code paths the issue is about, to keep the change narrowly scoped.

## Testing

```
go build ./...
go vet ./...
go test ./... -race -count=1
gofmt -l .   # clean for changed files
```

All pre-existing tests pass unchanged; `previewer_test.go`'s existing config-strategy test was updated only to assert the new `ShellCmd` mock call in place of `PrepareCmd`+`Cmd` (same scenario, same expected output/behavior).

New tests in `shell/shell_test.go`:
- `runs compound commands with shell operators (&&, ||, |, ;)` - runs `echo one && echo two` and asserts both echoed, reproducing #418's exact failure mode and proving it's fixed.
- `substitutes placeholders with shell-quoted values` - a `{}` replacement containing `&& rm -rf ...` is asserted to come through as a single literal argument rather than being interpreted as a second command (guards against injection via the substituted value).
- `returns an error when the command fails` - normal error propagation still works.
- `TestShellQuote` - unit tests for the quoting helper, including the embedded-single-quote escape case.

Fixes #418
