### PR TITLE
Show window names in the picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,9 +693,9 @@ show_windows = false
 With `show_windows = true`, each row also lists the names of the windows inside that session, dimmed after the session name. Window names that don't fit are summarized as `+N`:
 
 ```
->  sesh  editor  server  logs
-   dotfiles  nvim  shell
-   my-project  code  server  db  +2
+>  sesh editor server logs
+   dotfiles nvim shell
+   my-project code server db +2
    scratch
 ```
 

--- a/README.md
+++ b/README.md
@@ -687,7 +687,19 @@ The Picker TUI can be configured with some options that help you customize it's 
 prompt = "> "
 placeholder = "Filter sessions... "
 show_icons = false
+show_windows = false
 ```
+
+With `show_windows = true`, each row also lists the names of the windows inside that session, dimmed after the session name. Window names that don't fit are summarized as `+N`:
+
+```
+>  sesh  editor  server  logs
+   dotfiles  nvim  shell
+   my-project  code  server  db  +2
+   scratch
+```
+
+Window names are display-only: selecting a row still returns just the session name, and typing a window name does not match its session. The names for live tmux sessions are fetched in a single tmux call, so the option costs the same regardless of how many sessions you have.
 
 ### Default Session
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -430,6 +430,30 @@ sort_order = [
   "config", # 结果顺序：config, tmux, tmuxinator, zoxide
 ]
 ```
+
+### 选择器 TUI
+
+选择器 TUI 可以通过一些选项进行配置，以自定义其行为，这个选择器是外部模糊选择器的一个有用替代品。
+
+```toml
+[tui]
+prompt = "> "
+placeholder = "Filter sessions... "
+show_icons = false
+show_windows = false
+```
+
+当 `show_windows = true` 时，每一行还会在会话名称之后以暗色列出该会话中的窗口名称。放不下的窗口名称会汇总为 `+N`：
+
+```
+>  sesh editor server logs
+   dotfiles nvim shell
+   my-project code server db +2
+   scratch
+```
+
+窗口名称仅用于显示：选中某一行仍然只返回会话名称，输入窗口名称也不会匹配到它所属的会话。活动 tmux 会话的窗口名称通过一次 tmux 调用获取，因此无论您有多少会话，该选项的开销都相同。
+
 ### 默认会话
 
 可以配置默认会话以在连接到会话时运行命令。这对于运行开发服务器或启动 tmux 插件很有用。

--- a/lister/list.go
+++ b/lister/list.go
@@ -48,6 +48,18 @@ func (l *RealLister) List(opts ListOptions) (model.SeshSessions, error) {
 	resultsChan := make(chan strategyResult, len(srcsOrderedIndex))
 	var wg sync.WaitGroup
 
+	// Window names are display-only and fetched once for all sessions, in
+	// parallel with the source strategies, so they never cost a tmux call per
+	// session.
+	var windowNames map[string][]string
+	if l.config.TUI.ShowWindows && slices.Contains(srcsOrderedIndex, "tmux") {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			windowNames = tmuxWindowNames(l)
+		}()
+	}
+
 	for _, src := range srcsOrderedIndex {
 		wg.Add(1)
 		go func(s string) {
@@ -115,8 +127,11 @@ func (l *RealLister) List(opts ListOptions) (model.SeshSessions, error) {
 		})
 	}
 
-	return model.SeshSessions{
+	sessions := model.SeshSessions{
 		OrderedIndex: fullOrderedIndex,
 		Directory:    fullDirectory,
-	}, nil
+	}
+	attachWindowNames(sessions, windowNames)
+
+	return sessions, nil
 }

--- a/lister/list_test.go
+++ b/lister/list_test.go
@@ -291,3 +291,49 @@ func TestBlacklistedFlag(t *testing.T) {
 		})
 	}
 }
+
+func TestList_ShowWindows(t *testing.T) {
+	newLister := func(showWindows bool, mockTmux *tmux.MockTmux) Lister {
+		config := model.Config{}
+		config.TUI.ShowWindows = showWindows
+		return NewLister(config, new(home.MockHome), mockTmux, new(zoxide.MockZoxide), new(tmuxinator.MockTmuxinator))
+	}
+
+	t.Run("attaches window names when enabled", func(t *testing.T) {
+		mockTmux := new(tmux.MockTmux)
+		mockTmux.On("ListSessions").Return([]*model.TmuxSession{
+			{Name: "sesh", Path: "/p"},
+		}, nil)
+		mockTmux.EXPECT().ListAllWindowNames().Return(map[string][]string{
+			"sesh": {"editor", "server"},
+		}, nil).Once()
+
+		result, err := newLister(true, mockTmux).List(ListOptions{Tmux: true})
+		assert.NoError(t, err)
+		session := result.Directory[result.OrderedIndex[0]]
+		assert.Equal(t, []string{"editor", "server"}, session.WindowNames)
+		// One tmux call for all sessions, not one per session.
+		mockTmux.AssertExpectations(t)
+	})
+
+	t.Run("does not call tmux when disabled", func(t *testing.T) {
+		mockTmux := new(tmux.MockTmux)
+		mockTmux.On("ListSessions").Return([]*model.TmuxSession{
+			{Name: "sesh", Path: "/p"},
+		}, nil)
+
+		result, err := newLister(false, mockTmux).List(ListOptions{Tmux: true})
+		assert.NoError(t, err)
+		session := result.Directory[result.OrderedIndex[0]]
+		assert.Nil(t, session.WindowNames)
+		mockTmux.AssertNotCalled(t, "ListAllWindowNames")
+	})
+
+	t.Run("does not call tmux when tmux is not a listed source", func(t *testing.T) {
+		mockTmux := new(tmux.MockTmux)
+
+		_, err := newLister(true, mockTmux).List(ListOptions{Config: true})
+		assert.NoError(t, err)
+		mockTmux.AssertNotCalled(t, "ListAllWindowNames")
+	})
+}

--- a/lister/tmux.go
+++ b/lister/tmux.go
@@ -38,6 +38,35 @@ func listTmux(l *RealLister) (model.SeshSessions, error) {
 	}, nil
 }
 
+// tmuxWindowNames fetches the window names of every live tmux session in a
+// single tmux call. Failures are non-fatal: the picker simply renders sessions
+// without their window names.
+func tmuxWindowNames(l *RealLister) map[string][]string {
+	windowNames, err := l.tmux.ListAllWindowNames()
+	if err != nil {
+		return nil
+	}
+	return windowNames
+}
+
+// attachWindowNames fills in WindowNames for tmux sessions from a session name
+// keyed map. Sessions from other sources keep whatever they already have.
+func attachWindowNames(sessions model.SeshSessions, windowNames map[string][]string) {
+	if len(windowNames) == 0 {
+		return
+	}
+	for _, key := range sessions.OrderedIndex {
+		session, ok := sessions.Directory[key]
+		if !ok || session.Src != "tmux" {
+			continue
+		}
+		if names, ok := windowNames[session.Name]; ok {
+			session.WindowNames = names
+			sessions.Directory[key] = session
+		}
+	}
+}
+
 func (l *RealLister) FindTmuxSession(name string) (model.SeshSession, bool) {
 	sessions, err := listTmux(l)
 	if err != nil {

--- a/lister/tmux_test.go
+++ b/lister/tmux_test.go
@@ -201,3 +201,49 @@ func TestListTmuxSessionsError(t *testing.T) {
 		assert.Contains(t, err.Error(), "couldn't list tmux sessions")
 	})
 }
+
+func TestAttachWindowNames(t *testing.T) {
+	t.Run("fills in window names for tmux sessions only", func(t *testing.T) {
+		sessions := model.SeshSessions{
+			OrderedIndex: []string{"tmux:sesh", "config:sesh", "tmux:unknown"},
+			Directory: model.SeshSessionMap{
+				"tmux:sesh":    {Src: "tmux", Name: "sesh"},
+				"config:sesh":  {Src: "config", Name: "sesh", WindowNames: []string{"configured"}},
+				"tmux:unknown": {Src: "tmux", Name: "unknown"},
+			},
+		}
+		attachWindowNames(sessions, map[string][]string{
+			"sesh": {"editor", "server"},
+		})
+
+		assert.Equal(t, []string{"editor", "server"}, sessions.Directory["tmux:sesh"].WindowNames)
+		assert.Equal(t, []string{"configured"}, sessions.Directory["config:sesh"].WindowNames,
+			"config sessions keep their configured window names")
+		assert.Nil(t, sessions.Directory["tmux:unknown"].WindowNames)
+	})
+
+	t.Run("no-op when there are no window names", func(t *testing.T) {
+		sessions := model.SeshSessions{
+			OrderedIndex: []string{"tmux:sesh"},
+			Directory:    model.SeshSessionMap{"tmux:sesh": {Src: "tmux", Name: "sesh"}},
+		}
+		attachWindowNames(sessions, nil)
+		assert.Nil(t, sessions.Directory["tmux:sesh"].WindowNames)
+	})
+}
+
+func TestTmuxWindowNames(t *testing.T) {
+	t.Run("returns nil when tmux fails", func(t *testing.T) {
+		mockTmux := new(tmux.MockTmux)
+		mockTmux.EXPECT().ListAllWindowNames().Return(nil, assert.AnError)
+		l := &RealLister{tmux: mockTmux}
+		assert.Nil(t, tmuxWindowNames(l))
+	})
+
+	t.Run("returns the window names", func(t *testing.T) {
+		mockTmux := new(tmux.MockTmux)
+		mockTmux.EXPECT().ListAllWindowNames().Return(map[string][]string{"sesh": {"editor"}}, nil)
+		l := &RealLister{tmux: mockTmux}
+		assert.Equal(t, map[string][]string{"sesh": {"editor"}}, tmuxWindowNames(l))
+	})
+}

--- a/model/config.go
+++ b/model/config.go
@@ -67,6 +67,7 @@ type (
 	TUIConfig struct {
 		// TODO: keybindings and more
 		ShowIcons   bool   `toml:"show_icons"`
+		ShowWindows bool   `toml:"show_windows"`
 		Prompt      string `toml:"prompt"`
 		Placeholder string `toml:"placeholder"`
 	}

--- a/picker/picker.go
+++ b/picker/picker.go
@@ -16,6 +16,7 @@ const (
 
 type PickerOptions struct {
 	ShowIcons      *bool
+	ShowWindows    *bool
 	SeparatorAware *bool
 	Prompt         *string
 	Placeholder    *string
@@ -41,6 +42,11 @@ func (p *RealPicker) Pick(fetchFunc FetchFunc, opts PickerOptions) (string, erro
 		showIcons = p.config.TUI.ShowIcons
 	}
 
+	showWindows := p.config.TUI.ShowWindows
+	if opts.ShowWindows != nil {
+		showWindows = *opts.ShowWindows
+	}
+
 	prompt := defaultPrompt
 	if opts.Prompt != nil {
 		prompt = *opts.Prompt
@@ -55,7 +61,7 @@ func (p *RealPicker) Pick(fetchFunc FetchFunc, opts PickerOptions) (string, erro
 		placeholder = p.config.TUI.Placeholder
 	}
 
-	m := New(fetchFunc, showIcons, p.config.SeparatorAware, prompt, placeholder)
+	m := New(fetchFunc, showIcons, showWindows, p.config.SeparatorAware, prompt, placeholder)
 	prog := tea.NewProgram(m)
 	result, err := prog.Run()
 	if err != nil {

--- a/picker/picker_test.go
+++ b/picker/picker_test.go
@@ -36,7 +36,7 @@ func testFetchFunc(sessions model.SeshSessions) FetchFunc {
 // newTestModel creates a model and simulates the async load completing.
 func newTestModel() Model {
 	sessions := testSessions()
-	m := New(testFetchFunc(sessions), false, false, "> ", "Filter sessions...")
+	m := New(testFetchFunc(sessions), false, false, false, "> ", "Filter sessions...")
 	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
 	return result.(Model)
 }
@@ -53,7 +53,7 @@ func TestNew(t *testing.T) {
 
 func TestNew_StartsInLoadingState(t *testing.T) {
 	sessions := testSessions()
-	m := New(testFetchFunc(sessions), false, false, "> ", "Filter sessions...")
+	m := New(testFetchFunc(sessions), false, false, false, "> ", "Filter sessions...")
 	assert.True(t, m.loading)
 	assert.Len(t, m.allItems, 0)
 	assert.Len(t, m.filtered, 0)
@@ -202,7 +202,7 @@ func TestUpdate_Enter_EmptyList(t *testing.T) {
 
 func TestUpdate_Enter_WhileLoading(t *testing.T) {
 	sessions := testSessions()
-	m := New(testFetchFunc(sessions), false, false, "> ", "Filter sessions...")
+	m := New(testFetchFunc(sessions), false, false, false, "> ", "Filter sessions...")
 	assert.True(t, m.loading)
 
 	result, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
@@ -215,7 +215,7 @@ func TestUpdate_Enter_WhileLoading(t *testing.T) {
 
 func TestUpdate_Escape_WhileLoading(t *testing.T) {
 	sessions := testSessions()
-	m := New(testFetchFunc(sessions), false, false, "> ", "Filter sessions...")
+	m := New(testFetchFunc(sessions), false, false, false, "> ", "Filter sessions...")
 
 	result, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	resultModel := result.(Model)
@@ -225,7 +225,7 @@ func TestUpdate_Escape_WhileLoading(t *testing.T) {
 
 func TestUpdate_SessionsLoaded(t *testing.T) {
 	sessions := testSessions()
-	m := New(testFetchFunc(sessions), false, false, "> ", "Filter sessions...")
+	m := New(testFetchFunc(sessions), false, false, false, "> ", "Filter sessions...")
 	assert.True(t, m.loading)
 
 	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
@@ -239,7 +239,7 @@ func TestUpdate_SessionsLoaded(t *testing.T) {
 
 func TestUpdate_SessionsLoaded_WithPreTypedFilter(t *testing.T) {
 	sessions := testSessions()
-	m := New(testFetchFunc(sessions), false, false, "> ", "Filter sessions...")
+	m := New(testFetchFunc(sessions), false, false, false, "> ", "Filter sessions...")
 
 	// Simulate typing "dot" before sessions arrive
 	m.filterInput.SetValue("dot")
@@ -257,7 +257,7 @@ func TestUpdate_SessionsLoadError(t *testing.T) {
 	fetchErr := errors.New("zoxide not found")
 	m := New(func() (model.SeshSessions, error) {
 		return model.SeshSessions{}, fetchErr
-	}, false, false, "> ", "Filter sessions...")
+	}, false, false, false, "> ", "Filter sessions...")
 
 	result, _ := m.Update(sessionsLoadedMsg{err: fetchErr})
 	resultModel := result.(Model)
@@ -307,7 +307,7 @@ func TestView_ReturnsNonEmpty(t *testing.T) {
 
 func TestView_LoadingState(t *testing.T) {
 	sessions := testSessions()
-	m := New(testFetchFunc(sessions), false, false, "> ", "Filter sessions...")
+	m := New(testFetchFunc(sessions), false, false, false, "> ", "Filter sessions...")
 	m.width = 60
 	m.height = 24
 
@@ -352,7 +352,7 @@ func TestHalfPageMovement(t *testing.T) {
 		index[i] = key
 	}
 	sessions := model.SeshSessions{OrderedIndex: index, Directory: dir}
-	m := New(testFetchFunc(sessions), false, false, "> ", "Filter sessions...")
+	m := New(testFetchFunc(sessions), false, false, false, "> ", "Filter sessions...")
 	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
 	m = result.(Model)
 	m.height = 20
@@ -366,7 +366,7 @@ func TestHalfPageMovement(t *testing.T) {
 // newTestModelSeparatorAware creates a model with separator-aware matching enabled.
 func newTestModelSeparatorAware() Model {
 	sessions := testSessions()
-	m := New(testFetchFunc(sessions), false, true, "> ", "Filter sessions...")
+	m := New(testFetchFunc(sessions), false, false, true, "> ", "Filter sessions...")
 	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
 	return result.(Model)
 }
@@ -444,5 +444,143 @@ func TestApplyFilter_SeparatorAware_Disabled(t *testing.T) {
 	for _, f := range m.filtered {
 		assert.NotEqual(t, "my-project", f.item.name,
 			"space should NOT match dash when separator-aware is disabled")
+	}
+}
+
+// sessionsWithWindows returns sessions carrying window names for display.
+func sessionsWithWindows() model.SeshSessions {
+	dir := model.SeshSessionMap{
+		"s1": {Name: "sesh", Src: "tmux", WindowNames: []string{"editor", "server", "logs"}},
+		"s2": {Name: "dotfiles", Src: "tmux", WindowNames: []string{"nvim", "shell"}},
+		"s3": {Name: "scratch", Src: "tmux"},
+	}
+	return model.SeshSessions{
+		OrderedIndex: []string{"s1", "s2", "s3"},
+		Directory:    dir,
+	}
+}
+
+// newTestModelWithWindows creates a loaded model with window display enabled.
+func newTestModelWithWindows() Model {
+	sessions := sessionsWithWindows()
+	m := New(testFetchFunc(sessions), false, true, false, "> ", "Filter sessions...")
+	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
+	m = result.(Model)
+	m.width = 60
+	m.height = 24
+	return m
+}
+
+func TestView_ShowWindows(t *testing.T) {
+	m := newTestModelWithWindows()
+	out := fmt.Sprintf("%v", m.View())
+
+	assert.Contains(t, out, "sesh")
+	assert.Contains(t, out, "editor")
+	assert.Contains(t, out, "server")
+	assert.Contains(t, out, "nvim")
+}
+
+func TestView_ShowWindows_Disabled(t *testing.T) {
+	sessions := sessionsWithWindows()
+	m := New(testFetchFunc(sessions), false, false, false, "> ", "Filter sessions...")
+	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
+	m = result.(Model)
+	m.width = 60
+	m.height = 24
+
+	out := fmt.Sprintf("%v", m.View())
+	assert.Contains(t, out, "sesh")
+	assert.NotContains(t, out, "editor")
+}
+
+func TestView_ShowWindows_NoWindowsRendersCleanly(t *testing.T) {
+	m := newTestModelWithWindows()
+	out := fmt.Sprintf("%v", m.View())
+
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "scratch") {
+			assert.Equal(t, "  scratch", strings.TrimRight(line, " \r"),
+				"a session without window names should render exactly as before")
+		}
+	}
+}
+
+func TestView_ShowWindows_RowsFitContentWidth(t *testing.T) {
+	dir := model.SeshSessionMap{
+		"s1": {Name: "sesh", Src: "tmux", WindowNames: []string{
+			"editor", "server", "logs", "database", "tests", "docs", "shell",
+			"migrations", "worker", "queue", "metrics",
+		}},
+	}
+	sessions := model.SeshSessions{OrderedIndex: []string{"s1"}, Directory: dir}
+	m := New(testFetchFunc(sessions), false, true, false, "> ", "Filter sessions...")
+	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
+	m = result.(Model)
+	m.width = 60
+	m.height = 24
+
+	out := fmt.Sprintf("%v", m.View())
+	var row string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "sesh") {
+			row = line
+			break
+		}
+	}
+	assert.NotEmpty(t, row)
+	assert.LessOrEqual(t, lipgloss.Width(row), m.contentWidth(),
+		"row must not exceed the content width")
+	assert.Contains(t, row, "+", "elided windows should be summarized as +N")
+}
+
+func TestEnter_SelectsSessionNameOnly(t *testing.T) {
+	m := newTestModelWithWindows()
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	resultModel := result.(Model)
+
+	assert.Equal(t, "sesh", resultModel.Chosen(),
+		"selection must be the session name, never window names")
+}
+
+func TestApplyFilter_DoesNotMatchWindowNames(t *testing.T) {
+	m := newTestModelWithWindows()
+	m.filterInput.SetValue("editor")
+	m.applyFilter()
+
+	assert.Empty(t, m.filtered, "typing a window name must not match its session")
+}
+
+func TestSessionItems_StringIgnoresWindowNames(t *testing.T) {
+	items := buildItems(sessionsWithWindows(), false)
+	for i := range items {
+		assert.Equal(t, items[i].name, items.String(i),
+			"fuzzy source must expose the session name only")
+	}
+}
+
+func TestWindowsText(t *testing.T) {
+	tests := []struct {
+		name     string
+		names    []string
+		budget   int
+		expected string
+	}{
+		{"no names", nil, 40, ""},
+		{"zero budget", []string{"editor"}, 0, ""},
+		{"negative budget", []string{"editor"}, -5, ""},
+		{"all fit", []string{"editor", "server"}, 40, "  editor  server"},
+		{"one fits, rest elided", []string{"editor", "server", "logs"}, 14, "  editor  +2"},
+		{"none fit, count still shown", []string{"editorwindow"}, 6, "  +1"},
+		{"nothing fits at all", []string{"editorwindow"}, 3, ""},
+		{"exact fit", []string{"editor"}, 8, "  editor"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := windowsText(tt.names, tt.budget)
+			assert.Equal(t, tt.expected, got)
+			assert.LessOrEqual(t, lipgloss.Width(got), max(tt.budget, 0))
+		})
 	}
 }

--- a/picker/picker_test.go
+++ b/picker/picker_test.go
@@ -570,11 +570,11 @@ func TestWindowsText(t *testing.T) {
 		{"no names", nil, 40, ""},
 		{"zero budget", []string{"editor"}, 0, ""},
 		{"negative budget", []string{"editor"}, -5, ""},
-		{"all fit", []string{"editor", "server"}, 40, "  editor  server"},
-		{"one fits, rest elided", []string{"editor", "server", "logs"}, 14, "  editor  +2"},
-		{"none fit, count still shown", []string{"editorwindow"}, 6, "  +1"},
-		{"nothing fits at all", []string{"editorwindow"}, 3, ""},
-		{"exact fit", []string{"editor"}, 8, "  editor"},
+		{"all fit", []string{"editor", "server"}, 40, " editor server"},
+		{"one fits, rest elided", []string{"editor", "server", "logs"}, 14, " editor +2"},
+		{"none fit, count still shown", []string{"editorwindow"}, 6, " +1"},
+		{"nothing fits at all", []string{"editorwindow"}, 2, ""},
+		{"exact fit", []string{"editor"}, 7, " editor"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/picker/tui.go
+++ b/picker/tui.go
@@ -340,7 +340,7 @@ func (m Model) View() tea.View {
 
 // windowGap separates the session name from the window names, and each window
 // name from the next.
-const windowGap = "  "
+const windowGap = " "
 
 // windowsText renders window names inline within budget columns, eliding the
 // ones that don't fit as "+N". It returns "" when there are no names or not

--- a/picker/tui.go
+++ b/picker/tui.go
@@ -52,6 +52,7 @@ type Model struct {
 	chosen         string
 	quit           bool
 	showIcons      bool
+	showWindows    bool
 	separatorAware bool
 	focusCmd       tea.Cmd
 	loading        bool
@@ -100,7 +101,7 @@ func buildItems(sessions model.SeshSessions, separatorAware bool) sessionItems {
 	return items
 }
 
-func New(fetchFunc FetchFunc, showIcons bool, separatorAware bool, prompt string, placeholder string) Model {
+func New(fetchFunc FetchFunc, showIcons bool, showWindows bool, separatorAware bool, prompt string, placeholder string) Model {
 	ti := textinput.New()
 	ti.Placeholder = placeholder
 	ti.Prompt = prompt
@@ -108,6 +109,7 @@ func New(fetchFunc FetchFunc, showIcons bool, separatorAware bool, prompt string
 	m := Model{
 		filterInput:    ti,
 		showIcons:      showIcons,
+		showWindows:    showWindows,
 		separatorAware: separatorAware,
 		loading:        true,
 		fetchFunc:      fetchFunc,
@@ -295,6 +297,7 @@ func (m Model) View() tea.View {
 		cursorStyle := lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(2)).Bold(true)
 		matchStyle := lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(1)).Bold(true)
 		normalStyle := lipgloss.NewStyle()
+		windowStyle := lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(8)).Faint(true)
 
 		for i := m.offset; i < end; i++ {
 			item := m.filtered[i]
@@ -311,7 +314,17 @@ func (m Model) View() tea.View {
 			}
 			name := highlightMatches(item.item.name, item.matchedIndexes, matchStyle, normalStyle)
 
-			b.WriteString(fmt.Sprintf("%s%s%s\n", prefix, tag, name))
+			var windows string
+			if m.showWindows {
+				// Window names are display-only: they are never highlighted as
+				// matches and never become part of the selected value.
+				used := lipgloss.Width(prefix) + lipgloss.Width(tag) + lipgloss.Width(item.item.name)
+				if text := windowsText(item.item.session.WindowNames, m.contentWidth()-used); text != "" {
+					windows = windowStyle.Render(text)
+				}
+			}
+
+			b.WriteString(fmt.Sprintf("%s%s%s%s\n", prefix, tag, name, windows))
 		}
 
 		// Pad remaining visible lines
@@ -323,6 +336,50 @@ func (m Model) View() tea.View {
 	content := b.String()
 
 	return tea.NewView(content)
+}
+
+// windowGap separates the session name from the window names, and each window
+// name from the next.
+const windowGap = "  "
+
+// windowsText renders window names inline within budget columns, eliding the
+// ones that don't fit as "+N". It returns "" when there are no names or not
+// even one name fits.
+func windowsText(names []string, budget int) string {
+	if len(names) == 0 || budget <= 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	used, shown := 0, 0
+	for i, name := range names {
+		entry := windowGap + name
+		need := used + lipgloss.Width(entry)
+		// Reserve room for the elision label in case a later name doesn't fit.
+		if remaining := len(names) - i - 1; remaining > 0 {
+			need += lipgloss.Width(elisionLabel(remaining))
+		}
+		if need > budget {
+			break
+		}
+		b.WriteString(entry)
+		used += lipgloss.Width(entry)
+		shown++
+	}
+
+	if shown == len(names) {
+		return b.String()
+	}
+
+	label := elisionLabel(len(names) - shown)
+	if used+lipgloss.Width(label) <= budget {
+		return b.String() + label
+	}
+	return b.String()
+}
+
+func elisionLabel(hidden int) string {
+	return fmt.Sprintf("%s+%d", windowGap, hidden)
 }
 
 func highlightMatches(s string, indexes []int, matchStyle, normalStyle lipgloss.Style) string {

--- a/sesh.schema.json
+++ b/sesh.schema.json
@@ -93,6 +93,10 @@
           "type": "boolean",
           "description": "Show icons in the picker TUI"
         },
+        "show_windows": {
+          "type": "boolean",
+          "description": "Show the window names of each session in the picker TUI (display only, never part of the selected value)"
+        },
         "prompt": {
           "type": "string",
           "description": "The prompt shown in the picker TUI"

--- a/tmux/list_tmux_win.go
+++ b/tmux/list_tmux_win.go
@@ -32,6 +32,42 @@ func (t *RealTmux) ListWindows(targetSession string) ([]*model.TmuxWindow, error
 	return parseTmuxWindowsOutput(output)
 }
 
+func listAllWindowNamesFormat() string {
+	variables := []string{
+		"#{session_name}",
+		"#{window_name}",
+	}
+	return strings.Join(variables, separator)
+}
+
+// ListAllWindowNames returns the window names of every session, keyed by
+// session name, in a single tmux invocation. The picker uses this so showing
+// window names doesn't cost one shell call per session.
+func (t *RealTmux) ListAllWindowNames() (map[string][]string, error) {
+	output, err := t.shell.ListCmd(t.bin, "list-windows", "-a", "-F", listAllWindowNamesFormat())
+	if err != nil {
+		return nil, err
+	}
+	return parseAllWindowNamesOutput(output), nil
+}
+
+func parseAllWindowNamesOutput(rawList []string) map[string][]string {
+	windowNames := make(map[string][]string)
+	for _, line := range rawList {
+		// Split on the first separator only: window names are more likely to
+		// contain it than session names (which come from directory names).
+		session, name, found := strings.Cut(line, separator)
+		if !found {
+			continue
+		}
+		if session == "" || name == "" {
+			continue
+		}
+		windowNames[session] = append(windowNames[session], name)
+	}
+	return windowNames
+}
+
 func parseTmuxWindowsOutput(rawList []string) ([]*model.TmuxWindow, error) {
 	windows := make([]*model.TmuxWindow, 0, len(rawList))
 	for _, line := range rawList {

--- a/tmux/list_tmux_win_test.go
+++ b/tmux/list_tmux_win_test.go
@@ -52,3 +52,40 @@ func TestListWindows(t *testing.T) {
 		assert.True(t, windows[1].Active)
 	})
 }
+
+func TestListAllWindowNames(t *testing.T) {
+	t.Run("groups window names by session", func(t *testing.T) {
+		mockShell := &shell.MockShell{}
+		tmux := &RealTmux{shell: mockShell, bin: "tmux"}
+		mockShell.EXPECT().ListCmd("tmux", "list-windows", "-a", "-F", mock.Anything).Return(
+			[]string{"sesh::editor", "sesh::server", "dotfiles::nvim"},
+			nil,
+		)
+		windowNames, err := tmux.ListAllWindowNames()
+		assert.Nil(t, err)
+		assert.Equal(t, map[string][]string{
+			"sesh":     {"editor", "server"},
+			"dotfiles": {"nvim"},
+		}, windowNames)
+	})
+
+	t.Run("returns error from shell", func(t *testing.T) {
+		mockShell := &shell.MockShell{}
+		tmux := &RealTmux{shell: mockShell, bin: "tmux"}
+		mockShell.EXPECT().ListCmd("tmux", "list-windows", "-a", "-F", mock.Anything).Return(
+			nil, assert.AnError,
+		)
+		windowNames, err := tmux.ListAllWindowNames()
+		assert.Error(t, err)
+		assert.Nil(t, windowNames)
+	})
+
+	t.Run("parseAllWindowNamesOutput skips malformed lines", func(t *testing.T) {
+		raw := []string{"sesh::editor", "no-separator", "::orphan", "sesh::", "work::make::build"}
+		windowNames := parseAllWindowNamesOutput(raw)
+		assert.Equal(t, map[string][]string{
+			"sesh": {"editor"},
+			"work": {"make::build"},
+		}, windowNames)
+	})
+}

--- a/tmux/mock_Tmux.go
+++ b/tmux/mock_Tmux.go
@@ -253,6 +253,61 @@ func (_c *MockTmux_IsAttached_Call) RunAndReturn(run func() bool) *MockTmux_IsAt
 	return _c
 }
 
+// ListAllWindowNames provides a mock function for the type MockTmux
+func (_mock *MockTmux) ListAllWindowNames() (map[string][]string, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListAllWindowNames")
+	}
+
+	var r0 map[string][]string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() (map[string][]string, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() map[string][]string); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string][]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockTmux_ListAllWindowNames_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListAllWindowNames'
+type MockTmux_ListAllWindowNames_Call struct {
+	*mock.Call
+}
+
+// ListAllWindowNames is a helper method to define mock.On call
+func (_e *MockTmux_Expecter) ListAllWindowNames() *MockTmux_ListAllWindowNames_Call {
+	return &MockTmux_ListAllWindowNames_Call{Call: _e.mock.On("ListAllWindowNames")}
+}
+
+func (_c *MockTmux_ListAllWindowNames_Call) Run(run func()) *MockTmux_ListAllWindowNames_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockTmux_ListAllWindowNames_Call) Return(stringToStrings map[string][]string, err error) *MockTmux_ListAllWindowNames_Call {
+	_c.Call.Return(stringToStrings, err)
+	return _c
+}
+
+func (_c *MockTmux_ListAllWindowNames_Call) RunAndReturn(run func() (map[string][]string, error)) *MockTmux_ListAllWindowNames_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListSessions provides a mock function for the type MockTmux
 func (_mock *MockTmux) ListSessions() ([]*model.TmuxSession, error) {
 	ret := _mock.Called()

--- a/tmux/tmux.go
+++ b/tmux/tmux.go
@@ -9,6 +9,7 @@ import (
 type Tmux interface {
 	ListSessions() ([]*model.TmuxSession, error)
 	ListWindows(targetSession string) ([]*model.TmuxWindow, error)
+	ListAllWindowNames() (map[string][]string, error)
 	NewSession(sessionName string, startDir string) (string, error)
 	NewWindowInSession(name string, startDir string, targetSession string) (string, error)
 	IsAttached() bool


### PR DESCRIPTION
Closes #420

Adds a `[tui] show_windows` option (default **off**) that renders each session's window names inline after the session name, dimmed:

```
  > ● sesh editor server logs
    ● dotfiles nvim shell
    ● my-project code server db redis worker
    ● scratch
```

When a row would exceed `contentWidth()`, the trailing windows collapse into `+N` rather than wrapping:

```
  > ● sesh editor server logs database tests +6
```

## Display-only, as specified

- Selection still reads `selected.item.name` — window names never reach `m.chosen`.
- `sessionItems.String(i)` still returns `searchName`, so typing a window name doesn't match its session.
- Window names are rendered outside `highlightMatches`, so match highlighting can't bleed onto them.
- Sessions with no window names render byte-identical to before (no trailing separator).

## One tmux call, not N

`tmux.ListAllWindowNames()` issues a single `tmux list-windows -a -F '#{session_name}::#{window_name}'` and returns names keyed by session name. `lister.List` fires it as an extra goroutine alongside the source strategies, so it adds no wall-clock latency, and only when `show_windows` is on *and* tmux is among the requested sources. `FindTmuxSession`, `GetLastTmuxSession`, and the connect paths are untouched.

The issue suggested aggregating `#{window_name}` into the session list format; `list-windows -a` reaches the same one-call cost without wrestling `#{W:...}` loops through the `::` separator.

## Notes / judgment calls

- **No `--windows` CLI flag.** The lister decides whether to fetch window names from config, and `srcStrategy` takes no options, so a flag would toggle rendering for data that was never fetched. `PickerOptions.ShowWindows` exists for the override, but only config drives it today. Adding the flag properly means threading `ListOptions` through all five strategies — happy to do that in a follow-up if wanted.
- **`parseAllWindowNamesOutput` splits on the first `::`**, so a window named `make::build` survives intact while a session name containing `::` would break. Session names come from directory/repo names, so that's the safer side of an unavoidable ambiguity.

## Acceptance criteria

- [x] Picker rows show window names after the session name when available
- [x] Selecting a row returns only the session name (`TestEnter_SelectsSessionNameOnly`)
- [x] Fuzzy filtering does not match window names (`TestApplyFilter_DoesNotMatchWindowNames`, `TestSessionItems_StringIgnoresWindowNames`)
- [x] Long window lists are truncated rather than wrapping (`TestView_ShowWindows_RowsFitContentWidth`, `TestWindowsText`)
- [x] Sessions without window names render cleanly (`TestView_ShowWindows_NoWindowsRendersCleanly`)
- [x] New config option documented in the README and added to `sesh.schema.json`
- [x] `just test` passes

Also covered: `parseAllWindowNamesOutput` malformed-input handling, and a `List`-level assertion that `ListAllWindowNames` is called exactly once when enabled and never when disabled.