### PR TITLE
Add an opt-in preview pane to the picker TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,6 +690,9 @@ show_icons = false
 show_windows = false
 alias_auto_connect_delay = "150ms"
 alias_filter_prefix = "/"
+preview = false
+preview_width = 60
+preview_min_width = 100
 ```
 
 With `show_windows = true`, each row also lists the names of the windows inside that session, dimmed after the session name. Window names that don't fit are summarized as `+N`:
@@ -704,6 +707,22 @@ With `show_windows = true`, each row also lists the names of the windows inside 
 Window names are display-only: selecting a row still returns just the session name, and typing a window name does not match its session. The names for live tmux sessions are fetched in a single tmux call, so the option costs the same regardless of how many sessions you have.
 
 `alias_auto_connect_delay` and `alias_filter_prefix` tune aliases — see [Session Aliases](#session-aliases).
+
+#### Preview pane
+
+With `preview = true`, the highlighted session is previewed beside the list, using exactly the same output as `sesh preview` — live tmux panes via `capture-pane`, your `preview_command` for configured sessions, and a directory listing otherwise:
+
+```
+> sesh                │ $ eza --icons
+  dotfiles            │  README.md    main.go
+  my-project          │  picker/      previewer/
+```
+
+The pane is off by default, and `ctrl+o` toggles it at any time.
+
+`preview_width` is the share of the terminal, in percent, guaranteed to the pane. The session list is capped at 60 columns, so on a wide terminal everything past that cap goes to the preview on top of this share; on a narrow one the list is never squeezed below 40 columns.
+
+`preview_min_width` (default `100`) is the narrowest terminal that gets a split at all. Below it the picker renders the list only, and the pane comes back on its own once the window has room — handy in small tmux popups. Preview commands run in the background as the cursor moves, so a slow one never blocks the list, and a failing one is reported in the pane instead of taking the picker down.
 
 ### Default Session
 

--- a/README.md
+++ b/README.md
@@ -693,6 +693,7 @@ alias_filter_prefix = "/"
 preview = false
 preview_width = 60
 preview_min_width = 100
+preview_border = "line"
 ```
 
 With `show_windows = true`, each row also lists the names of the windows inside that session, dimmed after the session name. Window names that don't fit are summarized as `+N`:
@@ -721,6 +722,19 @@ With `preview = true`, the highlighted session is previewed beside the list, usi
 The pane is off by default, and `ctrl+o` toggles it at any time.
 
 `preview_width` is the share of the terminal, in percent, guaranteed to the pane. The session list is capped at 60 columns, so on a wide terminal everything past that cap goes to the preview on top of this share; on a narrow one the list is never squeezed below 40 columns.
+
+`preview_border` picks the divider between the two panes: `line` (default), `thick`, `double`, or `none` for no divider at all. Turning it off gives the divider's column to the preview text:
+
+```toml
+[tui]
+preview_border = "none"
+```
+
+```
+> sesh                 $ eza --icons
+  dotfiles              README.md    main.go
+  my-project            picker/      previewer/
+```
 
 `preview_min_width` (default `100`) is the narrowest terminal that gets a split at all. Below it the picker renders the list only, and the pane comes back on its own once the window has room — handy in small tmux popups. Preview commands run in the background as the cursor moves, so a slow one never blocks the list, and a failing one is reported in the pane instead of taking the picker down.
 

--- a/model/config.go
+++ b/model/config.go
@@ -21,6 +21,18 @@ const (
 	DefaultPreviewMinWidth = 100
 )
 
+// The dividers [tui] preview_border accepts between the picker's session list
+// and its preview pane. PreviewBorderNone draws no divider at all.
+const (
+	PreviewBorderNone   = "none"
+	PreviewBorderLine   = "line"
+	PreviewBorderThick  = "thick"
+	PreviewBorderDouble = "double"
+	// DefaultPreviewBorder is the divider used when [tui] preview_border is
+	// not set.
+	DefaultPreviewBorder = PreviewBorderLine
+)
+
 type (
 	Config struct {
 		Cache                   bool                 `toml:"cache"`
@@ -119,6 +131,10 @@ type (
 		// PreviewMinWidth is the narrowest terminal that still gets a preview
 		// pane; below it the picker renders list-only. Zero means unset.
 		PreviewMinWidth int `toml:"preview_min_width"`
+		// PreviewBorder is the divider drawn between the list and the preview
+		// pane: "line" (default), "thick", "double", or "none" for no divider.
+		// Empty means unset.
+		PreviewBorder string `toml:"preview_border"`
 	}
 
 	WildcardConfig struct {

--- a/model/config.go
+++ b/model/config.go
@@ -8,6 +8,19 @@ const DefaultAliasAutoConnectDelay = "150ms"
 // [tui] alias_filter_prefix is not set.
 const DefaultAliasFilterPrefix = "/"
 
+const (
+	// DefaultPreviewWidth is the share of the terminal, in percent, guaranteed
+	// to the picker's preview pane when [tui] preview_width is not set.
+	DefaultPreviewWidth = 60
+	// MinPreviewWidth and MaxPreviewWidth bound preview_width. A pane narrower
+	// or wider than these leaves too little room for the other half.
+	MinPreviewWidth = 10
+	MaxPreviewWidth = 90
+	// DefaultPreviewMinWidth is the narrowest terminal, in columns, that still
+	// gets a preview pane when [tui] preview_min_width is not set.
+	DefaultPreviewMinWidth = 100
+)
+
 type (
 	Config struct {
 		Cache                   bool                 `toml:"cache"`
@@ -95,6 +108,17 @@ type (
 		// explicit empty string (disable the mode) is distinguishable from an
 		// absent key (use DefaultAliasFilterPrefix).
 		AliasFilterPrefix *string `toml:"alias_filter_prefix"`
+		// Preview shows a preview of the highlighted session beside the list,
+		// using the same output as `sesh preview`. Opt-in: the pane costs a
+		// command per cursor move, and not everyone wants a split.
+		Preview bool `toml:"preview"`
+		// PreviewWidth is the share of the terminal, in percent, guaranteed to
+		// the preview pane. The list keeps its column cap, so anything left
+		// over goes to the preview on top of this. Zero means unset.
+		PreviewWidth int `toml:"preview_width"`
+		// PreviewMinWidth is the narrowest terminal that still gets a preview
+		// pane; below it the picker renders list-only. Zero means unset.
+		PreviewMinWidth int `toml:"preview_min_width"`
 	}
 
 	WildcardConfig struct {

--- a/picker/picker.go
+++ b/picker/picker.go
@@ -9,6 +9,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/previewer"
 )
 
 const (
@@ -23,6 +24,7 @@ type PickerOptions struct {
 	Prompt                  *string
 	Placeholder             *string
 	DisableAliasAutoConnect *bool
+	Preview                 *bool
 }
 
 type Picker interface {
@@ -30,11 +32,12 @@ type Picker interface {
 }
 
 type RealPicker struct {
-	config model.Config
+	config    model.Config
+	previewer previewer.Previewer
 }
 
-func NewPicker(config model.Config) Picker {
-	return &RealPicker{config: config}
+func NewPicker(config model.Config, previewer previewer.Previewer) Picker {
+	return &RealPicker{config: config, previewer: previewer}
 }
 
 // buildAliases collects the aliases defined on [[session]] blocks, keyed by
@@ -64,6 +67,31 @@ func aliasAutoConnectDelay(configured string) time.Duration {
 	}
 	d, _ := time.ParseDuration(model.DefaultAliasAutoConnectDelay)
 	return d
+}
+
+// previewWidth resolves the percent of the terminal guaranteed to the preview
+// pane, clamping rather than failing the picker on an out-of-range value (the
+// JSON schema flags those in the editor, but nothing rejects them at load).
+func previewWidth(configured int) int {
+	if configured <= 0 {
+		return model.DefaultPreviewWidth
+	}
+	if configured < model.MinPreviewWidth {
+		return model.MinPreviewWidth
+	}
+	if configured > model.MaxPreviewWidth {
+		return model.MaxPreviewWidth
+	}
+	return configured
+}
+
+// previewMinWidth resolves the narrowest terminal that still gets a preview
+// pane. Zero means the key is absent.
+func previewMinWidth(configured int) int {
+	if configured <= 0 {
+		return model.DefaultPreviewMinWidth
+	}
+	return configured
 }
 
 // aliasFilterPrefix resolves the sigil that enters alias-filter mode. A nil
@@ -109,6 +137,18 @@ func (p *RealPicker) Pick(fetchFunc FetchFunc, opts PickerOptions) (string, erro
 		disableAliasAutoConnect = *opts.DisableAliasAutoConnect
 	}
 
+	preview := p.config.TUI.Preview
+	if opts.Preview != nil {
+		preview = *opts.Preview
+	}
+
+	// The model reaches the previewer through a function so the TUI stays
+	// unaware of the package, mirroring how sessions arrive via FetchFunc.
+	var previewFunc PreviewFunc
+	if p.previewer != nil {
+		previewFunc = p.previewer.Preview
+	}
+
 	m := New(fetchFunc, Options{
 		ShowIcons:               showIcons,
 		ShowWindows:             showWindows,
@@ -119,6 +159,10 @@ func (p *RealPicker) Pick(fetchFunc FetchFunc, opts PickerOptions) (string, erro
 		AliasFilterPrefix:       aliasFilterPrefix(p.config.TUI.AliasFilterPrefix),
 		AliasAutoConnectDelay:   aliasAutoConnectDelay(p.config.TUI.AliasAutoConnectDelay),
 		DisableAliasAutoConnect: disableAliasAutoConnect,
+		Preview:                 preview,
+		PreviewWidth:            previewWidth(p.config.TUI.PreviewWidth),
+		PreviewMinWidth:         previewMinWidth(p.config.TUI.PreviewMinWidth),
+		PreviewFunc:             previewFunc,
 	})
 	prog := tea.NewProgram(m)
 	result, err := prog.Run()

--- a/picker/picker.go
+++ b/picker/picker.go
@@ -94,6 +94,19 @@ func previewMinWidth(configured int) int {
 	return configured
 }
 
+// previewBorder resolves the divider drawn between the list and the preview
+// pane, falling back to the default on an empty or unrecognized value rather
+// than failing the picker (the JSON schema flags those in the editor, but
+// nothing rejects them at load).
+func previewBorder(configured string) string {
+	switch configured {
+	case model.PreviewBorderNone, model.PreviewBorderLine, model.PreviewBorderThick, model.PreviewBorderDouble:
+		return configured
+	default:
+		return model.DefaultPreviewBorder
+	}
+}
+
 // aliasFilterPrefix resolves the sigil that enters alias-filter mode. A nil
 // value means the key is absent (the configurator normally fills it in, but the
 // picker can be constructed with a bare config), while an explicit empty string
@@ -162,6 +175,7 @@ func (p *RealPicker) Pick(fetchFunc FetchFunc, opts PickerOptions) (string, erro
 		Preview:                 preview,
 		PreviewWidth:            previewWidth(p.config.TUI.PreviewWidth),
 		PreviewMinWidth:         previewMinWidth(p.config.TUI.PreviewMinWidth),
+		PreviewBorder:           p.config.TUI.PreviewBorder,
 		PreviewFunc:             previewFunc,
 	})
 	prog := tea.NewProgram(m)

--- a/picker/picker_test.go
+++ b/picker/picker_test.go
@@ -1529,6 +1529,54 @@ func TestPreviewMinWidth_Resolution(t *testing.T) {
 	assert.Equal(t, 80, previewMinWidth(80))
 }
 
+func TestPreviewBorder_Resolution(t *testing.T) {
+	assert.Equal(t, model.DefaultPreviewBorder, previewBorder(""), "unset falls back")
+	assert.Equal(t, model.DefaultPreviewBorder, previewBorder("squiggly"),
+		"an unrecognized style falls back rather than failing the picker")
+	assert.Equal(t, model.PreviewBorderNone, previewBorder("none"))
+	assert.Equal(t, model.PreviewBorderThick, previewBorder("thick"))
+	assert.Equal(t, model.PreviewBorderDouble, previewBorder("double"))
+}
+
+func TestPreview_BorderStyles(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured string
+		divider    string
+		chrome     int
+	}{
+		{"unset draws a line", "", "│", 2},
+		{"line", model.PreviewBorderLine, "│", 2},
+		{"thick", model.PreviewBorderThick, "┃", 2},
+		{"double", model.PreviewBorderDouble, "║", 2},
+		{"none draws nothing", model.PreviewBorderNone, "", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, _ := previewModel(func(o *Options) { o.PreviewBorder = tt.configured })
+			result, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+			m = loadPreview(t, result.(Model), cmd)
+
+			assert.Equal(t, tt.chrome, m.previewChrome(),
+				"a hidden divider should give its column to the preview text")
+
+			out := m.View().Content
+			require.Contains(t, out, "preview of dotfiles")
+			for _, glyph := range []string{"│", "┃", "║"} {
+				if glyph == tt.divider {
+					assert.Contains(t, out, glyph)
+					continue
+				}
+				assert.NotContains(t, out, glyph, "only the configured divider may be drawn")
+			}
+			for i, line := range strings.Split(out, "\n") {
+				assert.LessOrEqual(t, lipgloss.Width(line), m.width,
+					"line %d may not exceed the terminal width", i)
+			}
+		})
+	}
+}
+
 func TestView_FillsTerminalHeight(t *testing.T) {
 	for _, height := range []int{10, 24, 50, 120} {
 		t.Run(fmt.Sprintf("height %d", height), func(t *testing.T) {

--- a/picker/picker_test.go
+++ b/picker/picker_test.go
@@ -353,9 +353,12 @@ func TestHighlightMatches_WithIndexes(t *testing.T) {
 
 func TestScrolling(t *testing.T) {
 	m := newTestModel()
-	m.height = 12
+	// Short enough that the five test sessions can't all fit at once, which is
+	// what makes the list scroll at all.
+	m.height = 6
 
 	visible := m.visibleCount()
+	require.Less(t, visible, len(m.filtered), "the list must overflow to scroll")
 	for i := 0; i < visible+2; i++ {
 		m.cursorDown(1)
 	}
@@ -1163,4 +1166,396 @@ func TestWindowsText(t *testing.T) {
 			assert.LessOrEqual(t, lipgloss.Width(got), max(tt.budget, 0))
 		})
 	}
+}
+
+// --- preview pane -----------------------------------------------------------
+
+// testPreviewFunc records every session it is asked about, so tests can assert
+// which fetches actually happened.
+func testPreviewFunc(asked *[]string) PreviewFunc {
+	return func(name string) (string, error) {
+		*asked = append(*asked, name)
+		return "preview of " + name, nil
+	}
+}
+
+// previewModel builds a loaded model with the preview pane on and a terminal
+// wide enough to split.
+func previewModel(tweak ...func(*Options)) (Model, *[]string) {
+	asked := &[]string{}
+	sessions := testSessions()
+	m := New(testFetchFunc(sessions), testOptionsWith(func(o *Options) {
+		o.Preview = true
+		o.PreviewFunc = testPreviewFunc(asked)
+		for _, fn := range tweak {
+			fn(o)
+		}
+	}))
+	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
+	m = result.(Model)
+	m.width = 120
+	m.height = 24
+	return m, asked
+}
+
+// previewFetch digs the preview fetch message out of a command, returning nil
+// when none was scheduled. Cursor keys return no other commands, but filter
+// keystrokes come back batched with a cursor blink.
+func previewFetch(cmd tea.Cmd) *previewFetchMsg {
+	if cmd == nil {
+		return nil
+	}
+	switch msg := cmd().(type) {
+	case previewFetchMsg:
+		return &msg
+	case tea.BatchMsg:
+		for _, batched := range msg {
+			if found := previewFetch(batched); found != nil {
+				return found
+			}
+		}
+	}
+	return nil
+}
+
+// loadPreview runs the fetch a command scheduled and feeds the result back in,
+// standing in for the debounce tick and the goroutine.
+func loadPreview(t *testing.T, m Model, cmd tea.Cmd) Model {
+	t.Helper()
+	fetch := previewFetch(cmd)
+	require.NotNil(t, fetch, "expected a preview fetch to be scheduled")
+	result, started := m.Update(*fetch)
+	m = result.(Model)
+	require.NotNil(t, started, "the fetch message should start the preview")
+	result, _ = m.Update(started())
+	return result.(Model)
+}
+
+func TestPreview_OffByDefault(t *testing.T) {
+	m := newTestModel()
+	m.width = 200
+	m.height = 24
+
+	assert.False(t, m.previewOn)
+	assert.False(t, m.splitActive())
+	assert.Equal(t, 0, m.previewCols())
+	assert.Equal(t, 60, m.contentWidth(), "list width must be untouched when off")
+}
+
+func TestPreview_NoFetchWhenDisabled(t *testing.T) {
+	asked := &[]string{}
+	sessions := testSessions()
+	m := New(testFetchFunc(sessions), testOptionsWith(func(o *Options) {
+		o.PreviewFunc = testPreviewFunc(asked)
+	}))
+	result, cmd := m.Update(sessionsLoadedMsg{sessions: sessions})
+	m = result.(Model)
+
+	assert.Nil(t, previewFetch(cmd))
+	result, cmd = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	assert.Nil(t, previewFetch(cmd))
+	assert.Empty(t, *asked)
+	assert.False(t, result.(Model).splitActive())
+}
+
+func TestPreview_FetchedForFirstSessionOnLoad(t *testing.T) {
+	asked := &[]string{}
+	sessions := testSessions()
+	m := New(testFetchFunc(sessions), testOptionsWith(func(o *Options) {
+		o.Preview = true
+		o.PreviewFunc = testPreviewFunc(asked)
+	}))
+	result, cmd := m.Update(sessionsLoadedMsg{sessions: sessions})
+
+	m = loadPreview(t, result.(Model), cmd)
+	assert.Equal(t, []string{"my-project"}, *asked)
+	assert.Equal(t, "my-project", m.previewName)
+	assert.Equal(t, "preview of my-project", m.previewContent)
+}
+
+func TestPreview_CursorMoveFetchesNewSession(t *testing.T) {
+	m, asked := previewModel()
+	result, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+
+	m = loadPreview(t, result.(Model), cmd)
+	assert.Equal(t, "dotfiles", m.previewName)
+	assert.Contains(t, *asked, "dotfiles")
+}
+
+func TestPreview_AlreadyPreviewedSessionIsNotRefetched(t *testing.T) {
+	m, asked := previewModel()
+	result, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = loadPreview(t, result.(Model), cmd)
+	before := len(*asked)
+
+	// Move away, then straight back before the new preview lands: the pane is
+	// still showing dotfiles, so there is nothing to fetch.
+	result, cmd = m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	m = result.(Model)
+	require.NotNil(t, previewFetch(cmd), "moving away schedules a fetch")
+
+	result, cmd = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = result.(Model)
+
+	assert.Nil(t, previewFetch(cmd), "the displayed preview should not be refetched")
+	assert.Len(t, *asked, before, "no preview command should have run")
+}
+
+func TestPreview_StaleResultIsDiscarded(t *testing.T) {
+	m, _ := previewModel()
+	result, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = loadPreview(t, result.(Model), cmd)
+	require.Equal(t, "dotfiles", m.previewName)
+
+	// A result from a cursor position the user has since left behind.
+	result, _ = m.Update(previewLoadedMsg{
+		seq:     m.previewSeq - 1,
+		name:    "my-project",
+		content: "stale content",
+	})
+	m = result.(Model)
+
+	assert.Equal(t, "dotfiles", m.previewName)
+	assert.Equal(t, "preview of dotfiles", m.previewContent,
+		"the pane should keep the preview that belongs to the highlighted row")
+}
+
+func TestPreview_StaleFetchTickIsDiscarded(t *testing.T) {
+	m, asked := previewModel()
+	result, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = result.(Model)
+	fetch := previewFetch(cmd)
+	require.NotNil(t, fetch)
+
+	// The cursor moves again before the debounce elapses, so the earlier tick
+	// arrives stale and must not shell out.
+	result, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = result.(Model)
+	before := len(*asked)
+	result, started := m.Update(*fetch)
+
+	assert.Nil(t, started, "a superseded tick should not start a fetch")
+	assert.Len(t, *asked, before)
+	assert.False(t, result.(Model).loading)
+}
+
+func TestPreview_KeepsPreviousContentWhileLoading(t *testing.T) {
+	m, _ := previewModel()
+	result, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = loadPreview(t, result.(Model), cmd)
+
+	// Move on, but don't deliver the new preview yet.
+	result, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = result.(Model)
+
+	assert.Equal(t, "preview of dotfiles", m.previewContent)
+	assert.Contains(t, m.View().Content, "preview of dotfiles")
+}
+
+func TestPreview_ErrorIsShownWithoutQuitting(t *testing.T) {
+	m, _ := previewModel()
+	result, _ := m.Update(previewLoadedMsg{
+		seq:  m.previewSeq,
+		name: "my-project",
+		err:  errors.New("preview_command exploded"),
+	})
+	m = result.(Model)
+
+	assert.False(t, m.Quit())
+	assert.NoError(t, m.LoadErr())
+	assert.Contains(t, m.View().Content, "Preview unavailable")
+}
+
+func TestPreview_EmptyFilterResultClearsPane(t *testing.T) {
+	m, _ := previewModel()
+	m.previewName = "my-project"
+	m.previewContent = "preview of my-project"
+
+	m, _ = typeFilter(m, "zzzznomatch")
+
+	require.Empty(t, m.filtered)
+	assert.Empty(t, m.previewContent, "no highlighted row means nothing to preview")
+	assert.Empty(t, m.previewName)
+}
+
+func TestPreview_CtrlOToggles(t *testing.T) {
+	m, asked := previewModel()
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
+	m = result.(Model)
+	assert.False(t, m.previewOn)
+	assert.False(t, m.splitActive())
+	assert.Equal(t, 60, m.contentWidth(), "the list reclaims the width")
+
+	before := len(*asked)
+	result, cmd := m.Update(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
+	m = result.(Model)
+	assert.True(t, m.previewOn)
+	assert.True(t, m.splitActive())
+	m = loadPreview(t, m, cmd)
+	assert.Len(t, *asked, before+1, "turning the pane back on fetches a preview")
+}
+
+func TestPreview_CtrlOIsInertWithoutAPreviewer(t *testing.T) {
+	m := newTestModel()
+	m.width = 120
+	m.height = 24
+
+	result, cmd := m.Update(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
+	m = result.(Model)
+
+	assert.Nil(t, cmd)
+	assert.False(t, m.previewOn)
+}
+
+func TestPreview_NarrowTerminalFallsBackToListOnly(t *testing.T) {
+	m, _ := previewModel()
+	m.width = 99 // one column under the default minimum
+
+	assert.True(t, m.previewOn, "the setting stays on")
+	assert.False(t, m.splitActive(), "but the pane isn't rendered")
+	assert.Equal(t, 60, m.contentWidth())
+
+	out := fmt.Sprintf("%v", m.View())
+	assert.NotContains(t, out, "preview of", "no preview content on a narrow terminal")
+
+	// Growing the window is enough to bring it back.
+	m.width = 120
+	assert.True(t, m.splitActive())
+}
+
+func TestPreview_SplitWidths(t *testing.T) {
+	tests := []struct {
+		name    string
+		width   int
+		pct     int
+		preview int
+		list    int
+	}{
+		{"at the minimum the list keeps its floor", 100, 60, 60, 40},
+		{"percent governs a middling terminal", 120, 60, 72, 48},
+		{"preview absorbs width past the list cap", 200, 60, 140, 60},
+		{"a small percent still leaves the cap alone", 200, 20, 140, 60},
+		{"a large percent squeezes the list to its floor", 120, 90, 80, 40},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, _ := previewModel(func(o *Options) { o.PreviewWidth = tt.pct })
+			m.width = tt.width
+
+			assert.Equal(t, tt.preview, m.previewCols(), "preview columns")
+			assert.Equal(t, tt.list, m.contentWidth(), "list columns")
+			assert.Equal(t, tt.width, m.previewCols()+m.contentWidth(),
+				"the two panes should use the full terminal width")
+		})
+	}
+}
+
+func TestPreview_ViewFitsTerminalWidth(t *testing.T) {
+	m, _ := previewModel()
+	result, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = loadPreview(t, result.(Model), cmd)
+
+	out := m.View().Content
+	assert.Contains(t, out, "preview of dotfiles")
+	for i, line := range strings.Split(out, "\n") {
+		assert.LessOrEqual(t, lipgloss.Width(line), m.width,
+			"line %d may not exceed the terminal width", i)
+	}
+}
+
+func TestPreview_LongContentIsClipped(t *testing.T) {
+	m, _ := previewModel(func(o *Options) {
+		o.PreviewFunc = func(string) (string, error) {
+			return strings.Repeat(strings.Repeat("x", 400)+"\n", 200), nil
+		}
+	})
+	result, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = loadPreview(t, result.(Model), cmd)
+
+	lines := strings.Split(m.View().Content, "\n")
+	assert.Len(t, lines, headerLines+m.visibleCount(),
+		"an oversized preview must not grow the picker")
+	for i, line := range lines {
+		assert.LessOrEqual(t, lipgloss.Width(line), m.width,
+			"line %d may not exceed the terminal width", i)
+	}
+}
+
+func TestClipLines(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		width    int
+		rows     int
+		expected string
+	}{
+		{"fits", "a\nb", 10, 5, "a\nb"},
+		{"clips rows", "a\nb\nc", 10, 2, "a\nb"},
+		{"clips columns", "abcdef", 3, 1, "abc"},
+		{"zero width", "abc", 0, 1, ""},
+		{"zero rows", "abc", 10, 0, ""},
+		{"carriage returns normalized", "a\r\nb", 10, 2, "a\nb"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, clipLines(tt.text, tt.width, tt.rows))
+		})
+	}
+}
+
+func TestClipLines_PreservesColorAndResets(t *testing.T) {
+	// tmux previews come from `capture-pane -e`, so the content is full of
+	// escapes that must survive truncation and not leak into the next line.
+	line := "\x1b[31mred text here\x1b[0m"
+	got := clipLines(line, 6, 1)
+
+	assert.Contains(t, got, "\x1b[31m", "color must survive truncation")
+	assert.True(t, strings.HasSuffix(got, "\x1b[0m"), "the line must be reset")
+	assert.Equal(t, 6, lipgloss.Width(got))
+}
+
+func TestPreviewWidth_Resolution(t *testing.T) {
+	assert.Equal(t, model.DefaultPreviewWidth, previewWidth(0), "unset falls back")
+	assert.Equal(t, model.DefaultPreviewWidth, previewWidth(-10))
+	assert.Equal(t, model.MinPreviewWidth, previewWidth(1), "clamped, not rejected")
+	assert.Equal(t, model.MaxPreviewWidth, previewWidth(300))
+	assert.Equal(t, 45, previewWidth(45))
+}
+
+func TestPreviewMinWidth_Resolution(t *testing.T) {
+	assert.Equal(t, model.DefaultPreviewMinWidth, previewMinWidth(0))
+	assert.Equal(t, model.DefaultPreviewMinWidth, previewMinWidth(-1))
+	assert.Equal(t, 80, previewMinWidth(80))
+}
+
+func TestView_FillsTerminalHeight(t *testing.T) {
+	for _, height := range []int{10, 24, 50, 120} {
+		t.Run(fmt.Sprintf("height %d", height), func(t *testing.T) {
+			m, asked := previewModel()
+			_ = asked
+			m.height = height
+			result, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+			m = loadPreview(t, result.(Model), cmd)
+
+			lines := strings.Split(m.View().Content, "\n")
+			assert.Len(t, lines, height, "the frame should use every row")
+			assert.True(t, m.View().AltScreen, "full height needs the alt screen")
+		})
+	}
+}
+
+func TestView_FillsTerminalHeight_ListOnly(t *testing.T) {
+	m := newTestModel()
+	m.width = 80
+	m.height = 40
+
+	lines := strings.Split(m.View().Content, "\n")
+	assert.Len(t, lines, 40, "the list-only frame should use every row too")
+}
+
+func TestVisibleCount_FallsBackBeforeSizeIsKnown(t *testing.T) {
+	m := newTestModel()
+	assert.Equal(t, 0, m.height, "no WindowSizeMsg has arrived yet")
+	assert.Equal(t, fallbackVisibleCount, m.visibleCount())
 }

--- a/picker/tui.go
+++ b/picker/tui.go
@@ -115,6 +115,10 @@ type Options struct {
 	PreviewWidth int
 	// PreviewMinWidth is the narrowest terminal that gets a preview pane.
 	PreviewMinWidth int
+	// PreviewBorder names the divider drawn between the list and the preview
+	// pane, one of the model.PreviewBorder* values. Empty or unrecognized
+	// means the default.
+	PreviewBorder string
 	// PreviewFunc renders previews. Nil disables the pane entirely.
 	PreviewFunc PreviewFunc
 }
@@ -155,8 +159,11 @@ type Model struct {
 	// previewName is the session the current content belongs to, and
 	// previewPending the one being fetched. Together they keep the cursor
 	// landing back on an already-previewed row from refetching it.
-	previewName    string
-	previewPending string
+	// previewBorderName is the resolved divider style, so an unset or bogus
+	// config value never reaches the renderer.
+	previewBorderName string
+	previewName       string
+	previewPending    string
 	previewContent string
 	previewErr     error
 	// previewSeq increments on every request so a result that arrives after the
@@ -280,6 +287,7 @@ func New(fetchFunc FetchFunc, opts Options) Model {
 		previewOn:               opts.Preview,
 		previewWidthPct:         previewWidth(opts.PreviewWidth),
 		previewMinWidth:         previewMinWidth(opts.PreviewMinWidth),
+		previewBorderName:       previewBorder(opts.PreviewBorder),
 	}
 	m.focusCmd = m.filterInput.Focus()
 	return m
@@ -688,10 +696,35 @@ const (
 	// minListWidth is the narrowest list worth splitting off; the preview gives
 	// columns back to stay above it.
 	minListWidth = 40
-	// previewChrome is the divider column plus the padding after it. Both sit
-	// inside the pane's width, so the text gets that much less room.
-	previewChrome = 2
+	// previewPadding is the gap between the divider — or the list itself, with
+	// the divider off — and the preview text. It sits inside the pane's width.
+	previewPadding = 1
 )
+
+// previewBorderStyle returns the lipgloss border for a resolved divider name,
+// and whether a divider is drawn at all.
+func previewBorderStyle(name string) (lipgloss.Border, bool) {
+	switch name {
+	case model.PreviewBorderNone:
+		return lipgloss.Border{}, false
+	case model.PreviewBorderThick:
+		return lipgloss.ThickBorder(), true
+	case model.PreviewBorderDouble:
+		return lipgloss.DoubleBorder(), true
+	default:
+		return lipgloss.NormalBorder(), true
+	}
+}
+
+// previewChrome is how much of the pane's width goes to the divider and the
+// padding after it, leaving the text that much less room. Without a divider
+// only the padding is charged, so disabling it gives that column to the text.
+func (m Model) previewChrome() int {
+	if _, drawn := previewBorderStyle(m.previewBorderName); drawn {
+		return previewPadding + 1
+	}
+	return previewPadding
+}
 
 // splitActive reports whether this frame renders a preview pane. Width is
 // checked here rather than at toggle time so growing the window is enough to
@@ -715,7 +748,7 @@ func (m Model) previewCols() int {
 	if max := m.width - minListWidth; cols > max {
 		cols = max
 	}
-	if cols <= previewChrome {
+	if cols <= m.previewChrome() {
 		return 0
 	}
 	return cols
@@ -847,12 +880,14 @@ func (m Model) previewView(cols, rows int) string {
 	}
 
 	// The divider and padding live inside Width, so the text gets less room.
-	body = clipLines(body, cols-previewChrome, rows)
+	body = clipLines(body, cols-m.previewChrome(), rows)
+
+	border, drawn := previewBorderStyle(m.previewBorderName)
 
 	return lipgloss.NewStyle().
-		Border(lipgloss.NormalBorder(), false, false, false, true).
+		Border(border, false, false, false, drawn).
 		BorderForeground(lipgloss.ANSIColor(8)).
-		PaddingLeft(1).
+		PaddingLeft(previewPadding).
 		PaddingTop(headerLines).
 		Width(cols).
 		Height(headerLines + rows).

--- a/picker/tui.go
+++ b/picker/tui.go
@@ -40,10 +40,33 @@ type filteredItem struct {
 // FetchFunc loads sessions asynchronously. It is called in a goroutine by Init().
 type FetchFunc func() (model.SeshSessions, error)
 
+// PreviewFunc renders the preview of a single session. It is called from a
+// tea.Cmd, never from Update or View: some strategies shell out, and blocking
+// the event loop on every cursor move would make the picker feel sluggish.
+type PreviewFunc func(name string) (string, error)
+
 // sessionsLoadedMsg carries the result of the async fetch back to Update().
 type sessionsLoadedMsg struct {
 	sessions model.SeshSessions
 	err      error
+}
+
+// previewFetchMsg fires after the debounce window and starts the fetch for the
+// session highlighted at the time it was scheduled. The seq identifies that
+// cursor position so later movement can invalidate it.
+type previewFetchMsg struct {
+	seq  int
+	name string
+}
+
+// previewLoadedMsg carries a rendered preview back to Update(). A result whose
+// seq is no longer current is discarded: the cursor has moved on, and the pane
+// keeps showing the last preview that did belong to its session.
+type previewLoadedMsg struct {
+	seq     int
+	name    string
+	content string
+	err     error
 }
 
 // aliasAutoConnectMsg fires once the auto-connect grace period has elapsed. The
@@ -83,6 +106,17 @@ type Options struct {
 	AliasAutoConnectDelay time.Duration
 	// DisableAliasAutoConnect suppresses auto-connect for this invocation.
 	DisableAliasAutoConnect bool
+	// Preview starts the picker with the preview pane showing. It can still be
+	// toggled at runtime, and is ignored on a terminal narrower than
+	// PreviewMinWidth.
+	Preview bool
+	// PreviewWidth is the share of the terminal, in percent, guaranteed to the
+	// preview pane.
+	PreviewWidth int
+	// PreviewMinWidth is the narrowest terminal that gets a preview pane.
+	PreviewMinWidth int
+	// PreviewFunc renders previews. Nil disables the pane entirely.
+	PreviewFunc PreviewFunc
 }
 
 type Model struct {
@@ -113,6 +147,21 @@ type Model struct {
 	// aliasSeq increments on every filter change so a pending auto-connect
 	// tick can tell whether it is stale.
 	aliasSeq int
+
+	previewFunc     PreviewFunc
+	previewOn       bool
+	previewWidthPct int
+	previewMinWidth int
+	// previewName is the session the current content belongs to, and
+	// previewPending the one being fetched. Together they keep the cursor
+	// landing back on an already-previewed row from refetching it.
+	previewName    string
+	previewPending string
+	previewContent string
+	previewErr     error
+	// previewSeq increments on every request so a result that arrives after the
+	// cursor moved on can be told apart from the current one.
+	previewSeq int
 }
 
 // srcIcon returns the nerd font icon and color for a session source.
@@ -227,6 +276,10 @@ func New(fetchFunc FetchFunc, opts Options) Model {
 		aliasFilterPrefix:       opts.AliasFilterPrefix,
 		aliasAutoConnectDelay:   opts.AliasAutoConnectDelay,
 		disableAliasAutoConnect: opts.DisableAliasAutoConnect,
+		previewFunc:             opts.PreviewFunc,
+		previewOn:               opts.Preview,
+		previewWidthPct:         previewWidth(opts.PreviewWidth),
+		previewMinWidth:         previewMinWidth(opts.PreviewMinWidth),
 	}
 	m.focusCmd = m.filterInput.Focus()
 	return m
@@ -240,6 +293,59 @@ func (m Model) fetchSessions() tea.Cmd {
 	return func() tea.Msg {
 		sessions, err := m.fetchFunc()
 		return sessionsLoadedMsg{sessions: sessions, err: err}
+	}
+}
+
+// previewDebounce is how long a cursor position has to hold before its preview
+// is fetched. Holding a movement key would otherwise shell out once per row
+// passed over; the stale-result guard makes those harmless, but not free.
+const previewDebounce = 60 * time.Millisecond
+
+// syncInputWidth fits the filter input to the list column. Toggling the preview
+// pane resizes that column, so it is called from there too, not just on resize.
+func (m *Model) syncInputWidth() {
+	m.filterInput.SetWidth(m.contentWidth() - 4)
+}
+
+// highlightedName returns the name of the session under the cursor.
+func (m Model) highlightedName() (string, bool) {
+	if m.cursor < 0 || m.cursor >= len(m.filtered) {
+		return "", false
+	}
+	return m.filtered[m.cursor].item.name, true
+}
+
+// schedulePreview arms a debounced fetch for the highlighted session, and
+// returns nil when there is nothing to do — the pane is off, the session is
+// already previewed, or its fetch is already in flight.
+func (m *Model) schedulePreview() tea.Cmd {
+	if m.previewFunc == nil || !m.previewOn {
+		return nil
+	}
+
+	name, ok := m.highlightedName()
+	if !ok {
+		// Nothing is highlighted, so there is nothing the old content could
+		// still be describing.
+		m.previewSeq++
+		m.previewName, m.previewPending, m.previewContent, m.previewErr = "", "", "", nil
+		return nil
+	}
+	if name == m.previewName || name == m.previewPending {
+		return nil
+	}
+
+	m.previewSeq++
+	m.previewPending = name
+	msg := previewFetchMsg{seq: m.previewSeq, name: name}
+	return tea.Tick(previewDebounce, func(time.Time) tea.Msg { return msg })
+}
+
+func (m Model) fetchPreview(seq int, name string) tea.Cmd {
+	previewFunc := m.previewFunc
+	return func() tea.Msg {
+		content, err := previewFunc(name)
+		return previewLoadedMsg{seq: seq, name: name, content: content, err: err}
 	}
 }
 
@@ -258,6 +364,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.chosen = alias.Target
 		return m, tea.Quit
 
+	case previewFetchMsg:
+		// The tick can't be cancelled, so a stale one still arrives.
+		if msg.seq != m.previewSeq {
+			return m, nil
+		}
+		return m, m.fetchPreview(msg.seq, msg.name)
+
+	case previewLoadedMsg:
+		if msg.seq != m.previewSeq {
+			return m, nil
+		}
+		m.previewPending = ""
+		m.previewName = msg.name
+		m.previewContent = msg.content
+		m.previewErr = msg.err
+		return m, nil
+
 	case sessionsLoadedMsg:
 		if msg.err != nil {
 			m.loadErr = msg.err
@@ -266,12 +389,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.loading = false
 		m.allItems = buildItems(msg.sessions, m.separatorAware)
 		m.applyFilter()
-		return m, nil
+		return m, m.schedulePreview()
 
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-		m.filterInput.SetWidth(m.contentWidth() - 4)
+		m.syncInputWidth()
 		return m, nil
 
 	case tea.KeyPressMsg:
@@ -292,19 +415,37 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case "up", "ctrl+k", "ctrl+p":
 			m.cursorUp(1)
-			return m, nil
+			return m, m.schedulePreview()
 
 		case "down", "ctrl+j", "ctrl+n":
 			m.cursorDown(1)
-			return m, nil
+			return m, m.schedulePreview()
 
 		case "ctrl+u":
 			m.cursorUp(m.visibleCount() / 2)
-			return m, nil
+			return m, m.schedulePreview()
 
 		case "ctrl+d":
 			m.cursorDown(m.visibleCount() / 2)
-			return m, nil
+			return m, m.schedulePreview()
+
+		case "ctrl+o":
+			// Toggling stays allowed on a narrow terminal: the pane is gated on
+			// width at render time, so it appears once the window has room.
+			if m.previewFunc == nil {
+				return m, nil
+			}
+			m.previewOn = !m.previewOn
+			m.syncInputWidth()
+			if !m.previewOn {
+				// Drop anything in flight so switching back on always refetches
+				// the highlighted row rather than waiting on a request made
+				// before the pane was hidden.
+				m.previewSeq++
+				m.previewPending = ""
+				return m, nil
+			}
+			return m, m.schedulePreview()
 		}
 	}
 
@@ -319,8 +460,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.cursor = 0
 		m.offset = 0
+		cmds := []tea.Cmd{cmd}
 		if tick := m.scheduleAliasAutoConnect(); tick != nil {
-			return m, tea.Batch(cmd, tick)
+			cmds = append(cmds, tick)
+		}
+		if preview := m.schedulePreview(); preview != nil {
+			cmds = append(cmds, preview)
+		}
+		if len(cmds) > 1 {
+			return m, tea.Batch(cmds...)
 		}
 	}
 
@@ -519,26 +667,67 @@ func (m *Model) cursorDown(n int) {
 	}
 }
 
+// fallbackVisibleCount is used for the frame that can render before the
+// terminal size is known.
+const fallbackVisibleCount = 5
+
+// visibleCount is how many session rows fit. The picker runs on the alt screen,
+// so it gets every row the terminal has apart from the filter row and the blank
+// line under it.
 func (m Model) visibleCount() int {
-	// border(2) + title(1) + blank(1) + filter(1) + blank(1) + counter(1) + help(1) + blank before counter(1)
-	chrome := 9
-	available := m.height - chrome
+	available := m.height - headerLines
 	if available < 1 {
-		available = 5
-	}
-	if available > 15 {
-		available = 15
+		return fallbackVisibleCount
 	}
 	return available
 }
 
-func (m Model) contentWidth() int {
-	w := m.width
-	if w < 30 {
-		w = 40
+const (
+	// maxListWidth is the widest the session list gets, split or not.
+	maxListWidth = 60
+	// minListWidth is the narrowest list worth splitting off; the preview gives
+	// columns back to stay above it.
+	minListWidth = 40
+	// previewChrome is the divider column plus the padding after it. Both sit
+	// inside the pane's width, so the text gets that much less room.
+	previewChrome = 2
+)
+
+// splitActive reports whether this frame renders a preview pane. Width is
+// checked here rather than at toggle time so growing the window is enough to
+// bring the pane back.
+func (m Model) splitActive() bool {
+	return m.previewOn && m.previewFunc != nil && m.width >= m.previewMinWidth
+}
+
+// previewCols is how many columns the preview pane occupies, divider included.
+// The configured percent is a floor: the list is capped at maxListWidth, and
+// everything past that goes to the preview rather than being left blank. The
+// list is never squeezed below minListWidth.
+func (m Model) previewCols() int {
+	if !m.splitActive() {
+		return 0
 	}
-	if w > 60 {
-		w = 60
+	cols := m.width * m.previewWidthPct / 100
+	if rest := m.width - maxListWidth; rest > cols {
+		cols = rest
+	}
+	if max := m.width - minListWidth; cols > max {
+		cols = max
+	}
+	if cols <= previewChrome {
+		return 0
+	}
+	return cols
+}
+
+func (m Model) contentWidth() int {
+	w := m.width - m.previewCols()
+	if w < 30 {
+		w = minListWidth
+	}
+	if w > maxListWidth {
+		w = maxListWidth
 	}
 	return w
 }
@@ -615,9 +804,83 @@ func (m Model) View() tea.View {
 		}
 	}
 
-	content := b.String()
+	// The last row leaves a trailing newline behind. Dropping it keeps the frame
+	// exactly the height of the terminal, and makes both halves of a split the
+	// same height so the divider spans the whole block.
+	content := strings.TrimSuffix(b.String(), "\n")
 
-	return tea.NewView(content)
+	if cols := m.previewCols(); cols > 0 {
+		list := lipgloss.NewStyle().
+			Width(m.contentWidth()).
+			MaxWidth(m.contentWidth()).
+			Render(content)
+		content = lipgloss.JoinHorizontal(lipgloss.Top, list, m.previewView(cols, visible))
+	}
+
+	v := tea.NewView(content)
+	// Full window mode: the picker fills the terminal and hands the user's
+	// scrollback back untouched when it quits.
+	v.AltScreen = true
+	return v
+}
+
+// headerLines is the filter row plus the blank line under it, which the
+// preview pane skips so its first line sits level with the first session row.
+const headerLines = 2
+
+// previewView renders the preview pane: a left divider, then the content of the
+// highlighted session clipped to the pane.
+func (m Model) previewView(cols, rows int) string {
+	faint := lipgloss.NewStyle().Faint(true)
+
+	var body string
+	switch {
+	case m.previewErr != nil:
+		// A broken preview_command shouldn't take the picker down with it.
+		body = faint.Render(fmt.Sprintf("Preview unavailable: %v", m.previewErr))
+	case m.previewName == "":
+		body = faint.Render("Loading preview...")
+	case strings.TrimSpace(m.previewContent) == "":
+		body = faint.Render("No preview")
+	default:
+		body = m.previewContent
+	}
+
+	// The divider and padding live inside Width, so the text gets less room.
+	body = clipLines(body, cols-previewChrome, rows)
+
+	return lipgloss.NewStyle().
+		Border(lipgloss.NormalBorder(), false, false, false, true).
+		BorderForeground(lipgloss.ANSIColor(8)).
+		PaddingLeft(1).
+		PaddingTop(headerLines).
+		Width(cols).
+		Height(headerLines + rows).
+		Render(body)
+}
+
+// clipLines cuts text to at most rows lines of width columns each. Truncation
+// is ANSI-aware because tmux previews come from `capture-pane -e`, and each
+// kept line is reset so a color left open can't bleed into the pane below it.
+func clipLines(text string, width, rows int) string {
+	if width < 1 || rows < 1 {
+		return ""
+	}
+
+	lines := strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n")
+	if len(lines) > rows {
+		lines = lines[:rows]
+	}
+
+	clip := lipgloss.NewStyle().MaxWidth(width)
+	for i, line := range lines {
+		line = clip.Render(line)
+		if strings.Contains(line, "\x1b") {
+			line += "\x1b[0m"
+		}
+		lines[i] = line
+	}
+	return strings.Join(lines, "\n")
 }
 
 // windowGap separates the session name from the window names, and each window

--- a/sesh.schema.json
+++ b/sesh.schema.json
@@ -115,6 +115,24 @@
           "description": "Single character that, typed first in the picker, narrows the list to aliased sessions (e.g. \"/tc\" finds the \"tc\" alias). Set to an empty string to disable.",
           "default": "/",
           "maxLength": 1
+        },
+        "preview": {
+          "type": "boolean",
+          "description": "Show a preview of the highlighted session beside the list in the picker TUI, using the same output as `sesh preview`",
+          "default": false
+        },
+        "preview_width": {
+          "type": "integer",
+          "description": "Share of the terminal width, in percent, guaranteed to the preview pane. The session list keeps its column cap, so any width left over goes to the preview on top of this.",
+          "default": 60,
+          "minimum": 10,
+          "maximum": 90
+        },
+        "preview_min_width": {
+          "type": "integer",
+          "description": "Narrowest terminal, in columns, that still gets a preview pane. Below this the picker renders the session list only.",
+          "default": 100,
+          "minimum": 1
         }
       },
       "additionalProperties": false

--- a/sesh.schema.json
+++ b/sesh.schema.json
@@ -133,6 +133,12 @@
           "description": "Narrowest terminal, in columns, that still gets a preview pane. Below this the picker renders the session list only.",
           "default": 100,
           "minimum": 1
+        },
+        "preview_border": {
+          "type": "string",
+          "description": "Divider drawn between the session list and the preview pane. Use \"none\" for no divider.",
+          "enum": ["line", "thick", "double", "none"],
+          "default": "line"
         }
       },
       "additionalProperties": false

--- a/seshcli/deps.go
+++ b/seshcli/deps.go
@@ -135,7 +135,7 @@ func (b *BaseDeps) BuildAll(configPath string) (*Deps, error) {
 	ic := icon.NewIcon(config)
 	p := previewer.NewPreviewer(usedLister, t, ic, b.Dir, b.Home, l, config, b.Shell)
 	cl := cloner.NewCloner(c, b.Git)
-	pk := picker.NewPicker(config)
+	pk := picker.NewPicker(config, p)
 	mk := mkdirer.NewMkdirer(b.Os, b.Home, c)
 
 	return &Deps{

--- a/seshcli/picker.go
+++ b/seshcli/picker.go
@@ -63,6 +63,16 @@ func NewPickerCommand(base *BaseDeps) *cobra.Command {
 				disableAliasAutoConnect, _ := cmd.Flags().GetBool("no-alias-auto")
 				pickerOpts.DisableAliasAutoConnect = &disableAliasAutoConnect
 			}
+			// --no-preview wins over --preview so it can override a --preview
+			// baked into an alias or wrapper script.
+			if cmd.Flags().Changed("preview") {
+				preview, _ := cmd.Flags().GetBool("preview")
+				pickerOpts.Preview = &preview
+			}
+			if cmd.Flags().Changed("no-preview") {
+				preview := false
+				pickerOpts.Preview = &preview
+			}
 			if cmd.Flags().Changed("placeholder") {
 				placeholder, _ := cmd.Flags().GetString("placeholder")
 				pickerOpts.Placeholder = &placeholder
@@ -98,6 +108,8 @@ func NewPickerCommand(base *BaseDeps) *cobra.Command {
 	cmd.Flags().StringP("prompt", "p", "", "prompt shown in the picker TUI")
 	cmd.Flags().String("placeholder", "", "placeholder text in the picker TUI")
 	cmd.Flags().Bool("no-alias-auto", false, "don't auto-connect when an alias is fully typed")
+	cmd.Flags().Bool("preview", false, "show a preview of the highlighted session beside the list")
+	cmd.Flags().Bool("no-preview", false, "hide the preview pane")
 
 	return cmd
 }


### PR DESCRIPTION
Closes #423

The picker rendered only the filter input and the session list, so the preview that `sesh preview` feeds to fzf had no equivalent in the native picker.

## Preview pane

Reuses the `previewer` package, so tmux sessions, config sessions, `default_session.preview_command` and plain directories behave exactly as they do in the fzf popup. Previews are fetched from a `tea.Cmd` with a short debounce and a stale-result guard, so a `preview_command` that shells out never blocks the event loop, and a result that arrives after the cursor moved on is discarded rather than shown against the wrong session.

```toml
[tui]
preview = false
preview_width = 60
preview_min_width = 100
preview_border = "line"   # "thick" | "double" | "none"
```

- `preview_width` is the share of the terminal guaranteed to the pane. The list keeps its 60 column cap, so extra width on a wide terminal goes to the preview; the list is never squeezed below 40 columns.
- `preview_min_width` is the narrowest terminal that still gets a split — handy in small tmux popups. The pane returns on its own once the window has room.
- `preview_border` picks the divider between the panes. `none` draws no divider and gives its column to the preview text. Empty or unrecognized values fall back to the default rather than failing the picker.
- `ctrl+o` toggles the pane at runtime, and `--preview` / `--no-preview` override the config per invocation.

A failing preview command is reported inside the pane instead of taking the picker down.

## Alt screen

The picker now runs on the alt screen and fills the terminal in both directions: `visibleCount` previously reserved nine lines for chrome that `View` never drew, then capped the list at fifteen rows however tall the terminal was.

## Testing

`go test ./...` — 521 passing, including coverage for debounce/stale-result handling, the split width math, divider styles, clipping of oversized previews, and frames filling the terminal height.