### PR TITLE
fix(picker): cap the fuzzy length penalty so long names can rank first

### DIFF
--- a/picker/picker_test.go
+++ b/picker/picker_test.go
@@ -470,6 +470,73 @@ func TestApplyFilter_SeparatorAware_Disabled(t *testing.T) {
 	}
 }
 
+// longNameSessions mirrors the shape of the bug the capped length penalty
+// fixes: a tmux session whose name is long but starts with the query, competing
+// with short zoxide paths that only contain it.
+func longNameSessions() model.SeshSessions {
+	dir := model.SeshSessionMap{
+		"s1": {Name: "~/c/sesh", Src: "zoxide"},
+		"s2": {Name: "~/c/re/sesh", Src: "zoxide"},
+		"s3": {Name: "~/c/sesh/w/411", Src: "zoxide"},
+		"s4": {Name: "sesh/w/423 — Add opt-in preview pane to the picker TUI", Src: "tmux"},
+	}
+	return model.SeshSessions{
+		OrderedIndex: []string{"s1", "s2", "s3", "s4"},
+		Directory:    dir,
+	}
+}
+
+func newLongNameModel() Model {
+	sessions := longNameSessions()
+	m := New(testFetchFunc(sessions), testOptionsWith(func(o *Options) {
+		o.SeparatorAware = true
+	}))
+	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
+	return result.(Model)
+}
+
+func TestApplyFilter_LongNameMatchingAtStartRanksFirst(t *testing.T) {
+	m := newLongNameModel()
+	m.filterInput.SetValue("sesh")
+	m.applyFilter()
+
+	assert.Len(t, m.filtered, 4)
+	assert.Equal(t, "sesh/w/423 — Add opt-in preview pane to the picker TUI",
+		m.filtered[0].item.name,
+		"a long name matching at its first character should outrank shorter partial matches")
+}
+
+func TestApplyFilter_LengthStillBreaksComparableMatches(t *testing.T) {
+	m := newLongNameModel()
+	m.filterInput.SetValue("c sesh")
+	m.applyFilter()
+
+	names := make([]string, 0, len(m.filtered))
+	for _, f := range m.filtered {
+		names = append(names, f.item.name)
+	}
+	assert.Equal(t, []string{"~/c/sesh", "~/c/sesh/w/411", "~/c/re/sesh"}, names,
+		"among comparable matches the shorter name should still come first")
+}
+
+func TestApplyFilter_ExactNameStillBeatsALongerPrefixMatch(t *testing.T) {
+	sessions := model.SeshSessions{
+		OrderedIndex: []string{"s1", "s2"},
+		Directory: model.SeshSessionMap{
+			"s1": {Name: "sesh plus a very long tail of unmatched characters", Src: "tmux"},
+			"s2": {Name: "sesh", Src: "tmux"},
+		},
+	}
+	m := New(testFetchFunc(sessions), testOptions())
+	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
+	m = result.(Model)
+	m.filterInput.SetValue("sesh")
+	m.applyFilter()
+
+	assert.Equal(t, "sesh", m.filtered[0].item.name,
+		"capping the penalty should not let a long name overtake an exact match")
+}
+
 // sessionsWithWindows returns sessions carrying window names for display.
 func sessionsWithWindows() model.SeshSessions {
 	dir := model.SeshSessionMap{

--- a/picker/tui.go
+++ b/picker/tui.go
@@ -640,7 +640,7 @@ func (m *Model) applyFilter() {
 		pattern = normalizeSeparators(pattern)
 	}
 
-	matches := fuzzy.FindFrom(pattern, m.allItems)
+	matches := rankMatches(fuzzy.FindFromNoSort(pattern, m.allItems))
 	m.filtered = make([]filteredItem, len(matches))
 	for i, match := range matches {
 		m.filtered[i] = filteredItem{
@@ -648,6 +648,43 @@ func (m *Model) applyFilter() {
 			matchedIndexes: match.MatchedIndexes,
 		}
 	}
+}
+
+// maxUnmatchedCharPenalty caps how much a name can be docked for the characters
+// the query didn't match. It is deliberately small — the same size as the fuzzy
+// library's adjacent-match bonus — so length can only ever break a tie between
+// matches the scorer already rates the same.
+const maxUnmatchedCharPenalty = 5
+
+// rankMatches scores unsorted fuzzy matches with the library's length penalty
+// capped, and orders them best first.
+//
+// sahilm/fuzzy docks a match one point for every character the query didn't
+// match, with no floor, so a long name loses to a short one even when it is
+// plainly the better match: typing "sesh" put a tmux session named
+// "sesh/w/423 — Add opt-in preview pane to the picker TUI" below a dozen zoxide
+// paths, despite matching at its very first character. Capping the penalty keeps
+// length as a tiebreaker without letting it outweigh where the match landed.
+//
+// Matches must come in unsorted (fuzzy.FindFromNoSort), so they arrive in
+// session-list order. The sort is stable, so equally scored matches keep that
+// order — which is the order the picker shows with an empty query, tmux
+// sessions first.
+func rankMatches(matches fuzzy.Matches) fuzzy.Matches {
+	ranked := make([]struct {
+		match fuzzy.Match
+		score int
+	}, len(matches))
+	for i, match := range matches {
+		penalty := len(match.MatchedIndexes) - len(match.Str)
+		ranked[i].match = match
+		ranked[i].score = match.Score - penalty + max(penalty, -maxUnmatchedCharPenalty)
+	}
+	sort.SliceStable(ranked, func(i, j int) bool { return ranked[i].score > ranked[j].score })
+	for i, r := range ranked {
+		matches[i] = r.match
+	}
+	return matches
 }
 
 func (m *Model) cursorUp(n int) {


### PR DESCRIPTION
## Problem

`sahilm/fuzzy` docks a match one point for every character the query didn't match, with no floor. Long names lose to short ones even when they're plainly the better match: typing `sesh` put a tmux session named `sesh/w/423 — Add opt-in preview pane to the picker TUI` below a dozen zoxide paths, despite matching at its very first character.

## Change

`applyFilter` now calls `fuzzy.FindFromNoSort` and ranks the matches itself via `rankMatches`, which caps the unmatched-character penalty at 5 — the same size as the library's adjacent-match bonus — so length can only break a tie between matches the scorer already rates the same.

The sort is stable and matches arrive in session-list order, so equally scored items keep the picker's default ordering (tmux sessions first).

## Tests

Three new cases in `picker/picker_test.go`:
- a long name matching at its first character outranks shorter partial matches
- length still breaks ties among comparable matches
- an exact match still beats a longer prefix match (the cap doesn't overshoot)

`go test ./picker/...` — 150 passing.