### PR TITLE
Session aliases with optional auto-connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,7 @@ prompt = "> "
 placeholder = "Filter sessions... "
 show_icons = false
 show_windows = false
+alias_auto_connect_delay = "150ms"
 ```
 
 With `show_windows = true`, each row also lists the names of the windows inside that session, dimmed after the session name. Window names that don't fit are summarized as `+N`:
@@ -700,6 +701,8 @@ With `show_windows = true`, each row also lists the names of the windows inside 
 ```
 
 Window names are display-only: selecting a row still returns just the session name, and typing a window name does not match its session. The names for live tmux sessions are fetched in a single tmux call, so the option costs the same regardless of how many sessions you have.
+
+`alias_auto_connect_delay` is the grace period before an alias auto-connects — see [Session Aliases](#session-aliases).
 
 ### Default Session
 
@@ -739,6 +742,39 @@ path = "~/c/dotfiles/.config/tmux"
 startup_command = "nvim tmux.conf"
 preview_command = "bat --color=always ~/c/dotfiles/.config/tmux/tmux.conf"
 ```
+
+### Session Aliases
+
+Fuzzy matching is great for discovery, but the top result for `wp` shifts as sessions come and go, so muscle memory never quite forms. An alias gives a session a short, fixed name you can always count on:
+
+```toml
+[[session]]
+name = "wallpaper"
+path = "~/c/wallpaper"
+alias = "wp"
+alias_auto_connect = true
+
+[[session]]
+name = "dotfiles"
+path = "~/.config"
+alias = "dot"
+```
+
+Aliases must be unique (case-insensitively) — sesh reports an error at startup if two sessions share one.
+
+An alias does two things. On the command line, `sesh connect wp` behaves exactly like `sesh connect wallpaper`. In the picker, the session is tagged with its alias so it stays discoverable:
+
+```
+>  wp wallpaper
+   dot dotfiles
+   my-project
+```
+
+With `alias_auto_connect = true`, typing the full alias in the picker connects immediately — no <kbd>Enter</kbd>. It is opt-in per session because it is only worth it for the handful you jump to constantly. Filtering is unaffected either way: an aliased session appears wherever fuzzy matching ranks it, and a partial alias behaves like any other query.
+
+Aliases that share a prefix (`w` and `wp`) are allowed. `[tui] alias_auto_connect_delay` (default `150ms`) is the grace period before auto-connect fires, which leaves room to finish typing the longer one. Raise it if you type slowly, or lower it to `"0s"` to fire the instant the alias is complete.
+
+To keep typing past an alias in a one-off invocation, run the picker with `--no-alias-auto`.
 
 ### Path substitution
 

--- a/README.md
+++ b/README.md
@@ -762,7 +762,7 @@ alias = "dot"
 
 Aliases must be unique (case-insensitively) — sesh reports an error at startup if two sessions share one.
 
-An alias does two things. On the command line, `sesh connect wp` behaves exactly like `sesh connect wallpaper`. In the picker, the session is tagged with its alias so it stays discoverable:
+On the command line, `sesh connect wp` behaves exactly like `sesh connect wallpaper`. In the picker, aliased sessions are tagged with a chip so they stay discoverable:
 
 ```
 >  wp wallpaper
@@ -770,7 +770,17 @@ An alias does two things. On the command line, `sesh connect wp` behaves exactly
    my-project
 ```
 
-With `alias_auto_connect = true`, typing the full alias in the picker connects immediately — no <kbd>Enter</kbd>. It is opt-in per session because it is only worth it for the handful you jump to constantly. Filtering is unaffected either way: an aliased session appears wherever fuzzy matching ranks it, and a partial alias behaves like any other query.
+Typing an alias exactly resolves to that session and nothing else, regardless of how fuzzy matching would have ranked it — the whole point being that the result never shifts:
+
+```
+filter: wp
+
+>  wp wallpaper
+```
+
+Anything short of an exact alias is fuzzy-matched as usual, so `w` and `wpx` behave like any other query. An alias resolves even when its session isn't in the current list — say you're running `sesh picker --tmux` and it isn't started yet.
+
+With `alias_auto_connect = true`, typing the full alias connects immediately — no <kbd>Enter</kbd>. It is opt-in per session because it is only worth it for the handful you jump to constantly.
 
 Aliases that share a prefix (`w` and `wp`) are allowed. `[tui] alias_auto_connect_delay` (default `150ms`) is the grace period before auto-connect fires, which leaves room to finish typing the longer one. Raise it if you type slowly, or lower it to `"0s"` to fire the instant the alias is complete.
 

--- a/README.md
+++ b/README.md
@@ -689,6 +689,7 @@ placeholder = "Filter sessions... "
 show_icons = false
 show_windows = false
 alias_auto_connect_delay = "150ms"
+alias_filter_prefix = "/"
 ```
 
 With `show_windows = true`, each row also lists the names of the windows inside that session, dimmed after the session name. Window names that don't fit are summarized as `+N`:
@@ -702,7 +703,7 @@ With `show_windows = true`, each row also lists the names of the windows inside 
 
 Window names are display-only: selecting a row still returns just the session name, and typing a window name does not match its session. The names for live tmux sessions are fetched in a single tmux call, so the option costs the same regardless of how many sessions you have.
 
-`alias_auto_connect_delay` is the grace period before an alias auto-connects — see [Session Aliases](#session-aliases).
+`alias_auto_connect_delay` and `alias_filter_prefix` tune aliases — see [Session Aliases](#session-aliases).
 
 ### Default Session
 
@@ -785,6 +786,29 @@ With `alias_auto_connect = true`, typing the full alias connects immediately —
 Aliases that share a prefix (`w` and `wp`) are allowed. `[tui] alias_auto_connect_delay` (default `150ms`) is the grace period before auto-connect fires, which leaves room to finish typing the longer one. Raise it if you type slowly, or lower it to `"0s"` to fire the instant the alias is complete.
 
 To keep typing past an alias in a one-off invocation, run the picker with `--no-alias-auto`.
+
+#### Browsing aliases
+
+Typing `/` as the first character narrows the picker to aliased sessions only, which is how you go from "I know I set up a shortcut for this" to the session without remembering the shortcut:
+
+```
+filter: /
+
+>  wp  wallpaper
+   dot dotfiles
+   tc  tmux config
+```
+
+What you type next narrows further, matching aliases by prefix (`/t` finds `tc`) and then falling back to session names (`/config` also finds `tc`, since aliases come first and names are matched anywhere). Aliases whose sessions aren't running still show up.
+
+Completing an alias in this mode connects immediately, whether or not it set `alias_auto_connect` — reaching for `/` says the next thing you type is a shortcut to jump to. `alias_auto_connect_delay` still applies, so `/w` leaves room to become `/wp`, and `--no-alias-auto` still holds it back.
+
+Only a leading `/` counts, so `code/app` filters normally. But a query that *starts* with a path — `/Users/you/code` — would enter alias mode instead, so pick a different sigil if you filter that way:
+
+```toml
+[tui]
+alias_filter_prefix = "@"   # or "" to turn the mode off
+```
 
 ### Path substitution
 

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/joshmedeski/sesh/v2/model"
 	"github.com/joshmedeski/sesh/v2/oswrap"
@@ -125,6 +126,31 @@ func (c *RealConfigurator) applyDefaults(config *model.Config) {
 	if config.TUI.Placeholder == "" {
 		config.TUI.Placeholder = "Filter Sessions..."
 	}
+	if config.TUI.AliasAutoConnectDelay == "" {
+		config.TUI.AliasAutoConnectDelay = model.DefaultAliasAutoConnectDelay
+	}
+}
+
+// validateAliases rejects alias configurations that can't behave predictably.
+// Aliases that share a prefix (`w` and `wp`) are allowed on purpose: the
+// auto-connect delay is what makes them usable together.
+func validateAliases(config *model.Config) error {
+	if _, err := time.ParseDuration(config.TUI.AliasAutoConnectDelay); err != nil {
+		return fmt.Errorf("invalid alias_auto_connect_delay %q: %w", config.TUI.AliasAutoConnectDelay, err)
+	}
+
+	seen := make(map[string]string, len(config.SessionConfigs))
+	for _, session := range config.SessionConfigs {
+		if session.Alias == "" {
+			continue
+		}
+		key := strings.ToLower(session.Alias)
+		if owner, exists := seen[key]; exists {
+			return fmt.Errorf("duplicate alias %q used by both %q and %q", session.Alias, owner, session.Name)
+		}
+		seen[key] = session.Name
+	}
+	return nil
 }
 
 func (c *RealConfigurator) getConfigFileFromPath(configPath string) (model.Config, error) {
@@ -148,6 +174,9 @@ func (c *RealConfigurator) getConfigFileFromPath(configPath string) (model.Confi
 	}
 
 	c.applyDefaults(&config)
+	if err := validateAliases(&config); err != nil {
+		return config, err
+	}
 	return config, nil
 }
 
@@ -180,6 +209,9 @@ func (c *RealConfigurator) getConfigFileFromUserConfigDir() (model.Config, error
 	}
 
 	c.applyDefaults(&config)
+	if err := validateAliases(&config); err != nil {
+		return config, err
+	}
 	return config, nil
 }
 

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/joshmedeski/sesh/v2/model"
 	"github.com/joshmedeski/sesh/v2/oswrap"
@@ -129,6 +130,10 @@ func (c *RealConfigurator) applyDefaults(config *model.Config) {
 	if config.TUI.AliasAutoConnectDelay == "" {
 		config.TUI.AliasAutoConnectDelay = model.DefaultAliasAutoConnectDelay
 	}
+	if config.TUI.AliasFilterPrefix == nil {
+		prefix := model.DefaultAliasFilterPrefix
+		config.TUI.AliasFilterPrefix = &prefix
+	}
 }
 
 // validateAliases rejects alias configurations that can't behave predictably.
@@ -137,6 +142,18 @@ func (c *RealConfigurator) applyDefaults(config *model.Config) {
 func validateAliases(config *model.Config) error {
 	if _, err := time.ParseDuration(config.TUI.AliasAutoConnectDelay); err != nil {
 		return fmt.Errorf("invalid alias_auto_connect_delay %q: %w", config.TUI.AliasAutoConnectDelay, err)
+	}
+
+	// An empty prefix disables alias-filter mode, so only non-empty values are
+	// checked. More than one character would mean the mode only engages partway
+	// through typing, and whitespace can't be told apart from a normal query.
+	if prefix := config.TUI.AliasFilterPrefix; prefix != nil && *prefix != "" {
+		if utf8.RuneCountInString(*prefix) > 1 {
+			return fmt.Errorf("invalid alias_filter_prefix %q: must be a single character", *prefix)
+		}
+		if strings.TrimSpace(*prefix) == "" {
+			return fmt.Errorf("invalid alias_filter_prefix %q: must not be whitespace", *prefix)
+		}
 	}
 
 	seen := make(map[string]string, len(config.SessionConfigs))

--- a/configurator/configurator_test.go
+++ b/configurator/configurator_test.go
@@ -281,6 +281,38 @@ func TestGetConfig_AliasAutoConnectDelayInvalid(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid alias_auto_connect_delay")
 }
 
+func TestGetConfig_AliasFilterPrefixDefault(t *testing.T) {
+	config, err := configFromTOML(t, "")
+	assert.NoError(t, err)
+	require.NotNil(t, config.TUI.AliasFilterPrefix, "an absent key is filled in with the default")
+	assert.Equal(t, "/", *config.TUI.AliasFilterPrefix)
+}
+
+func TestGetConfig_AliasFilterPrefixOverride(t *testing.T) {
+	config, err := configFromTOML(t, "[tui]\nalias_filter_prefix = \"@\"\n")
+	assert.NoError(t, err)
+	require.NotNil(t, config.TUI.AliasFilterPrefix)
+	assert.Equal(t, "@", *config.TUI.AliasFilterPrefix)
+}
+
+func TestGetConfig_AliasFilterPrefixDisabled(t *testing.T) {
+	config, err := configFromTOML(t, "[tui]\nalias_filter_prefix = \"\"\n")
+	assert.NoError(t, err)
+	require.NotNil(t, config.TUI.AliasFilterPrefix,
+		"an explicit empty string disables the mode and must survive the defaults")
+	assert.Equal(t, "", *config.TUI.AliasFilterPrefix)
+}
+
+func TestGetConfig_AliasFilterPrefixInvalid(t *testing.T) {
+	_, err := configFromTOML(t, "[tui]\nalias_filter_prefix = \"//\"\n")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a single character")
+
+	_, err = configFromTOML(t, "[tui]\nalias_filter_prefix = \" \"\n")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be whitespace")
+}
+
 func TestGetConfig_SessionAliases(t *testing.T) {
 	config, err := configFromTOML(t, `
 [[session]]

--- a/configurator/configurator_test.go
+++ b/configurator/configurator_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/joshmedeski/sesh/v2/model"
 	"github.com/joshmedeski/sesh/v2/pathwrap"
 	"github.com/joshmedeski/sesh/v2/runtimewrap"
 	"github.com/stretchr/testify/assert"
@@ -248,6 +249,89 @@ func TestGetConfig_ImportPathWithTilde(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, config.SessionConfigs, 1)
 	assert.Equal(t, "test-session", config.SessionConfigs[0].Name)
+}
+
+// configFromTOML loads a config straight from TOML content, going through the
+// same defaults and validation as a real config file.
+func configFromTOML(t *testing.T, contents string) (model.Config, error) {
+	t.Helper()
+	mockOs := &testOs{
+		homeDir: "/home/testuser",
+		files:   map[string][]byte{"/main/sesh.toml": []byte(contents)},
+	}
+	c := NewConfiguratorWithPath(mockOs, pathwrap.NewPath(), &runtimewrap.MockRunTime{}, "/main/sesh.toml")
+	return c.GetConfig()
+}
+
+func TestGetConfig_AliasAutoConnectDelayDefault(t *testing.T) {
+	config, err := configFromTOML(t, "")
+	assert.NoError(t, err)
+	assert.Equal(t, "150ms", config.TUI.AliasAutoConnectDelay)
+}
+
+func TestGetConfig_AliasAutoConnectDelayOverride(t *testing.T) {
+	config, err := configFromTOML(t, "[tui]\nalias_auto_connect_delay = \"300ms\"\n")
+	assert.NoError(t, err)
+	assert.Equal(t, "300ms", config.TUI.AliasAutoConnectDelay)
+}
+
+func TestGetConfig_AliasAutoConnectDelayInvalid(t *testing.T) {
+	_, err := configFromTOML(t, "[tui]\nalias_auto_connect_delay = \"soon\"\n")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid alias_auto_connect_delay")
+}
+
+func TestGetConfig_SessionAliases(t *testing.T) {
+	config, err := configFromTOML(t, `
+[[session]]
+name = "wallpaper"
+path = "~/c/wallpaper"
+alias = "wp"
+alias_auto_connect = true
+
+[[session]]
+name = "dotfiles"
+path = "~/.config"
+alias = "dot"
+`)
+	assert.NoError(t, err)
+	require.Len(t, config.SessionConfigs, 2)
+	assert.Equal(t, "wp", config.SessionConfigs[0].Alias)
+	assert.True(t, config.SessionConfigs[0].AliasAutoConnect)
+	assert.Equal(t, "dot", config.SessionConfigs[1].Alias)
+	assert.False(t, config.SessionConfigs[1].AliasAutoConnect,
+		"alias_auto_connect is opt-in per session")
+}
+
+func TestGetConfig_DuplicateAliases(t *testing.T) {
+	_, err := configFromTOML(t, `
+[[session]]
+name = "wallpaper"
+alias = "wp"
+
+[[session]]
+name = "wordpress"
+alias = "WP"
+`)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate alias")
+	assert.Contains(t, err.Error(), "wordpress")
+}
+
+func TestGetConfig_OverlappingAliasPrefixesAllowed(t *testing.T) {
+	// `w` and `wp` share a prefix on purpose: the auto-connect delay is what
+	// makes them usable together.
+	config, err := configFromTOML(t, `
+[[session]]
+name = "wallpaper"
+alias = "wp"
+
+[[session]]
+name = "work"
+alias = "w"
+`)
+	assert.NoError(t, err)
+	assert.Len(t, config.SessionConfigs, 2)
 }
 
 func TestGetConfig_XDGConfigHomeNotSet(t *testing.T) {

--- a/connector/alias.go
+++ b/connector/alias.go
@@ -1,0 +1,19 @@
+package connector
+
+import "strings"
+
+// resolveAlias maps a configured alias to its session name so that
+// `sesh connect wp` behaves exactly like `sesh connect wallpaper`, running the
+// full strategy chain against the real name. Anything that isn't an alias is
+// returned untouched.
+func (c *RealConnector) resolveAlias(name string) string {
+	if name == "" {
+		return name
+	}
+	for _, session := range c.config.SessionConfigs {
+		if session.Alias != "" && strings.EqualFold(session.Alias, name) {
+			return session.Name
+		}
+	}
+	return name
+}

--- a/connector/alias_test.go
+++ b/connector/alias_test.go
@@ -1,0 +1,41 @@
+package connector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/joshmedeski/sesh/v2/model"
+)
+
+func TestResolveAlias(t *testing.T) {
+	c := &RealConnector{config: model.Config{
+		SessionConfigs: []model.SessionConfig{
+			{Name: "wallpaper", Alias: "wp"},
+			{Name: "dotfiles", Alias: "DOT"},
+			{Name: "notes"},
+		},
+	}}
+
+	t.Run("resolves an alias to its session name", func(t *testing.T) {
+		assert.Equal(t, "wallpaper", c.resolveAlias("wp"))
+	})
+
+	t.Run("matches aliases case-insensitively", func(t *testing.T) {
+		assert.Equal(t, "dotfiles", c.resolveAlias("dot"))
+		assert.Equal(t, "wallpaper", c.resolveAlias("WP"))
+	})
+
+	t.Run("passes unknown names through untouched", func(t *testing.T) {
+		assert.Equal(t, "my-project", c.resolveAlias("my-project"))
+		assert.Equal(t, "", c.resolveAlias(""))
+	})
+
+	t.Run("does not match a partial alias", func(t *testing.T) {
+		assert.Equal(t, "w", c.resolveAlias("w"))
+	})
+
+	t.Run("leaves session names alone when they have no alias", func(t *testing.T) {
+		assert.Equal(t, "notes", c.resolveAlias("notes"))
+	})
+}

--- a/connector/connect.go
+++ b/connector/connect.go
@@ -8,6 +8,8 @@ import (
 
 // TODO: send to logging (local txt file?)
 func (c *RealConnector) Connect(name string, opts model.ConnectOpts) (string, error) {
+	name = c.resolveAlias(name)
+
 	// TODO: make it configurable to change the order of connection establishments?
 	// ["tmux", "config", "dir", "zoxide"]
 	// TODO: make it configurable to disable certain strategies (including flags for optimized fzf commands)

--- a/model/config.go
+++ b/model/config.go
@@ -4,6 +4,10 @@ package model
 // [tui] alias_auto_connect_delay is not set.
 const DefaultAliasAutoConnectDelay = "150ms"
 
+// DefaultAliasFilterPrefix is the sigil that enters alias-filter mode when
+// [tui] alias_filter_prefix is not set.
+const DefaultAliasFilterPrefix = "/"
+
 type (
 	Config struct {
 		Cache                   bool                 `toml:"cache"`
@@ -86,6 +90,11 @@ type (
 		// auto-connecting to it, giving longer aliases that share a prefix time
 		// to be typed. Any duration string time.ParseDuration accepts.
 		AliasAutoConnectDelay string `toml:"alias_auto_connect_delay"`
+		// AliasFilterPrefix is the single character that, typed first in the
+		// picker, narrows the list to aliased sessions. It is a pointer so an
+		// explicit empty string (disable the mode) is distinguishable from an
+		// absent key (use DefaultAliasFilterPrefix).
+		AliasFilterPrefix *string `toml:"alias_filter_prefix"`
 	}
 
 	WildcardConfig struct {

--- a/model/config.go
+++ b/model/config.go
@@ -1,5 +1,9 @@
 package model
 
+// DefaultAliasAutoConnectDelay is the grace period used when
+// [tui] alias_auto_connect_delay is not set.
+const DefaultAliasAutoConnectDelay = "150ms"
+
 type (
 	Config struct {
 		Cache                   bool                 `toml:"cache"`
@@ -55,6 +59,14 @@ type (
 		Name                string `toml:"name"`
 		Path                string `toml:"path"`
 		DisableStartCommand bool   `toml:"disable_startup_command"`
+		// Alias is a short, exact-match shortcut for this session. Typing it in
+		// the picker marks the session with a chip, and `sesh connect <alias>`
+		// resolves to this session's name.
+		Alias string `toml:"alias"`
+		// AliasAutoConnect connects to this session as soon as its alias is
+		// fully typed in the picker, without pressing enter. Opt-in per session
+		// since it is only desirable for sessions you jump to constantly.
+		AliasAutoConnect bool `toml:"alias_auto_connect"`
 		DefaultSessionConfig
 	}
 
@@ -70,6 +82,10 @@ type (
 		ShowWindows bool   `toml:"show_windows"`
 		Prompt      string `toml:"prompt"`
 		Placeholder string `toml:"placeholder"`
+		// AliasAutoConnectDelay is the grace period between typing an alias and
+		// auto-connecting to it, giving longer aliases that share a prefix time
+		// to be typed. Any duration string time.ParseDuration accepts.
+		AliasAutoConnectDelay string `toml:"alias_auto_connect_delay"`
 	}
 
 	WildcardConfig struct {

--- a/picker/picker.go
+++ b/picker/picker.go
@@ -3,6 +3,8 @@ package picker
 import (
 	"errors"
 	"fmt"
+	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -15,11 +17,12 @@ const (
 )
 
 type PickerOptions struct {
-	ShowIcons      *bool
-	ShowWindows    *bool
-	SeparatorAware *bool
-	Prompt         *string
-	Placeholder    *string
+	ShowIcons               *bool
+	ShowWindows             *bool
+	SeparatorAware          *bool
+	Prompt                  *string
+	Placeholder             *string
+	DisableAliasAutoConnect *bool
 }
 
 type Picker interface {
@@ -32,6 +35,35 @@ type RealPicker struct {
 
 func NewPicker(config model.Config) Picker {
 	return &RealPicker{config: config}
+}
+
+// buildAliases collects the aliases defined on [[session]] blocks, keyed by
+// lowercased alias so lookups are case-insensitive. Duplicate aliases are
+// rejected at config load, so last-one-wins here is unreachable in practice.
+func buildAliases(sessions []model.SessionConfig) map[string]Alias {
+	aliases := make(map[string]Alias)
+	for _, session := range sessions {
+		if session.Alias == "" || session.Name == "" {
+			continue
+		}
+		aliases[strings.ToLower(session.Alias)] = Alias{
+			Alias:       session.Alias,
+			Target:      session.Name,
+			AutoConnect: session.AliasAutoConnect,
+		}
+	}
+	return aliases
+}
+
+// aliasAutoConnectDelay parses the configured delay, falling back to the
+// default rather than failing the picker on a malformed value (the configurator
+// already rejects those at load time).
+func aliasAutoConnectDelay(configured string) time.Duration {
+	if d, err := time.ParseDuration(configured); err == nil {
+		return d
+	}
+	d, _ := time.ParseDuration(model.DefaultAliasAutoConnectDelay)
+	return d
 }
 
 func (p *RealPicker) Pick(fetchFunc FetchFunc, opts PickerOptions) (string, error) {
@@ -61,7 +93,21 @@ func (p *RealPicker) Pick(fetchFunc FetchFunc, opts PickerOptions) (string, erro
 		placeholder = p.config.TUI.Placeholder
 	}
 
-	m := New(fetchFunc, showIcons, showWindows, p.config.SeparatorAware, prompt, placeholder)
+	disableAliasAutoConnect := false
+	if opts.DisableAliasAutoConnect != nil {
+		disableAliasAutoConnect = *opts.DisableAliasAutoConnect
+	}
+
+	m := New(fetchFunc, Options{
+		ShowIcons:               showIcons,
+		ShowWindows:             showWindows,
+		SeparatorAware:          p.config.SeparatorAware,
+		Prompt:                  prompt,
+		Placeholder:             placeholder,
+		Aliases:                 buildAliases(p.config.SessionConfigs),
+		AliasAutoConnectDelay:   aliasAutoConnectDelay(p.config.TUI.AliasAutoConnectDelay),
+		DisableAliasAutoConnect: disableAliasAutoConnect,
+	})
 	prog := tea.NewProgram(m)
 	result, err := prog.Run()
 	if err != nil {

--- a/picker/picker.go
+++ b/picker/picker.go
@@ -66,6 +66,17 @@ func aliasAutoConnectDelay(configured string) time.Duration {
 	return d
 }
 
+// aliasFilterPrefix resolves the sigil that enters alias-filter mode. A nil
+// value means the key is absent (the configurator normally fills it in, but the
+// picker can be constructed with a bare config), while an explicit empty string
+// disables the mode.
+func aliasFilterPrefix(configured *string) string {
+	if configured == nil {
+		return model.DefaultAliasFilterPrefix
+	}
+	return *configured
+}
+
 func (p *RealPicker) Pick(fetchFunc FetchFunc, opts PickerOptions) (string, error) {
 	showIcons := false
 	if opts.ShowIcons != nil {
@@ -105,6 +116,7 @@ func (p *RealPicker) Pick(fetchFunc FetchFunc, opts PickerOptions) (string, erro
 		Prompt:                  prompt,
 		Placeholder:             placeholder,
 		Aliases:                 buildAliases(p.config.SessionConfigs),
+		AliasFilterPrefix:       aliasFilterPrefix(p.config.TUI.AliasFilterPrefix),
 		AliasAutoConnectDelay:   aliasAutoConnectDelay(p.config.TUI.AliasAutoConnectDelay),
 		DisableAliasAutoConnect: disableAliasAutoConnect,
 	})

--- a/picker/picker_test.go
+++ b/picker/picker_test.go
@@ -11,6 +11,7 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/joshmedeski/sesh/v2/model"
 )
@@ -719,7 +720,7 @@ func TestView_AliasChip_RowsFitContentWidth(t *testing.T) {
 	t.Fatal("expected a row for the sesh session")
 }
 
-func TestApplyFilter_AliasesDoNotAffectResults(t *testing.T) {
+func TestApplyFilter_NonAliasQueriesAreUnaffected(t *testing.T) {
 	plain := newTestModel()
 	plain.filterInput.SetValue("o")
 	plain.applyFilter()
@@ -731,8 +732,88 @@ func TestApplyFilter_AliasesDoNotAffectResults(t *testing.T) {
 	assert.Equal(t, len(plain.filtered), len(aliased.filtered))
 	for i := range plain.filtered {
 		assert.Equal(t, plain.filtered[i].item.name, aliased.filtered[i].item.name,
-			"aliases must not reorder or filter results")
+			"anything short of an exact alias must rank exactly as before")
 	}
+}
+
+func TestApplyFilter_ExactAliasIsTheOnlyResult(t *testing.T) {
+	m := newAliasModel()
+	m.filterInput.SetValue("wp")
+	m.applyFilter()
+
+	require.Len(t, m.filtered, 1, "an exact alias resolves to its session, whatever the ranking")
+	assert.Equal(t, "my-project", m.filtered[0].item.name)
+	assert.Empty(t, m.filtered[0].matchedIndexes,
+		"the alias matched the session, not characters within its name")
+	assert.Equal(t, "tmux", m.filtered[0].item.src,
+		"the listed session is reused so its source and windows come along")
+}
+
+func TestApplyFilter_ExactAliasIsCaseInsensitive(t *testing.T) {
+	m := newAliasModel()
+	m.filterInput.SetValue("WP")
+	m.applyFilter()
+
+	require.Len(t, m.filtered, 1)
+	assert.Equal(t, "my-project", m.filtered[0].item.name)
+}
+
+func TestApplyFilter_AliasTargetMissingFromList(t *testing.T) {
+	m := newAliasModel(func(o *Options) {
+		o.Aliases = map[string]Alias{"wp": {Alias: "wp", Target: "wallpaper"}}
+	})
+	m.filterInput.SetValue("wp")
+	m.applyFilter()
+
+	require.Len(t, m.filtered, 1,
+		"an alias always names a [[session]], so it stays selectable when unlisted")
+	assert.Equal(t, "wallpaper", m.filtered[0].item.name)
+	assert.Equal(t, "config", m.filtered[0].item.src)
+}
+
+func TestApplyFilter_PartialAliasFallsBackToFuzzy(t *testing.T) {
+	m := newAliasModel()
+	m.filterInput.SetValue("do")
+	m.applyFilter()
+
+	require.Len(t, m.filtered, 1)
+	assert.NotEmpty(t, m.filtered[0].matchedIndexes,
+		"a partial alias is fuzzy-matched like any other query")
+}
+
+func TestApplyFilter_TypingPastAnAliasFallsBackToFuzzy(t *testing.T) {
+	m := newAliasModel()
+	m.filterInput.SetValue("dotf")
+	m.applyFilter()
+
+	require.Len(t, m.filtered, 1)
+	assert.NotEmpty(t, m.filtered[0].matchedIndexes,
+		"past the alias the query is fuzzy-matched again")
+}
+
+func TestApplyFilter_ExactAliasIgnoresSeparatorNormalization(t *testing.T) {
+	m := newAliasModel(func(o *Options) {
+		o.SeparatorAware = true
+		o.Aliases = map[string]Alias{"w-p": {Alias: "w-p", Target: "my-project"}}
+	})
+
+	m.filterInput.SetValue("w p")
+	m.applyFilter()
+	assert.NotEqual(t, 1, len(m.filtered),
+		"normalized input must not resolve an alias containing a separator")
+
+	m.filterInput.SetValue("w-p")
+	m.applyFilter()
+	require.Len(t, m.filtered, 1)
+	assert.Equal(t, "my-project", m.filtered[0].item.name)
+}
+
+func TestEnter_AfterTypingAliasSelectsTheTarget(t *testing.T) {
+	m, _ := typeFilter(newAliasModel(), "dot")
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	assert.Equal(t, "dotfiles", result.(Model).Chosen(),
+		"enter must land on the aliased session even without auto-connect")
 }
 
 func TestAliasAutoConnect_FiresOnExactAlias(t *testing.T) {

--- a/picker/picker_test.go
+++ b/picker/picker_test.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/joshmedeski/sesh/v2/model"
@@ -33,10 +35,26 @@ func testFetchFunc(sessions model.SeshSessions) FetchFunc {
 	}
 }
 
+func testOptions() Options {
+	return Options{
+		Prompt:                "> ",
+		Placeholder:           "Filter sessions...",
+		AliasAutoConnectDelay: 150 * time.Millisecond,
+	}
+}
+
+// testOptionsWith builds the default test options and lets a test tweak the
+// handful of fields it cares about.
+func testOptionsWith(fn func(*Options)) Options {
+	opts := testOptions()
+	fn(&opts)
+	return opts
+}
+
 // newTestModel creates a model and simulates the async load completing.
 func newTestModel() Model {
 	sessions := testSessions()
-	m := New(testFetchFunc(sessions), false, false, false, "> ", "Filter sessions...")
+	m := New(testFetchFunc(sessions), testOptions())
 	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
 	return result.(Model)
 }
@@ -53,7 +71,7 @@ func TestNew(t *testing.T) {
 
 func TestNew_StartsInLoadingState(t *testing.T) {
 	sessions := testSessions()
-	m := New(testFetchFunc(sessions), false, false, false, "> ", "Filter sessions...")
+	m := New(testFetchFunc(sessions), testOptions())
 	assert.True(t, m.loading)
 	assert.Len(t, m.allItems, 0)
 	assert.Len(t, m.filtered, 0)
@@ -202,7 +220,7 @@ func TestUpdate_Enter_EmptyList(t *testing.T) {
 
 func TestUpdate_Enter_WhileLoading(t *testing.T) {
 	sessions := testSessions()
-	m := New(testFetchFunc(sessions), false, false, false, "> ", "Filter sessions...")
+	m := New(testFetchFunc(sessions), testOptions())
 	assert.True(t, m.loading)
 
 	result, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
@@ -215,7 +233,7 @@ func TestUpdate_Enter_WhileLoading(t *testing.T) {
 
 func TestUpdate_Escape_WhileLoading(t *testing.T) {
 	sessions := testSessions()
-	m := New(testFetchFunc(sessions), false, false, false, "> ", "Filter sessions...")
+	m := New(testFetchFunc(sessions), testOptions())
 
 	result, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	resultModel := result.(Model)
@@ -225,7 +243,7 @@ func TestUpdate_Escape_WhileLoading(t *testing.T) {
 
 func TestUpdate_SessionsLoaded(t *testing.T) {
 	sessions := testSessions()
-	m := New(testFetchFunc(sessions), false, false, false, "> ", "Filter sessions...")
+	m := New(testFetchFunc(sessions), testOptions())
 	assert.True(t, m.loading)
 
 	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
@@ -239,7 +257,7 @@ func TestUpdate_SessionsLoaded(t *testing.T) {
 
 func TestUpdate_SessionsLoaded_WithPreTypedFilter(t *testing.T) {
 	sessions := testSessions()
-	m := New(testFetchFunc(sessions), false, false, false, "> ", "Filter sessions...")
+	m := New(testFetchFunc(sessions), testOptions())
 
 	// Simulate typing "dot" before sessions arrive
 	m.filterInput.SetValue("dot")
@@ -257,7 +275,7 @@ func TestUpdate_SessionsLoadError(t *testing.T) {
 	fetchErr := errors.New("zoxide not found")
 	m := New(func() (model.SeshSessions, error) {
 		return model.SeshSessions{}, fetchErr
-	}, false, false, false, "> ", "Filter sessions...")
+	}, testOptions())
 
 	result, _ := m.Update(sessionsLoadedMsg{err: fetchErr})
 	resultModel := result.(Model)
@@ -307,7 +325,7 @@ func TestView_ReturnsNonEmpty(t *testing.T) {
 
 func TestView_LoadingState(t *testing.T) {
 	sessions := testSessions()
-	m := New(testFetchFunc(sessions), false, false, false, "> ", "Filter sessions...")
+	m := New(testFetchFunc(sessions), testOptions())
 	m.width = 60
 	m.height = 24
 
@@ -352,7 +370,7 @@ func TestHalfPageMovement(t *testing.T) {
 		index[i] = key
 	}
 	sessions := model.SeshSessions{OrderedIndex: index, Directory: dir}
-	m := New(testFetchFunc(sessions), false, false, false, "> ", "Filter sessions...")
+	m := New(testFetchFunc(sessions), testOptions())
 	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
 	m = result.(Model)
 	m.height = 20
@@ -366,7 +384,7 @@ func TestHalfPageMovement(t *testing.T) {
 // newTestModelSeparatorAware creates a model with separator-aware matching enabled.
 func newTestModelSeparatorAware() Model {
 	sessions := testSessions()
-	m := New(testFetchFunc(sessions), false, false, true, "> ", "Filter sessions...")
+	m := New(testFetchFunc(sessions), testOptionsWith(func(o *Options) { o.SeparatorAware = true }))
 	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
 	return result.(Model)
 }
@@ -463,7 +481,7 @@ func sessionsWithWindows() model.SeshSessions {
 // newTestModelWithWindows creates a loaded model with window display enabled.
 func newTestModelWithWindows() Model {
 	sessions := sessionsWithWindows()
-	m := New(testFetchFunc(sessions), false, true, false, "> ", "Filter sessions...")
+	m := New(testFetchFunc(sessions), testOptionsWith(func(o *Options) { o.ShowWindows = true }))
 	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
 	m = result.(Model)
 	m.width = 60
@@ -483,7 +501,7 @@ func TestView_ShowWindows(t *testing.T) {
 
 func TestView_ShowWindows_Disabled(t *testing.T) {
 	sessions := sessionsWithWindows()
-	m := New(testFetchFunc(sessions), false, false, false, "> ", "Filter sessions...")
+	m := New(testFetchFunc(sessions), testOptions())
 	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
 	m = result.(Model)
 	m.width = 60
@@ -514,7 +532,7 @@ func TestView_ShowWindows_RowsFitContentWidth(t *testing.T) {
 		}},
 	}
 	sessions := model.SeshSessions{OrderedIndex: []string{"s1"}, Directory: dir}
-	m := New(testFetchFunc(sessions), false, true, false, "> ", "Filter sessions...")
+	m := New(testFetchFunc(sessions), testOptionsWith(func(o *Options) { o.ShowWindows = true }))
 	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
 	m = result.(Model)
 	m.width = 60
@@ -558,6 +576,280 @@ func TestSessionItems_StringIgnoresWindowNames(t *testing.T) {
 		assert.Equal(t, items[i].name, items.String(i),
 			"fuzzy source must expose the session name only")
 	}
+}
+
+// testAliases mirrors what buildAliases produces for a config with `wp` on
+// wallpaper (auto-connect) and `dot` on dotfiles (no auto-connect).
+func testAliases() map[string]Alias {
+	return map[string]Alias{
+		"wp":  {Alias: "wp", Target: "my-project", AutoConnect: true},
+		"dot": {Alias: "dot", Target: "dotfiles"},
+	}
+}
+
+// newAliasModel returns a loaded model with testAliases applied. The delay is
+// kept tiny so tests that wait out a real tick stay fast.
+func newAliasModel(tweak ...func(*Options)) Model {
+	sessions := testSessions()
+	m := New(testFetchFunc(sessions), testOptionsWith(func(o *Options) {
+		o.Aliases = testAliases()
+		o.AliasAutoConnectDelay = time.Millisecond
+		for _, fn := range tweak {
+			fn(o)
+		}
+	}))
+	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
+	m = result.(Model)
+	m.width = 60
+	m.height = 24
+	return m
+}
+
+// typeFilter types a value one key at a time, exercising the same code path as
+// a real user, and returns the model plus the command from the last keystroke.
+func typeFilter(m Model, value string) (Model, tea.Cmd) {
+	var cmd tea.Cmd
+	for _, r := range value {
+		var result tea.Model
+		result, cmd = m.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+		m = result.(Model)
+	}
+	return m, cmd
+}
+
+// aliasTick runs a command and digs out the auto-connect message it produces,
+// returning nil when no auto-connect was scheduled. The text input always
+// returns a cursor-blink command, so the command being non-nil says nothing on
+// its own.
+func aliasTick(cmd tea.Cmd) *aliasAutoConnectMsg {
+	if cmd == nil {
+		return nil
+	}
+	switch msg := cmd().(type) {
+	case aliasAutoConnectMsg:
+		return &msg
+	case tea.BatchMsg:
+		for _, batched := range msg {
+			if found := aliasTick(batched); found != nil {
+				return found
+			}
+		}
+	}
+	return nil
+}
+
+func TestBuildAliases(t *testing.T) {
+	aliases := buildAliases([]model.SessionConfig{
+		{Name: "wallpaper", Alias: "WP", AliasAutoConnect: true},
+		{Name: "dotfiles", Alias: "dot"},
+		{Name: "notes"},
+		{Name: "", Alias: "orphan"},
+	})
+
+	assert.Len(t, aliases, 2, "sessions without an alias or name are skipped")
+	assert.Equal(t, Alias{Alias: "WP", Target: "wallpaper", AutoConnect: true}, aliases["wp"],
+		"aliases are keyed lowercased but keep their configured casing for display")
+	assert.False(t, aliases["dot"].AutoConnect)
+}
+
+func TestAliasAutoConnectDelay(t *testing.T) {
+	assert.Equal(t, 300*time.Millisecond, aliasAutoConnectDelay("300ms"))
+	assert.Equal(t, 150*time.Millisecond, aliasAutoConnectDelay(""), "empty falls back to the default")
+	assert.Equal(t, 150*time.Millisecond, aliasAutoConnectDelay("nonsense"), "invalid falls back to the default")
+}
+
+// reverseVideo is the escape sequence that swaps foreground and background,
+// which is what keeps the chip label legible under any color scheme.
+const reverseVideo = "\x1b[7m"
+
+func TestAliasChip(t *testing.T) {
+	m := newAliasModel(func(o *Options) { o.ShowIcons = true })
+	chip := m.aliasChip("my-project")
+	assert.Contains(t, chip, "wp")
+	assert.Contains(t, chip, chipLeftGlyph)
+	assert.Contains(t, chip, chipRightGlyph)
+	assert.Contains(t, chip, reverseVideo, "the chip label must be inverted to stay legible")
+	assert.Equal(t, "", m.aliasChip("notes"), "sessions without an alias get no chip")
+
+	plain := newAliasModel()
+	assert.Contains(t, plain.aliasChip("my-project"), "[wp]")
+	assert.Contains(t, plain.aliasChip("my-project"), reverseVideo)
+	assert.NotContains(t, plain.aliasChip("my-project"), chipLeftGlyph,
+		"nerd font glyphs are only used when icons are enabled")
+}
+
+func TestView_AliasChip(t *testing.T) {
+	m := newAliasModel()
+	out := ansi.Strip(fmt.Sprintf("%v", m.View()))
+
+	assert.Contains(t, out, "[wp] my-project")
+	assert.Contains(t, out, "[dot] dotfiles")
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "notes") {
+			assert.Equal(t, "  notes", strings.TrimRight(line, " \r"),
+				"a session without an alias should render exactly as before")
+		}
+	}
+}
+
+func TestView_AliasChip_RowsFitContentWidth(t *testing.T) {
+	dir := model.SeshSessionMap{
+		"s1": {Name: "sesh", Src: "tmux", WindowNames: []string{
+			"editor", "server", "logs", "database", "tests", "docs", "shell",
+		}},
+	}
+	sessions := model.SeshSessions{OrderedIndex: []string{"s1"}, Directory: dir}
+	m := New(testFetchFunc(sessions), testOptionsWith(func(o *Options) {
+		o.ShowWindows = true
+		o.Aliases = map[string]Alias{"sh": {Alias: "sh", Target: "sesh"}}
+	}))
+	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
+	m = result.(Model)
+	m.width = 60
+	m.height = 24
+
+	out := fmt.Sprintf("%v", m.View())
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "sesh") {
+			assert.LessOrEqual(t, lipgloss.Width(line), m.contentWidth(),
+				"the chip must be counted against the row's width budget")
+			return
+		}
+	}
+	t.Fatal("expected a row for the sesh session")
+}
+
+func TestApplyFilter_AliasesDoNotAffectResults(t *testing.T) {
+	plain := newTestModel()
+	plain.filterInput.SetValue("o")
+	plain.applyFilter()
+
+	aliased := newAliasModel()
+	aliased.filterInput.SetValue("o")
+	aliased.applyFilter()
+
+	assert.Equal(t, len(plain.filtered), len(aliased.filtered))
+	for i := range plain.filtered {
+		assert.Equal(t, plain.filtered[i].item.name, aliased.filtered[i].item.name,
+			"aliases must not reorder or filter results")
+	}
+}
+
+func TestAliasAutoConnect_FiresOnExactAlias(t *testing.T) {
+	m, cmd := typeFilter(newAliasModel(), "wp")
+	tick := aliasTick(cmd)
+	if assert.NotNil(t, tick, "typing an auto-connect alias should schedule a tick") {
+		assert.Equal(t, m.aliasSeq, tick.seq)
+	}
+
+	result, quitCmd := m.Update(*tick)
+	resultModel := result.(Model)
+
+	assert.Equal(t, "my-project", resultModel.Chosen())
+	assert.NotNil(t, quitCmd)
+	assert.False(t, resultModel.Quit(), "auto-connect is a selection, not a cancel")
+}
+
+func TestAliasAutoConnect_MatchesCaseInsensitively(t *testing.T) {
+	m, cmd := typeFilter(newAliasModel(), "WP")
+	assert.NotNil(t, aliasTick(cmd))
+
+	result, _ := m.Update(aliasAutoConnectMsg{seq: m.aliasSeq, alias: "wp"})
+	assert.Equal(t, "my-project", result.(Model).Chosen())
+}
+
+func TestAliasAutoConnect_IgnoresStaleTick(t *testing.T) {
+	m, _ := typeFilter(newAliasModel(), "wp")
+
+	result, _ := m.Update(aliasAutoConnectMsg{seq: m.aliasSeq - 1, alias: "wp"})
+	assert.Equal(t, "", result.(Model).Chosen(),
+		"a tick from an earlier keystroke must not connect")
+}
+
+func TestAliasAutoConnect_IgnoresTickAfterFilterChanged(t *testing.T) {
+	m, _ := typeFilter(newAliasModel(), "wp")
+	seq := m.aliasSeq
+	m.filterInput.SetValue("wpx")
+
+	result, _ := m.Update(aliasAutoConnectMsg{seq: seq, alias: "wp"})
+	assert.Equal(t, "", result.(Model).Chosen(),
+		"keeping typing past an alias must not connect to it")
+}
+
+func TestAliasAutoConnect_SkipsAliasesWithoutAutoConnect(t *testing.T) {
+	m, cmd := typeFilter(newAliasModel(), "dot")
+	assert.Nil(t, aliasTick(cmd), "an alias without alias_auto_connect should not schedule a tick")
+
+	result, _ := m.Update(aliasAutoConnectMsg{seq: m.aliasSeq, alias: "dot"})
+	assert.Equal(t, "", result.(Model).Chosen(),
+		"even a hand-delivered tick must not connect without alias_auto_connect")
+}
+
+func TestAliasAutoConnect_PartialAliasDoesNothing(t *testing.T) {
+	_, cmd := typeFilter(newAliasModel(), "w")
+	assert.Nil(t, aliasTick(cmd), "a partial alias behaves like a normal fuzzy query")
+}
+
+func TestAliasAutoConnect_TrailingWhitespaceDoesNotMatch(t *testing.T) {
+	_, cmd := typeFilter(newAliasModel(), "wp ")
+	assert.Nil(t, aliasTick(cmd), "the alias must match the raw input exactly")
+}
+
+func TestAliasAutoConnect_Suppressed(t *testing.T) {
+	m, cmd := typeFilter(newAliasModel(func(o *Options) { o.DisableAliasAutoConnect = true }), "wp")
+	assert.Nil(t, aliasTick(cmd), "--no-alias-auto should stop the tick from being scheduled")
+
+	result, _ := m.Update(aliasAutoConnectMsg{seq: m.aliasSeq, alias: "wp"})
+	assert.Equal(t, "", result.(Model).Chosen())
+}
+
+func TestAliasAutoConnect_FiresWhileLoading(t *testing.T) {
+	sessions := testSessions()
+	m := New(testFetchFunc(sessions), testOptionsWith(func(o *Options) {
+		o.Aliases = testAliases()
+		o.AliasAutoConnectDelay = time.Millisecond
+	}))
+	assert.True(t, m.loading)
+
+	m, cmd := typeFilter(m, "wp")
+	assert.NotNil(t, aliasTick(cmd),
+		"the alias target comes from config, so loading must not block it")
+
+	result, _ := m.Update(aliasAutoConnectMsg{seq: m.aliasSeq, alias: "wp"})
+	assert.Equal(t, "my-project", result.(Model).Chosen())
+}
+
+func TestScheduleAliasAutoConnect_ZeroDelaySkipsTimer(t *testing.T) {
+	m := newAliasModel(func(o *Options) { o.AliasAutoConnectDelay = 0 })
+	m.filterInput.SetValue("wp")
+
+	cmd := m.scheduleAliasAutoConnect()
+	if assert.NotNil(t, cmd) {
+		assert.Equal(t, aliasAutoConnectMsg{seq: m.aliasSeq, alias: "wp"}, cmd(),
+			"a zero delay should not go through a timer")
+	}
+}
+
+func TestScheduleAliasAutoConnect_BumpsSeqOnEveryChange(t *testing.T) {
+	m := newAliasModel()
+	m.filterInput.SetValue("notes")
+
+	assert.Nil(t, m.scheduleAliasAutoConnect(), "a non-alias schedules nothing")
+	assert.Equal(t, 1, m.aliasSeq,
+		"the sequence still advances so any pending tick is invalidated")
+}
+
+func TestAliasAutoConnect_SeparatorAwareDoesNotMangleAliases(t *testing.T) {
+	m := newAliasModel(func(o *Options) {
+		o.SeparatorAware = true
+		o.Aliases = map[string]Alias{"w-p": {Alias: "w-p", Target: "my-project", AutoConnect: true}}
+	})
+
+	_, cmd := typeFilter(m, "w p")
+	assert.Nil(t, aliasTick(cmd), "normalized input must not match an alias containing a separator")
+
+	_, cmd = typeFilter(m, "w-p")
+	assert.NotNil(t, aliasTick(cmd), "the raw alias still matches with separator_aware on")
 }
 
 func TestWindowsText(t *testing.T) {

--- a/picker/picker_test.go
+++ b/picker/picker_test.go
@@ -41,6 +41,7 @@ func testOptions() Options {
 		Prompt:                "> ",
 		Placeholder:           "Filter sessions...",
 		AliasAutoConnectDelay: 150 * time.Millisecond,
+		AliasFilterPrefix:     model.DefaultAliasFilterPrefix,
 	}
 }
 
@@ -665,18 +666,31 @@ const reverseVideo = "\x1b[7m"
 
 func TestAliasChip(t *testing.T) {
 	m := newAliasModel(func(o *Options) { o.ShowIcons = true })
-	chip := m.aliasChip("my-project")
+	chip := m.aliasChip("my-project", 0)
 	assert.Contains(t, chip, "wp")
 	assert.Contains(t, chip, chipLeftGlyph)
 	assert.Contains(t, chip, chipRightGlyph)
 	assert.Contains(t, chip, reverseVideo, "the chip label must be inverted to stay legible")
-	assert.Equal(t, "", m.aliasChip("notes"), "sessions without an alias get no chip")
+	assert.Equal(t, "", m.aliasChip("notes", 0), "sessions without an alias get no chip")
 
 	plain := newAliasModel()
-	assert.Contains(t, plain.aliasChip("my-project"), "[wp]")
-	assert.Contains(t, plain.aliasChip("my-project"), reverseVideo)
-	assert.NotContains(t, plain.aliasChip("my-project"), chipLeftGlyph,
+	assert.Contains(t, ansi.Strip(plain.aliasChip("my-project", 0)), "[wp]")
+	assert.Contains(t, plain.aliasChip("my-project", 0), reverseVideo)
+	assert.NotContains(t, plain.aliasChip("my-project", 0), chipLeftGlyph,
 		"nerd font glyphs are only used when icons are enabled")
+}
+
+func TestAliasChip_HighlightsMatchedPrefix(t *testing.T) {
+	m := newAliasModel()
+
+	// The matched runes carry a color on top of reverse video, so they read as a
+	// colored block; the rest of the label stays plain reverse video.
+	assert.NotEqual(t, m.aliasChip("my-project", 0), m.aliasChip("my-project", 1),
+		"a matched prefix must be styled differently from an unmatched label")
+	assert.Equal(t, "[wp] ", ansi.Strip(m.aliasChip("my-project", 1)),
+		"highlighting must not change the text of the chip")
+	assert.Equal(t, m.aliasChip("my-project", 2), m.aliasChip("my-project", 99),
+		"a match longer than the alias is clamped rather than panicking")
 }
 
 func TestView_AliasChip(t *testing.T) {
@@ -931,6 +945,199 @@ func TestAliasAutoConnect_SeparatorAwareDoesNotMangleAliases(t *testing.T) {
 
 	_, cmd = typeFilter(m, "w-p")
 	assert.NotNil(t, aliasTick(cmd), "the raw alias still matches with separator_aware on")
+}
+
+// filteredNames lists the session names currently shown, for asserting on both
+// membership and order.
+func filteredNames(m Model) []string {
+	names := make([]string, 0, len(m.filtered))
+	for _, item := range m.filtered {
+		names = append(names, item.item.name)
+	}
+	return names
+}
+
+// filterAliasMode types a query into alias-filter mode, sigil included.
+func filterAliasMode(m Model, query string) Model {
+	m.filterInput.SetValue(m.aliasFilterPrefix + query)
+	m.applyFilter()
+	return m
+}
+
+func TestApplyFilter_AliasModeShowsEveryAlias(t *testing.T) {
+	m := filterAliasMode(newAliasModel(), "")
+
+	assert.Equal(t, []string{"my-project", "dotfiles"}, filteredNames(m),
+		"the bare sigil narrows to aliased sessions, in list order")
+	for _, item := range m.filtered {
+		assert.Equal(t, 0, item.chipMatchLen, "nothing is typed yet, so nothing is highlighted")
+	}
+}
+
+func TestApplyFilter_AliasModeMatchesAliasPrefix(t *testing.T) {
+	m := filterAliasMode(newAliasModel(), "d")
+
+	require.Equal(t, []string{"dotfiles"}, filteredNames(m))
+	assert.Equal(t, 1, m.filtered[0].chipMatchLen, "the matched part of the chip is highlighted")
+
+	// `xy` on a session whose name shares no letters with the query isolates the
+	// alias tier from the session-name fallback.
+	mid := newAliasModel(func(o *Options) {
+		o.Aliases = map[string]Alias{"xy": {Alias: "xy", Target: "notes"}}
+	})
+	assert.Empty(t, filteredNames(filterAliasMode(mid, "y")),
+		"aliases match by prefix, so a mid-alias substring finds nothing")
+}
+
+func TestApplyFilter_AliasModeIsCaseInsensitive(t *testing.T) {
+	m := filterAliasMode(newAliasModel(), "DO")
+	assert.Equal(t, []string{"dotfiles"}, filteredNames(m))
+}
+
+func TestApplyFilter_AliasModeFallsBackToSessionName(t *testing.T) {
+	m := filterAliasMode(newAliasModel(), "project")
+
+	require.Equal(t, []string{"my-project"}, filteredNames(m),
+		"a session name is matched by substring, since names are multi-word")
+	assert.Equal(t, 0, m.filtered[0].chipMatchLen,
+		"the query matched the name, not the chip, so the chip is left plain")
+}
+
+func TestApplyFilter_AliasModeRanksAliasMatchesFirst(t *testing.T) {
+	m := newAliasModel(func(o *Options) {
+		o.Aliases = map[string]Alias{
+			"do": {Alias: "do", Target: "my-project"},
+			"z":  {Alias: "z", Target: "dotfiles"},
+		}
+	})
+	m = filterAliasMode(m, "do")
+
+	assert.Equal(t, []string{"my-project", "dotfiles"}, filteredNames(m),
+		"an alias match outranks a session whose name merely contains the query")
+}
+
+func TestApplyFilter_AliasModeIncludesUnlistedAliases(t *testing.T) {
+	m := newAliasModel(func(o *Options) {
+		o.Aliases = map[string]Alias{
+			"dot": {Alias: "dot", Target: "dotfiles"},
+			"wp":  {Alias: "wp", Target: "wallpaper"},
+			"aa":  {Alias: "aa", Target: "archive"},
+		}
+	})
+	m = filterAliasMode(m, "")
+
+	assert.Equal(t, []string{"dotfiles", "archive", "wallpaper"}, filteredNames(m),
+		"unlisted aliases trail the listed ones, sorted so the order never shifts")
+	for _, item := range m.filtered[1:] {
+		assert.Equal(t, "config", item.item.src)
+	}
+}
+
+func TestApplyFilter_AliasModeWithNoMatches(t *testing.T) {
+	m := filterAliasMode(newAliasModel(), "zzz")
+	assert.Empty(t, m.filtered)
+}
+
+func TestApplyFilter_AliasModeWithNoAliasesConfigured(t *testing.T) {
+	m := newTestModel()
+	m.width, m.height = 60, 24
+	m = filterAliasMode(m, "")
+
+	assert.Empty(t, m.filtered)
+	assert.Contains(t, ansi.Strip(fmt.Sprintf("%v", m.View())), "No aliases configured",
+		"the sigil should read as unconfigured rather than broken")
+}
+
+func TestApplyFilter_SigilPastTheStartIsANormalQuery(t *testing.T) {
+	m := newAliasModel()
+	m.filterInput.SetValue("code/app")
+	m.applyFilter()
+
+	require.Equal(t, []string{"~/code/app"}, filteredNames(m),
+		"only a leading sigil enters alias mode, so path-like queries still work")
+	assert.NotEmpty(t, m.filtered[0].matchedIndexes)
+}
+
+func TestApplyFilter_CustomAliasFilterPrefix(t *testing.T) {
+	m := newAliasModel(func(o *Options) { o.AliasFilterPrefix = "@" })
+
+	m = filterAliasMode(m, "")
+	assert.Equal(t, []string{"my-project", "dotfiles"}, filteredNames(m))
+
+	m.filterInput.SetValue("/")
+	m.applyFilter()
+	assert.NotEmpty(t, m.filtered, "the default sigil is inert once one is configured")
+}
+
+func TestApplyFilter_AliasFilterPrefixDisabled(t *testing.T) {
+	m := newAliasModel(func(o *Options) { o.AliasFilterPrefix = "" })
+	m.filterInput.SetValue("/")
+	m.applyFilter()
+
+	assert.Equal(t, []string{"~/code/app"}, filteredNames(m),
+		"an empty prefix disables the mode, leaving the sigil a normal query")
+}
+
+func ptr[T any](v T) *T { return &v }
+
+func TestAliasFilterPrefix(t *testing.T) {
+	assert.Equal(t, "/", aliasFilterPrefix(nil), "an absent key falls back to the default")
+	assert.Equal(t, "", aliasFilterPrefix(ptr("")), "an explicit empty string disables the mode")
+	assert.Equal(t, "@", aliasFilterPrefix(ptr("@")))
+}
+
+func TestAliasAutoConnect_AliasModeFiresWithoutTheOptIn(t *testing.T) {
+	m, cmd := typeFilter(newAliasModel(), "/dot")
+	require.NotNil(t, aliasTick(cmd),
+		"reaching for the sigil is itself the intent, so alias_auto_connect isn't required")
+
+	result, quitCmd := m.Update(aliasAutoConnectMsg{seq: m.aliasSeq, alias: "dot"})
+	assert.Equal(t, "dotfiles", result.(Model).Chosen())
+	assert.NotNil(t, quitCmd)
+}
+
+func TestAliasAutoConnect_AliasModePartialAliasDoesNothing(t *testing.T) {
+	_, cmd := typeFilter(newAliasModel(), "/d")
+	assert.Nil(t, aliasTick(cmd), "only an exact alias auto-connects")
+}
+
+func TestAliasAutoConnect_AliasModeSessionNameMatchDoesNothing(t *testing.T) {
+	_, cmd := typeFilter(newAliasModel(), "/project")
+	assert.Nil(t, aliasTick(cmd), "matching a session name is not typing an alias")
+}
+
+func TestAliasAutoConnect_AliasModeLeavesRoomForALongerAlias(t *testing.T) {
+	m := newAliasModel(func(o *Options) {
+		o.Aliases = map[string]Alias{
+			"w":  {Alias: "w", Target: "my-project"},
+			"wp": {Alias: "wp", Target: "dotfiles"},
+		}
+	})
+
+	m, cmd := typeFilter(m, "/w")
+	tick := aliasTick(cmd)
+	require.NotNil(t, tick)
+
+	m, _ = typeFilter(m, "p")
+	result, _ := m.Update(*tick)
+	assert.Equal(t, "", result.(Model).Chosen(),
+		"the tick armed by the shorter alias must not fire once the longer one is typed")
+}
+
+func TestAliasAutoConnect_AliasModeSuppressed(t *testing.T) {
+	m, cmd := typeFilter(newAliasModel(func(o *Options) { o.DisableAliasAutoConnect = true }), "/wp")
+	assert.Nil(t, aliasTick(cmd), "--no-alias-auto covers alias mode too")
+
+	result, _ := m.Update(aliasAutoConnectMsg{seq: m.aliasSeq, alias: "wp"})
+	assert.Equal(t, "", result.(Model).Chosen())
+}
+
+func TestEnter_InAliasModeSelectsTheTarget(t *testing.T) {
+	m, _ := typeFilter(newAliasModel(), "/do")
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	assert.Equal(t, "dotfiles", result.(Model).Chosen(),
+		"the sigil must never leak into the chosen session name")
 }
 
 func TestWindowsText(t *testing.T) {

--- a/picker/tui.go
+++ b/picker/tui.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"image/color"
 	"strings"
+	"time"
 
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
@@ -41,6 +42,42 @@ type sessionsLoadedMsg struct {
 	err      error
 }
 
+// aliasAutoConnectMsg fires once the auto-connect grace period has elapsed. The
+// seq identifies the filter change that scheduled it so later keystrokes can
+// invalidate it.
+type aliasAutoConnectMsg struct {
+	seq   int
+	alias string
+}
+
+// Alias is a picker shortcut for a single session, derived from an
+// [[session]] config block.
+type Alias struct {
+	// Alias is the shortcut as written in the config, used for display.
+	Alias string
+	// Target is the name of the session the alias resolves to.
+	Target string
+	// AutoConnect connects to Target as soon as the alias is fully typed.
+	AutoConnect bool
+}
+
+// Options configures the picker model. Zero values are valid and mean
+// "off"/"unset", except Prompt and Placeholder which are passed through as-is.
+type Options struct {
+	ShowIcons      bool
+	ShowWindows    bool
+	SeparatorAware bool
+	Prompt         string
+	Placeholder    string
+	// Aliases is keyed by lowercased alias.
+	Aliases map[string]Alias
+	// AliasAutoConnectDelay is the grace period before auto-connect fires,
+	// leaving room to finish typing a longer alias that shares a prefix.
+	AliasAutoConnectDelay time.Duration
+	// DisableAliasAutoConnect suppresses auto-connect for this invocation.
+	DisableAliasAutoConnect bool
+}
+
 type Model struct {
 	allItems       sessionItems
 	filtered       []filteredItem
@@ -58,6 +95,16 @@ type Model struct {
 	loading        bool
 	fetchFunc      FetchFunc
 	loadErr        error
+
+	// aliases is keyed by lowercased alias; aliasByName is keyed by session
+	// name so rows can be tagged while rendering.
+	aliases                 map[string]Alias
+	aliasByName             map[string]string
+	aliasAutoConnectDelay   time.Duration
+	disableAliasAutoConnect bool
+	// aliasSeq increments on every filter change so a pending auto-connect
+	// tick can tell whether it is stale.
+	aliasSeq int
 }
 
 // srcIcon returns the nerd font icon and color for a session source.
@@ -75,6 +122,37 @@ func srcIcon(src string) (string, color.Color) {
 		return g.Icon + " ", lipgloss.ANSIColor(ansi)
 	}
 	return "? ", lipgloss.ANSIColor(8)
+}
+
+// Powerline half circles used to round off the alias chip. They are nerd font
+// glyphs, so they are only used when icons are enabled.
+const (
+	chipLeftGlyph  = ""
+	chipRightGlyph = ""
+)
+
+// aliasChip renders the alias of a session as a chip that sits before the
+// session name, e.g. ` wp ` with nerd fonts or `[wp] ` without. It returns ""
+// for sessions that have no alias.
+//
+// The label uses reverse video rather than an explicit fg/bg pair so the text
+// is always the terminal's background color on its foreground color, which
+// stays legible under any color scheme. The half circles are left unstyled for
+// the same reason: their default foreground is exactly the color the reversed
+// label fills with, so the chip reads as one shape.
+func (m Model) aliasChip(name string) string {
+	alias, ok := m.aliasByName[name]
+	if !ok {
+		return ""
+	}
+
+	label := lipgloss.NewStyle().Reverse(true)
+	if !m.showIcons {
+		// Without nerd fonts the half circles render as tofu, so fall back to
+		// brackets that still read as a chip.
+		return label.Render("["+alias+"]") + " "
+	}
+	return chipLeftGlyph + label.Render(alias) + chipRightGlyph + " "
 }
 
 var separatorReplacer = strings.NewReplacer("-", " ", "_", " ", "/", " ", "\\", " ")
@@ -101,18 +179,27 @@ func buildItems(sessions model.SeshSessions, separatorAware bool) sessionItems {
 	return items
 }
 
-func New(fetchFunc FetchFunc, showIcons bool, showWindows bool, separatorAware bool, prompt string, placeholder string) Model {
+func New(fetchFunc FetchFunc, opts Options) Model {
 	ti := textinput.New()
-	ti.Placeholder = placeholder
-	ti.Prompt = prompt
+	ti.Placeholder = opts.Placeholder
+	ti.Prompt = opts.Prompt
+
+	aliasByName := make(map[string]string, len(opts.Aliases))
+	for _, alias := range opts.Aliases {
+		aliasByName[alias.Target] = alias.Alias
+	}
 
 	m := Model{
-		filterInput:    ti,
-		showIcons:      showIcons,
-		showWindows:    showWindows,
-		separatorAware: separatorAware,
-		loading:        true,
-		fetchFunc:      fetchFunc,
+		filterInput:             ti,
+		showIcons:               opts.ShowIcons,
+		showWindows:             opts.ShowWindows,
+		separatorAware:          opts.SeparatorAware,
+		loading:                 true,
+		fetchFunc:               fetchFunc,
+		aliases:                 opts.Aliases,
+		aliasByName:             aliasByName,
+		aliasAutoConnectDelay:   opts.AliasAutoConnectDelay,
+		disableAliasAutoConnect: opts.DisableAliasAutoConnect,
 	}
 	m.focusCmd = m.filterInput.Focus()
 	return m
@@ -131,6 +218,19 @@ func (m Model) fetchSessions() tea.Cmd {
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case aliasAutoConnectMsg:
+		// The tick can't be cancelled, so a stale one still arrives: ignore it
+		// unless it is the latest and the filter still reads as that alias.
+		if msg.seq != m.aliasSeq {
+			return m, nil
+		}
+		alias, ok := m.aliases[strings.ToLower(m.filterInput.Value())]
+		if !ok || alias.Alias != msg.alias || !alias.AutoConnect || m.disableAliasAutoConnect {
+			return m, nil
+		}
+		m.chosen = alias.Target
+		return m, tea.Quit
+
 	case sessionsLoadedMsg:
 		if msg.err != nil {
 			m.loadErr = msg.err
@@ -192,9 +292,37 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.cursor = 0
 		m.offset = 0
+		if tick := m.scheduleAliasAutoConnect(); tick != nil {
+			return m, tea.Batch(cmd, tick)
+		}
 	}
 
 	return m, cmd
+}
+
+// scheduleAliasAutoConnect invalidates any pending auto-connect and, when the
+// filter now reads as an alias that opted into auto-connect, arms a fresh one.
+// It returns nil when there is nothing to schedule. Auto-connect deliberately
+// works while sessions are still loading: the target comes from the config, not
+// from the list, so there is no reason to make the user wait.
+func (m *Model) scheduleAliasAutoConnect() tea.Cmd {
+	m.aliasSeq++
+
+	if m.disableAliasAutoConnect {
+		return nil
+	}
+	// Matched against the raw input: separator-aware normalization must not
+	// turn `w p` into a match for the alias `w-p`.
+	alias, ok := m.aliases[strings.ToLower(m.filterInput.Value())]
+	if !ok || !alias.AutoConnect {
+		return nil
+	}
+
+	msg := aliasAutoConnectMsg{seq: m.aliasSeq, alias: alias.Alias}
+	if m.aliasAutoConnectDelay <= 0 {
+		return func() tea.Msg { return msg }
+	}
+	return tea.Tick(m.aliasAutoConnectDelay, func(time.Time) tea.Msg { return msg })
 }
 
 func (m *Model) applyFilter() {
@@ -312,19 +440,20 @@ func (m Model) View() tea.View {
 				iconStyle := lipgloss.NewStyle().Foreground(clr)
 				tag = iconStyle.Render(icn)
 			}
+			chip := m.aliasChip(item.item.name)
 			name := highlightMatches(item.item.name, item.matchedIndexes, matchStyle, normalStyle)
 
 			var windows string
 			if m.showWindows {
 				// Window names are display-only: they are never highlighted as
 				// matches and never become part of the selected value.
-				used := lipgloss.Width(prefix) + lipgloss.Width(tag) + lipgloss.Width(item.item.name)
+				used := lipgloss.Width(prefix) + lipgloss.Width(tag) + lipgloss.Width(chip) + lipgloss.Width(item.item.name)
 				if text := windowsText(item.item.session.WindowNames, m.contentWidth()-used); text != "" {
 					windows = windowStyle.Render(text)
 				}
 			}
 
-			b.WriteString(fmt.Sprintf("%s%s%s%s\n", prefix, tag, name, windows))
+			b.WriteString(fmt.Sprintf("%s%s%s%s%s\n", prefix, tag, chip, name, windows))
 		}
 
 		// Pad remaining visible lines

--- a/picker/tui.go
+++ b/picker/tui.go
@@ -3,6 +3,7 @@ package picker
 import (
 	"fmt"
 	"image/color"
+	"sort"
 	"strings"
 	"time"
 
@@ -31,6 +32,9 @@ func (s sessionItems) Len() int            { return len(s) }
 type filteredItem struct {
 	item           sessionItem
 	matchedIndexes []int
+	// chipMatchLen is how many leading runes of the alias chip matched the
+	// query, used to highlight the chip in alias-filter mode.
+	chipMatchLen int
 }
 
 // FetchFunc loads sessions asynchronously. It is called in a goroutine by Init().
@@ -71,6 +75,9 @@ type Options struct {
 	Placeholder    string
 	// Aliases is keyed by lowercased alias.
 	Aliases map[string]Alias
+	// AliasFilterPrefix is the sigil that, typed first, narrows the list to
+	// aliased sessions. Empty disables the mode.
+	AliasFilterPrefix string
 	// AliasAutoConnectDelay is the grace period before auto-connect fires,
 	// leaving room to finish typing a longer alias that shares a prefix.
 	AliasAutoConnectDelay time.Duration
@@ -100,6 +107,7 @@ type Model struct {
 	// name so rows can be tagged while rendering.
 	aliases                 map[string]Alias
 	aliasByName             map[string]string
+	aliasFilterPrefix       string
 	aliasAutoConnectDelay   time.Duration
 	disableAliasAutoConnect bool
 	// aliasSeq increments on every filter change so a pending auto-connect
@@ -133,26 +141,44 @@ const (
 
 // aliasChip renders the alias of a session as a chip that sits before the
 // session name, e.g. ` wp ` with nerd fonts or `[wp] ` without. It returns ""
-// for sessions that have no alias.
+// for sessions that have no alias. The first matchLen runes of the alias are
+// highlighted, for alias-filter mode.
 //
 // The label uses reverse video rather than an explicit fg/bg pair so the text
 // is always the terminal's background color on its foreground color, which
 // stays legible under any color scheme. The half circles are left unstyled for
 // the same reason: their default foreground is exactly the color the reversed
 // label fills with, so the chip reads as one shape.
-func (m Model) aliasChip(name string) string {
+func (m Model) aliasChip(name string, matchLen int) string {
 	alias, ok := m.aliasByName[name]
 	if !ok {
 		return ""
 	}
 
 	label := lipgloss.NewStyle().Reverse(true)
+	text := highlightChipPrefix(alias, matchLen, label)
 	if !m.showIcons {
 		// Without nerd fonts the half circles render as tofu, so fall back to
 		// brackets that still read as a chip.
-		return label.Render("["+alias+"]") + " "
+		return label.Render("[") + text + label.Render("]") + " "
 	}
-	return chipLeftGlyph + label.Render(alias) + chipRightGlyph + " "
+	return chipLeftGlyph + text + chipRightGlyph + " "
+}
+
+// highlightChipPrefix styles the first matchLen runes of a chip label as
+// matched. Reverse video is kept throughout so the chip stays one shape;
+// setting a foreground under it paints the matched runes as a colored block,
+// which is the same red used to highlight matches in session names.
+func highlightChipPrefix(alias string, matchLen int, label lipgloss.Style) string {
+	runes := []rune(alias)
+	if matchLen <= 0 {
+		return label.Render(alias)
+	}
+	if matchLen > len(runes) {
+		matchLen = len(runes)
+	}
+	matched := label.Foreground(lipgloss.ANSIColor(1)).Render(string(runes[:matchLen]))
+	return matched + label.Render(string(runes[matchLen:]))
 }
 
 var separatorReplacer = strings.NewReplacer("-", " ", "_", " ", "/", " ", "\\", " ")
@@ -198,6 +224,7 @@ func New(fetchFunc FetchFunc, opts Options) Model {
 		fetchFunc:               fetchFunc,
 		aliases:                 opts.Aliases,
 		aliasByName:             aliasByName,
+		aliasFilterPrefix:       opts.AliasFilterPrefix,
 		aliasAutoConnectDelay:   opts.AliasAutoConnectDelay,
 		disableAliasAutoConnect: opts.DisableAliasAutoConnect,
 	}
@@ -224,8 +251,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.seq != m.aliasSeq {
 			return m, nil
 		}
-		alias, ok := m.aliases[strings.ToLower(m.filterInput.Value())]
-		if !ok || alias.Alias != msg.alias || !alias.AutoConnect || m.disableAliasAutoConnect {
+		alias, ok := m.exactAlias(m.filterInput.Value())
+		if !ok || alias.Alias != msg.alias || m.disableAliasAutoConnect {
 			return m, nil
 		}
 		m.chosen = alias.Target
@@ -300,8 +327,31 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+// exactAlias resolves the input to an alias when one is typed exactly, in
+// either normal or alias-filter mode, and reports whether that alias should
+// auto-connect.
+//
+// In alias-filter mode the per-session alias_auto_connect opt-in is bypassed:
+// reaching for the sigil is itself an explicit statement that the next thing
+// typed is an alias to jump to. In normal mode it still gates, so an alias
+// typed incidentally while filtering doesn't connect on its own.
+//
+// The input is matched raw, never separator-normalized, so an alias containing
+// `-` or `_` can't be matched by typing a space instead.
+func (m *Model) exactAlias(raw string) (Alias, bool) {
+	if query, ok := m.aliasFilterQuery(raw); ok {
+		alias, found := m.aliases[strings.ToLower(query)]
+		return alias, found
+	}
+	alias, found := m.aliases[strings.ToLower(raw)]
+	if !found || !alias.AutoConnect {
+		return Alias{}, false
+	}
+	return alias, true
+}
+
 // scheduleAliasAutoConnect invalidates any pending auto-connect and, when the
-// filter now reads as an alias that opted into auto-connect, arms a fresh one.
+// filter now reads as an alias that should auto-connect, arms a fresh one.
 // It returns nil when there is nothing to schedule. Auto-connect deliberately
 // works while sessions are still loading: the target comes from the config, not
 // from the list, so there is no reason to make the user wait.
@@ -311,10 +361,8 @@ func (m *Model) scheduleAliasAutoConnect() tea.Cmd {
 	if m.disableAliasAutoConnect {
 		return nil
 	}
-	// Matched against the raw input: separator-aware normalization must not
-	// turn `w p` into a match for the alias `w-p`.
-	alias, ok := m.aliases[strings.ToLower(m.filterInput.Value())]
-	if !ok || !alias.AutoConnect {
+	alias, ok := m.exactAlias(m.filterInput.Value())
+	if !ok {
 		return nil
 	}
 
@@ -346,8 +394,79 @@ func (m *Model) aliasMatch(raw string) (sessionItem, bool) {
 	return sessionItem{name: alias.Target, searchName: alias.Target, src: "config"}, true
 }
 
+// aliasFilterQuery reports whether the raw input opens alias-filter mode and,
+// if so, returns whatever was typed after the sigil. Only a leading sigil
+// counts, so slashes inside a path-like query are left alone.
+func (m *Model) aliasFilterQuery(raw string) (string, bool) {
+	if m.aliasFilterPrefix == "" || !strings.HasPrefix(raw, m.aliasFilterPrefix) {
+		return "", false
+	}
+	return strings.TrimPrefix(raw, m.aliasFilterPrefix), true
+}
+
+// aliasCandidates returns every aliased session as a row, in list order.
+// Aliases whose target isn't in the loaded list still appear — an alias always
+// names a [[session]], so it must remain reachable even when that session is
+// filtered out or hasn't started yet. Those trail the listed ones, sorted by
+// alias so the order doesn't shift between runs.
+func (m *Model) aliasCandidates() []sessionItem {
+	candidates := make([]sessionItem, 0, len(m.aliases))
+	listed := make(map[string]bool, len(m.aliases))
+
+	for _, item := range m.allItems {
+		alias, ok := m.aliasByName[item.name]
+		if !ok {
+			continue
+		}
+		listed[strings.ToLower(alias)] = true
+		candidates = append(candidates, item)
+	}
+
+	missing := make([]string, 0, len(m.aliases))
+	for key := range m.aliases {
+		if !listed[key] {
+			missing = append(missing, key)
+		}
+	}
+	sort.Strings(missing)
+	for _, key := range missing {
+		target := m.aliases[key].Target
+		candidates = append(candidates, sessionItem{name: target, searchName: target, src: "config"})
+	}
+
+	return candidates
+}
+
+// filterAliases narrows the aliased sessions by query, in two tiers: aliases
+// the query prefixes come first, then aliases whose session name contains it.
+// Session names are multi-word, so a prefix rule there would make "config"
+// miss "tmux config"; the alias tier stays a prefix match because aliases are
+// short and should narrow deterministically as they're typed.
+func (m *Model) filterAliases(query string) []filteredItem {
+	candidates := m.aliasCandidates()
+	q := strings.ToLower(query)
+	matchLen := len([]rune(query))
+
+	byAlias := make([]filteredItem, 0, len(candidates))
+	byName := make([]filteredItem, 0, len(candidates))
+	for _, item := range candidates {
+		alias := m.aliasByName[item.name]
+		switch {
+		case strings.HasPrefix(strings.ToLower(alias), q):
+			byAlias = append(byAlias, filteredItem{item: item, chipMatchLen: matchLen})
+		case q != "" && strings.Contains(strings.ToLower(item.name), q):
+			byName = append(byName, filteredItem{item: item})
+		}
+	}
+	return append(byAlias, byName...)
+}
+
 func (m *Model) applyFilter() {
 	pattern := m.filterInput.Value()
+	if query, ok := m.aliasFilterQuery(pattern); ok {
+		m.filtered = m.filterAliases(query)
+		return
+	}
 	if pattern == "" {
 		m.filtered = make([]filteredItem, len(m.allItems))
 		for i, item := range m.allItems {
@@ -441,6 +560,14 @@ func (m Model) View() tea.View {
 		for i := 1; i < visible; i++ {
 			b.WriteString("\n")
 		}
+	} else if _, aliasMode := m.aliasFilterQuery(m.filterInput.Value()); aliasMode && len(m.aliases) == 0 {
+		// Without this the sigil looks broken rather than simply unconfigured.
+		emptyStyle := lipgloss.NewStyle().Faint(true)
+		b.WriteString(emptyStyle.Render("  No aliases configured"))
+		b.WriteString("\n")
+		for i := 1; i < visible; i++ {
+			b.WriteString("\n")
+		}
 	} else {
 		// Session list
 		end := m.offset + visible
@@ -466,7 +593,7 @@ func (m Model) View() tea.View {
 				iconStyle := lipgloss.NewStyle().Foreground(clr)
 				tag = iconStyle.Render(icn)
 			}
-			chip := m.aliasChip(item.item.name)
+			chip := m.aliasChip(item.item.name, item.chipMatchLen)
 			name := highlightMatches(item.item.name, item.matchedIndexes, matchStyle, normalStyle)
 
 			var windows string

--- a/picker/tui.go
+++ b/picker/tui.go
@@ -325,6 +325,27 @@ func (m *Model) scheduleAliasAutoConnect() tea.Cmd {
 	return tea.Tick(m.aliasAutoConnectDelay, func(time.Time) tea.Msg { return msg })
 }
 
+// aliasMatch resolves an exactly-typed alias to the session it points at. It
+// takes the raw input, never the separator-normalized pattern, so an alias
+// containing `-` or `_` can't be matched by typing a space instead.
+//
+// The session is looked up in the loaded list so its source and window names
+// come along, and falls back to a config-sourced item when the target isn't
+// listed — an alias always names a [[session]], so connecting still works even
+// if that session is filtered out or hasn't loaded yet.
+func (m *Model) aliasMatch(raw string) (sessionItem, bool) {
+	alias, ok := m.aliases[strings.ToLower(raw)]
+	if !ok {
+		return sessionItem{}, false
+	}
+	for _, item := range m.allItems {
+		if item.name == alias.Target {
+			return item, true
+		}
+	}
+	return sessionItem{name: alias.Target, searchName: alias.Target, src: "config"}, true
+}
+
 func (m *Model) applyFilter() {
 	pattern := m.filterInput.Value()
 	if pattern == "" {
@@ -332,6 +353,11 @@ func (m *Model) applyFilter() {
 		for i, item := range m.allItems {
 			m.filtered[i] = filteredItem{item: item}
 		}
+		return
+	}
+
+	if item, ok := m.aliasMatch(pattern); ok {
+		m.filtered = []filteredItem{{item: item}}
 		return
 	}
 

--- a/sesh.schema.json
+++ b/sesh.schema.json
@@ -109,6 +109,12 @@
           "type": "string",
           "description": "Grace period between typing a session alias and auto-connecting to it, leaving room to finish typing a longer alias that shares a prefix. Any Go duration string (e.g. \"150ms\", \"1s\").",
           "default": "150ms"
+        },
+        "alias_filter_prefix": {
+          "type": "string",
+          "description": "Single character that, typed first in the picker, narrows the list to aliased sessions (e.g. \"/tc\" finds the \"tc\" alias). Set to an empty string to disable.",
+          "default": "/",
+          "maxLength": 1
         }
       },
       "additionalProperties": false

--- a/sesh.schema.json
+++ b/sesh.schema.json
@@ -104,6 +104,11 @@
         "placeholder": {
           "type": "string",
           "description": "The placeholder text in the picker TUI"
+        },
+        "alias_auto_connect_delay": {
+          "type": "string",
+          "description": "Grace period between typing a session alias and auto-connecting to it, leaving room to finish typing a longer alias that shares a prefix. Any Go duration string (e.g. \"150ms\", \"1s\").",
+          "default": "150ms"
         }
       },
       "additionalProperties": false
@@ -155,6 +160,15 @@
           "disable_startup_command": {
             "type": "boolean",
             "description": "Disable the default startup command for this session",
+            "default": false
+          },
+          "alias": {
+            "type": "string",
+            "description": "Short exact-match shortcut for this session. Shown as a chip in the picker, and resolved by `sesh connect <alias>`. Must be unique across sessions."
+          },
+          "alias_auto_connect": {
+            "type": "boolean",
+            "description": "Connect to this session as soon as its alias is fully typed in the picker, without pressing enter. Requires `alias`.",
             "default": false
           },
           "startup_command": {

--- a/seshcli/picker.go
+++ b/seshcli/picker.go
@@ -59,6 +59,10 @@ func NewPickerCommand(base *BaseDeps) *cobra.Command {
 			} else if deps.Config.TUI.Prompt != "" {
 				pickerOpts.Prompt = &deps.Config.TUI.Prompt
 			}
+			if cmd.Flags().Changed("no-alias-auto") {
+				disableAliasAutoConnect, _ := cmd.Flags().GetBool("no-alias-auto")
+				pickerOpts.DisableAliasAutoConnect = &disableAliasAutoConnect
+			}
 			if cmd.Flags().Changed("placeholder") {
 				placeholder, _ := cmd.Flags().GetString("placeholder")
 				pickerOpts.Placeholder = &placeholder
@@ -93,6 +97,7 @@ func NewPickerCommand(base *BaseDeps) *cobra.Command {
 	cmd.Flags().BoolP("separator-aware", "s", false, "match spaces to separators (-_/\\)")
 	cmd.Flags().StringP("prompt", "p", "", "prompt shown in the picker TUI")
 	cmd.Flags().String("placeholder", "", "placeholder text in the picker TUI")
+	cmd.Flags().Bool("no-alias-auto", false, "don't auto-connect when an alias is fully typed")
 
 	return cmd
 }


### PR DESCRIPTION
Closes #421.

Fuzzy matching is non-deterministic from the user's point of view: the top result for `wp` shifts as sessions come and go, so muscle memory never quite forms. An alias gives a session a short, fixed name instead.

```toml
[tui]
alias_auto_connect_delay = "150ms"   # default, adjustable
alias_filter_prefix = "/"            # default, "" disables

[[session]]
name = "wallpaper"
path = "~/c/wallpaper"
alias = "wp"
alias_auto_connect = true            # per-session, default false
```

## What it does

**Exact match.** Typing an alias exactly resolves to that session and nothing else, regardless of ranking — the point being that the result never shifts. It resolves even when the session isn't in the current list (`sesh picker --tmux` before it's started), since an alias always names a `[[session]]`. Anything short of an exact alias (`w`, `wpx`) is fuzzy-matched exactly as before.

**Chip.** Aliased rows are tagged so they stay discoverable: `` wp `` with nerd fonts, `[wp]` when `show_icons = false` so non-nerd-font terminals don't get tofu. The label uses reverse video, which stays legible under any color scheme, and is counted against the `show_windows` width budget.

**Auto-connect.** With `alias_auto_connect = true`, typing the full alias connects without <kbd>Enter</kbd>. Opt-in per session because it's only worth it for the handful you jump to constantly. Suppressible for one run with `sesh picker --no-alias-auto`.

**CLI.** `sesh connect wp` behaves exactly like `sesh connect wallpaper` — the alias resolves before the strategy chain, so an already-running session still reattaches rather than being recreated.

## Filtering to aliases with `/`

Exact match only helps once you remember the alias. Typing `/` as the first character narrows the picker to aliased sessions, which covers the other case: knowing you set up a shortcut for something without recalling which.

```
filter: /

>  wp  wallpaper
   dot dotfiles
   tc  tmux config
```

**Two match tiers.** What you type after the sigil matches aliases by **prefix** (`/t` finds `tc`), then falls back to session names by **substring** (`/config` also finds `tc`). Alias matches always rank above name matches. Aliases are short, so prefix matching narrows them deterministically as you type; session names are multi-word, so a prefix rule there would make `/config` miss `tmux config`.

**Highlighting.** The matched part of the chip is highlighted in the same red used for matches in session names, so you can see which tier a row came in on — a name-tier match leaves the chip plain.

**Stable order.** Listed sessions come first in list order, then aliases whose session isn't loaded, sorted by alias. Nothing shifts between runs, which is the whole premise of aliases.

**Auto-connect without the opt-in.** Completing an alias in this mode connects even if that session didn't set `alias_auto_connect` — reaching for the sigil is itself a statement that the next thing typed is a shortcut to jump to. `alias_auto_connect_delay` still applies, so `/w` leaves room to become `/wp`, and `--no-alias-auto` still holds it back.

**Configurable sigil.** Only a *leading* sigil counts, so `code/app` filters normally. But a query that starts with an absolute path (`/Users/you/code`) would enter the mode, so the sigil is settable — `alias_filter_prefix = "@"`, or `""` to turn the mode off entirely. Multi-character and whitespace values are rejected at config load.

**Empty state.** With no aliases configured, the list reads `No aliases configured` rather than looking broken.

## Notes on the implementation

- Auto-connect arms a `tea.Tick` for the configured delay. `tea.Tick` can't be cancelled, so the message carries a sequence number and the handler re-checks the filter value: typing past an alias can't connect to it, and that's also what makes overlapping aliases like `w` and `wp` workable inside the grace period. Set the delay to `"0s"` to fire the instant an alias completes.
- It fires while sessions are still loading, since the target comes from config rather than the list.
- Alias matching always uses the raw input, so `separator_aware` can't let `w p` resolve the alias `w-p`.
- Both auto-connect paths funnel through one `exactAlias` helper, which is also where the "alias mode bypasses the opt-in" rule lives, so the schedule and the tick handler can't disagree about whether something should connect.
- `alias_filter_prefix` is a `*string` in the config model. That's what makes an explicit `""` (disable the mode) distinguishable from an absent key (use the default) — the usual empty-string-means-unset pattern can't express it.
- Duplicate aliases (case-insensitive), a malformed delay, and an invalid sigil are all rejected at config load with a readable error.
- The picker constructor takes an `Options` struct now rather than a tenth positional argument. Contained to `picker/`.

## Testing

`just test` green; 102 tests in `picker` (77% coverage), plus config validation and CLI resolution tests. Covers the exact-match and fallback paths, both chip variants, the width invariant, stale/superseded ticks, suppression, and firing while loading. For the sigil: both match tiers and their ordering, prefix-vs-substring semantics, case insensitivity, unlisted aliases and their sort, a sigil past the start staying a normal query, a custom sigil, the disabled sigil, chip highlight clamping, auto-connect without the opt-in, the `/w` → `/wp` grace period, and that the sigil never leaks into the selected session name. Also rendered the TUI directly for `/`, `/d` and `/project` to confirm the highlight and tiers look right rather than only asserting on them.

`sesh.schema.json` is in sync with the config model, verified with the repo's `config-schema-sync` check.

One thing left alone, since it predates this branch: `picker.go` reads `p.config.SeparatorAware` and ignores `opts.SeparatorAware`, so `sesh picker --separator-aware` is a no-op. Happy to fix here or separately.

`README.zh-cn.md` is untouched — aliases were never documented there (its `[tui]` section predates them), so there was nothing to mirror.
