### PR TITLE
Picker TUI: `#{1-9}` index jump and a `--query` prefill flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,6 +709,24 @@ Window names are display-only: selecting a row still returns just the session na
 
 `alias_auto_connect_delay` and `alias_filter_prefix` tune aliases — see [Session Aliases](#session-aliases).
 
+#### Jumping by number
+
+Typing `#` as the first character numbers the rows and turns the next digit into a jump — the fastest way to reach one of your first few sessions without reading their names:
+
+```
+filter: #
+
+> 1 sesh
+  2 dotfiles
+  3 my-project
+```
+
+Pressing <kbd>3</kbd> connects to `my-project` immediately. Only `1`–`9` jump, and only the first nine rows are numbered.
+
+The numbers follow the visible list, so anything typed after the sigil narrows it first and renumbers what's left — `#a` then <kbd>2</kbd> jumps to the second match for `a`. A digit with no row at that position does nothing rather than filtering.
+
+Only a leading `#` counts, so `feat#123` filters normally. If you configure `alias_filter_prefix = "#"`, alias mode wins and this mode is unreachable.
+
 #### Preview pane
 
 With `preview = true`, the highlighted session is previewed beside the list, using exactly the same output as `sesh preview` — live tmux panes via `capture-pane`, your `preview_command` for configured sessions, and a directory listing otherwise:

--- a/README.md
+++ b/README.md
@@ -709,6 +709,20 @@ Window names are display-only: selecting a row still returns just the session na
 
 `alias_auto_connect_delay` and `alias_filter_prefix` tune aliases — see [Session Aliases](#session-aliases).
 
+#### Starting with a filter
+
+`--query` (`-q`) opens the picker with its filter already typed out, which is handy for tmux keybinds that scope the list to one slice of your sessions:
+
+```sh
+bind-key "P" display-popup -h 90% -w 50% -E "sesh picker -q work/"
+```
+
+The query goes in exactly as if you'd typed it, so the list is narrowed the moment sessions load, and backspacing widens it again. Sigils work too — `-q '#'` opens straight into [number jumping](#jumping-by-number) and `-q /` into [alias mode](#session-aliases).
+
+A query that matches a single session doesn't connect on its own; the picker opens with that row highlighted and waits for <kbd>enter</kbd>. Neither does a query that spells out an alias with `alias_auto_connect` on — auto-connect stays a reward for actually typing it, so a scripted `--query` never connects somewhere you didn't look.
+
+This is per-invocation only, with no `[tui]` equivalent: a default query would silently hide sessions on every launch.
+
 #### Jumping by number
 
 Typing `#` as the first character numbers the rows and turns the next digit into a jump — the fastest way to reach one of your first few sessions without reading their names:

--- a/configurator/configurator_test.go
+++ b/configurator/configurator_test.go
@@ -208,7 +208,7 @@ func TestGetConfig_ImportPathWithEnvVar(t *testing.T) {
 			"CONFIGS": "/custom/dir",
 		},
 		files: map[string][]byte{
-			"/main/sesh.toml":            mainTOML,
+			"/main/sesh.toml":           mainTOML,
 			"/custom/dir/imported.toml": importData,
 		},
 	}
@@ -236,7 +236,7 @@ func TestGetConfig_ImportPathWithTilde(t *testing.T) {
 	mockOs := &testOs{
 		homeDir: "/home/testuser",
 		files: map[string][]byte{
-			"/main/sesh.toml":                             mainTOML,
+			"/main/sesh.toml":                      mainTOML,
 			"/home/testuser/imports/imported.toml": importData,
 		},
 	}

--- a/icon/icon.go
+++ b/icon/icon.go
@@ -26,7 +26,7 @@ var (
 	tmuxIcon       string = ""
 	configIcon     string = ""
 	tmuxinatorIcon string = ""
-	tmuxPaneIcon       string = ""
+	tmuxPaneIcon   string = ""
 )
 
 // Glyph holds the icon character and ANSI color code for a session source.

--- a/lister/config_wildcard_test.go
+++ b/lister/config_wildcard_test.go
@@ -42,12 +42,12 @@ func TestFindConfigWildcard(t *testing.T) {
 	}
 
 	// Register pattern expansions used across multiple test cases
-	mockHome.On("ExpandPath","~/projects/*").Return("/Users/test/projects/*", nil)
-	mockHome.On("ExpandPath","~/work/*").Return("/Users/test/work/*", nil)
-	mockHome.On("ExpandPath","~/deep/**").Return("/Users/test/deep/**", nil)
+	mockHome.On("ExpandPath", "~/projects/*").Return("/Users/test/projects/*", nil)
+	mockHome.On("ExpandPath", "~/work/*").Return("/Users/test/work/*", nil)
+	mockHome.On("ExpandPath", "~/deep/**").Return("/Users/test/deep/**", nil)
 
 	t.Run("should match path against wildcard pattern", func(t *testing.T) {
-		mockHome.On("ExpandPath","/Users/test/projects/myapp").Return("/Users/test/projects/myapp", nil)
+		mockHome.On("ExpandPath", "/Users/test/projects/myapp").Return("/Users/test/projects/myapp", nil)
 		wc, found := realLister.FindConfigWildcard("/Users/test/projects/myapp")
 		assert.True(t, found)
 		assert.Equal(t, "nvim", wc.StartupCommand)
@@ -55,14 +55,14 @@ func TestFindConfigWildcard(t *testing.T) {
 	})
 
 	t.Run("should return false when no pattern matches", func(t *testing.T) {
-		mockHome.On("ExpandPath","/Users/test/other/myapp").Return("/Users/test/other/myapp", nil)
+		mockHome.On("ExpandPath", "/Users/test/other/myapp").Return("/Users/test/other/myapp", nil)
 		wc, found := realLister.FindConfigWildcard("/Users/test/other/myapp")
 		assert.False(t, found)
 		assert.Equal(t, model.WildcardConfig{}, wc)
 	})
 
 	t.Run("should match second wildcard pattern", func(t *testing.T) {
-		mockHome.On("ExpandPath","/Users/test/work/project").Return("/Users/test/work/project", nil)
+		mockHome.On("ExpandPath", "/Users/test/work/project").Return("/Users/test/work/project", nil)
 		wc, found := realLister.FindConfigWildcard("/Users/test/work/project")
 		assert.True(t, found)
 		assert.Equal(t, "make dev", wc.StartupCommand)
@@ -70,32 +70,32 @@ func TestFindConfigWildcard(t *testing.T) {
 	})
 
 	t.Run("should not match nested paths (single-level glob)", func(t *testing.T) {
-		mockHome.On("ExpandPath","/Users/test/projects/foo/bar").Return("/Users/test/projects/foo/bar", nil)
+		mockHome.On("ExpandPath", "/Users/test/projects/foo/bar").Return("/Users/test/projects/foo/bar", nil)
 		_, found := realLister.FindConfigWildcard("/Users/test/projects/foo/bar")
 		assert.False(t, found)
 	})
 
 	t.Run("should match nested paths with ** pattern", func(t *testing.T) {
-		mockHome.On("ExpandPath","/Users/test/deep/foo/bar/baz").Return("/Users/test/deep/foo/bar/baz", nil)
+		mockHome.On("ExpandPath", "/Users/test/deep/foo/bar/baz").Return("/Users/test/deep/foo/bar/baz", nil)
 		wc, found := realLister.FindConfigWildcard("/Users/test/deep/foo/bar/baz")
 		assert.True(t, found)
 		assert.Equal(t, "deep-cmd", wc.StartupCommand)
 	})
 
 	t.Run("should not match unrelated paths with ** pattern", func(t *testing.T) {
-		mockHome.On("ExpandPath","/Users/test/other/foo").Return("/Users/test/other/foo", nil)
+		mockHome.On("ExpandPath", "/Users/test/other/foo").Return("/Users/test/other/foo", nil)
 		_, found := realLister.FindConfigWildcard("/Users/test/other/foo")
 		assert.False(t, found)
 	})
 
 	t.Run("should not match the prefix directory itself with **", func(t *testing.T) {
-		mockHome.On("ExpandPath","/Users/test/deep").Return("/Users/test/deep", nil)
+		mockHome.On("ExpandPath", "/Users/test/deep").Return("/Users/test/deep", nil)
 		_, found := realLister.FindConfigWildcard("/Users/test/deep")
 		assert.False(t, found)
 	})
 
 	t.Run("should not match the prefix directory with trailing slash and **", func(t *testing.T) {
-		mockHome.On("ExpandPath","/Users/test/deep/").Return("/Users/test/deep/", nil)
+		mockHome.On("ExpandPath", "/Users/test/deep/").Return("/Users/test/deep/", nil)
 		_, found := realLister.FindConfigWildcard("/Users/test/deep/")
 		assert.False(t, found)
 	})

--- a/model/git.go
+++ b/model/git.go
@@ -1,8 +1,8 @@
 package model
 
 type GitCloneOptions struct {
-	Dir    string
-	CmdDir string
-	Repo   string
+	Dir      string
+	CmdDir   string
+	Repo     string
 	GitFlags []string
 }

--- a/picker/picker.go
+++ b/picker/picker.go
@@ -25,6 +25,7 @@ type PickerOptions struct {
 	Placeholder             *string
 	DisableAliasAutoConnect *bool
 	Preview                 *bool
+	Query                   *string
 }
 
 type Picker interface {
@@ -155,6 +156,13 @@ func (p *RealPicker) Pick(fetchFunc FetchFunc, opts PickerOptions) (string, erro
 		preview = *opts.Preview
 	}
 
+	// A pre-filled query is per-invocation only: a configured default would
+	// silently hide sessions on every launch.
+	query := ""
+	if opts.Query != nil {
+		query = *opts.Query
+	}
+
 	// The model reaches the previewer through a function so the TUI stays
 	// unaware of the package, mirroring how sessions arrive via FetchFunc.
 	var previewFunc PreviewFunc
@@ -168,6 +176,7 @@ func (p *RealPicker) Pick(fetchFunc FetchFunc, opts PickerOptions) (string, erro
 		SeparatorAware:          p.config.SeparatorAware,
 		Prompt:                  prompt,
 		Placeholder:             placeholder,
+		Query:                   query,
 		Aliases:                 buildAliases(p.config.SessionConfigs),
 		AliasFilterPrefix:       aliasFilterPrefix(p.config.TUI.AliasFilterPrefix),
 		AliasAutoConnectDelay:   aliasAutoConnectDelay(p.config.TUI.AliasAutoConnectDelay),

--- a/picker/picker_test.go
+++ b/picker/picker_test.go
@@ -1607,3 +1607,106 @@ func TestVisibleCount_FallsBackBeforeSizeIsKnown(t *testing.T) {
 	assert.Equal(t, 0, m.height, "no WindowSizeMsg has arrived yet")
 	assert.Equal(t, fallbackVisibleCount, m.visibleCount())
 }
+
+// filterIndexMode types a query into index mode, sigil included.
+func filterIndexMode(m Model, query string) Model {
+	m.filterInput.SetValue(indexFilterPrefix + query)
+	m.applyFilter()
+	return m
+}
+
+func TestIndexMode_JumpsToTheNthSession(t *testing.T) {
+	m, _ := typeFilter(newTestModel(), "#")
+	require.Equal(t, []string{"my-project", "dotfiles", "~/code/app", "rails-app", "notes"},
+		filteredNames(m), "the bare sigil leaves the list alone")
+
+	result, cmd := m.Update(tea.KeyPressMsg{Code: '2', Text: "2"})
+	assert.Equal(t, "dotfiles", result.(Model).Chosen())
+	assert.NotNil(t, cmd, "jumping connects immediately")
+	assert.Equal(t, "#", result.(Model).filterInput.Value(),
+		"the digit is consumed by the mode, not typed into the filter")
+}
+
+func TestIndexMode_CountsTheFilteredList(t *testing.T) {
+	m, _ := typeFilter(newTestModel(), "#a")
+	require.Equal(t, []string{"rails-app", "~/code/app"}, filteredNames(m),
+		"anything after the sigil filters as it normally would")
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: '2', Text: "2"})
+	assert.Equal(t, "~/code/app", result.(Model).Chosen(),
+		"the numbering follows the visible list, not the full one")
+}
+
+func TestIndexMode_DigitPastTheEndIsANoOp(t *testing.T) {
+	m, _ := typeFilter(newTestModel(), "#notes")
+	require.Len(t, m.filtered, 1)
+
+	result, cmd := m.Update(tea.KeyPressMsg{Code: '3', Text: "3"})
+	after := result.(Model)
+	assert.Equal(t, "", after.Chosen())
+	assert.False(t, after.Quit())
+	assert.Nil(t, cmd)
+	assert.Equal(t, "#notes", after.filterInput.Value(),
+		"index mode owns the digits, so an unreachable one stays out of the filter")
+}
+
+func TestIndexMode_ZeroFallsThroughToFiltering(t *testing.T) {
+	m, _ := typeFilter(newTestModel(), "#0")
+
+	assert.Equal(t, "", m.Chosen(), "only 1-9 jump")
+	assert.Equal(t, "#0", m.filterInput.Value(), "the zero is a normal keystroke")
+}
+
+func TestIndexMode_WhileLoading(t *testing.T) {
+	sessions := testSessions()
+	m, _ := typeFilter(New(testFetchFunc(sessions), testOptions()), "#1")
+
+	require.True(t, m.loading)
+	assert.Equal(t, "", m.Chosen(), "there is nothing to jump to yet")
+	assert.Equal(t, "#", m.filterInput.Value())
+}
+
+func TestIndexMode_SigilPastTheStartIsANormalQuery(t *testing.T) {
+	m, _ := typeFilter(newTestModel(), "a#1")
+
+	assert.Equal(t, "", m.Chosen(), "only a leading sigil enters index mode")
+	assert.Equal(t, "a#1", m.filterInput.Value())
+}
+
+func TestIndexMode_AliasSigilWins(t *testing.T) {
+	m := newAliasModel(func(o *Options) { o.AliasFilterPrefix = indexFilterPrefix })
+	m, _ = typeFilter(m, "#")
+	require.Equal(t, []string{"my-project", "dotfiles"}, filteredNames(m),
+		"the configured alias sigil still opens alias mode")
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: '1', Text: "1"})
+	assert.Equal(t, "", result.(Model).Chosen(), "index mode is unreachable, so the digit filters")
+	assert.Equal(t, "#1", result.(Model).filterInput.Value())
+}
+
+func TestIndexMode_AliasesStillResolveAfterTheSigil(t *testing.T) {
+	m := filterIndexMode(newAliasModel(), "dot")
+
+	assert.Equal(t, []string{"dotfiles"}, filteredNames(m),
+		"an exact alias after the index sigil resolves like it does on its own")
+}
+
+func TestView_IndexModeNumbersRows(t *testing.T) {
+	m := newTestModel()
+	m.width, m.height = 60, 24
+
+	plain := ansi.Strip(m.View().Content)
+	assert.Contains(t, plain, "> my-project", "the gutter is only drawn in index mode")
+
+	m = filterIndexMode(m, "")
+	plain = ansi.Strip(m.View().Content)
+	assert.Contains(t, plain, "> 1 my-project")
+	assert.Contains(t, plain, "  2 dotfiles")
+}
+
+func TestIndexGutter_RunsOutAfterNine(t *testing.T) {
+	style := lipgloss.NewStyle()
+	assert.Equal(t, "9 ", indexGutter(maxIndexJump-1, style))
+	assert.Equal(t, "  ", indexGutter(maxIndexJump, style),
+		"rows past the ninth are unreachable, and blanks keep the names aligned")
+}

--- a/picker/picker_test.go
+++ b/picker/picker_test.go
@@ -131,6 +131,95 @@ func TestApplyFilter_NoMatches(t *testing.T) {
 	assert.Len(t, m.filtered, 0)
 }
 
+// newQueryModel returns a loaded model whose filter was pre-filled with query,
+// as `--query` does.
+func newQueryModel(query string, tweak ...func(*Options)) (Model, tea.Cmd) {
+	sessions := testSessions()
+	m := New(testFetchFunc(sessions), testOptionsWith(func(o *Options) {
+		o.Query = query
+		for _, fn := range tweak {
+			fn(o)
+		}
+	}))
+	result, cmd := m.Update(sessionsLoadedMsg{sessions: sessions})
+	return result.(Model), cmd
+}
+
+func TestQuery_PreFillsFilter(t *testing.T) {
+	m, _ := newQueryModel("notes")
+
+	assert.Equal(t, "notes", m.filterInput.Value())
+	require.Len(t, m.filtered, 1, "the list is narrowed as soon as sessions load")
+	assert.Equal(t, "notes", m.filtered[0].item.name)
+}
+
+func TestQuery_Empty(t *testing.T) {
+	m, _ := newQueryModel("")
+
+	assert.Equal(t, "", m.filterInput.Value())
+	assert.Len(t, m.filtered, 5)
+}
+
+func TestQuery_IsEditable(t *testing.T) {
+	m, _ := newQueryModel("notes")
+
+	// The cursor sits at the end of the pre-filled value, so a backspace trims
+	// it rather than doing nothing.
+	result, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	m = result.(Model)
+
+	assert.Equal(t, "note", m.filterInput.Value())
+	assert.Len(t, m.filtered, 1)
+}
+
+func TestQuery_SingleMatchDoesNotAutoSelect(t *testing.T) {
+	m, _ := newQueryModel("notes")
+
+	assert.Equal(t, "", m.chosen, "the picker still waits for enter")
+	assert.False(t, m.quit)
+}
+
+func TestQuery_EntersAliasMode(t *testing.T) {
+	m, _ := newQueryModel(model.DefaultAliasFilterPrefix, func(o *Options) {
+		o.Aliases = testAliases()
+	})
+
+	require.Len(t, m.filtered, 2, "the sigil narrows the list to aliased sessions")
+	assert.Equal(t, "my-project", m.filtered[0].item.name)
+	assert.Equal(t, "dotfiles", m.filtered[1].item.name)
+}
+
+func TestQuery_EntersIndexMode(t *testing.T) {
+	m, _ := newQueryModel(indexFilterPrefix)
+
+	name, handled := m.indexJump("2")
+	assert.True(t, handled)
+	assert.Equal(t, "dotfiles", name)
+}
+
+func TestQuery_DoesNotAutoConnectExactAlias(t *testing.T) {
+	m, cmd := newQueryModel("wp", func(o *Options) {
+		o.Aliases = testAliases()
+		o.AliasAutoConnectDelay = time.Millisecond
+	})
+
+	assert.Nil(t, aliasTick(cmd), "auto-connect stays a reward for typing")
+	assert.Equal(t, "", m.chosen)
+}
+
+func TestQuery_AutoConnectsAfterAKeystroke(t *testing.T) {
+	m, _ := newQueryModel("w", func(o *Options) {
+		o.Aliases = testAliases()
+		o.AliasAutoConnectDelay = time.Millisecond
+	})
+
+	_, cmd := typeFilter(m, "p")
+
+	tick := aliasTick(cmd)
+	require.NotNil(t, tick, "completing the alias by hand still arms auto-connect")
+	assert.Equal(t, "wp", tick.alias)
+}
+
 func TestCursorDown(t *testing.T) {
 	m := newTestModel()
 	m.height = 30

--- a/picker/tui.go
+++ b/picker/tui.go
@@ -96,6 +96,10 @@ type Options struct {
 	SeparatorAware bool
 	Prompt         string
 	Placeholder    string
+	// Query pre-fills the filter input. It goes in as if it had been typed —
+	// the sigils for alias and index mode included — but never triggers alias
+	// auto-connect on its own, which stays a reward for an actual keystroke.
+	Query string
 	// Aliases is keyed by lowercased alias.
 	Aliases map[string]Alias
 	// AliasFilterPrefix is the sigil that, typed first, narrows the list to
@@ -273,6 +277,9 @@ func New(fetchFunc FetchFunc, opts Options) Model {
 	ti := textinput.New()
 	ti.Placeholder = opts.Placeholder
 	ti.Prompt = opts.Prompt
+	// SetValue leaves the cursor at the end, so the pre-filled query reads as
+	// something just typed and can be backspaced away.
+	ti.SetValue(opts.Query)
 
 	aliasByName := make(map[string]string, len(opts.Aliases))
 	for _, alias := range opts.Aliases {

--- a/picker/tui.go
+++ b/picker/tui.go
@@ -168,8 +168,8 @@ type Model struct {
 	previewBorderName string
 	previewName       string
 	previewPending    string
-	previewContent string
-	previewErr     error
+	previewContent    string
+	previewErr        error
 	// previewSeq increments on every request so a result that arrives after the
 	// cursor moved on can be told apart from the current one.
 	previewSeq int

--- a/picker/tui.go
+++ b/picker/tui.go
@@ -237,6 +237,14 @@ func highlightChipPrefix(alias string, matchLen int, label lipgloss.Style) strin
 	return matched + label.Render(string(runes[matchLen:]))
 }
 
+// indexFilterPrefix is the sigil that, typed first, enters index mode: the rows
+// are numbered and the next digit jumps straight to one of them.
+const indexFilterPrefix = "#"
+
+// maxIndexJump is the highest position index mode can reach. Only single digits
+// are in scope, so rows past the ninth are unnumbered.
+const maxIndexJump = 9
+
 var separatorReplacer = strings.NewReplacer("-", " ", "_", " ", "/", " ", "\\", " ")
 
 func normalizeSeparators(s string) string {
@@ -454,6 +462,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			return m, m.schedulePreview()
+
+		default:
+			// Index mode owns the digits while it is active, so an out-of-range
+			// one is swallowed rather than filtering the list.
+			if name, handled := m.indexJump(msg.String()); handled {
+				if name == "" {
+					return m, nil
+				}
+				m.chosen = name
+				return m, tea.Quit
+			}
 		}
 	}
 
@@ -617,23 +636,69 @@ func (m *Model) filterAliases(query string) []filteredItem {
 	return append(byAlias, byName...)
 }
 
+// indexFilterQuery reports whether the raw input opens index mode and, if so,
+// returns whatever was typed after the sigil. Only a leading sigil counts, so a
+// `#` inside a branch-like query is left alone. The alias sigil is resolved
+// first, so configuring it as `#` keeps alias mode and leaves index mode
+// unreachable rather than making the two fight over the same keystroke.
+func (m *Model) indexFilterQuery(raw string) (string, bool) {
+	if _, ok := m.aliasFilterQuery(raw); ok {
+		return "", false
+	}
+	if !strings.HasPrefix(raw, indexFilterPrefix) {
+		return "", false
+	}
+	return strings.TrimPrefix(raw, indexFilterPrefix), true
+}
+
+// indexJump resolves a keypress in index mode to the session it selects. The
+// second return reports that the key belongs to the mode: it is true for every
+// digit 1-9 while the mode is active, even when no row sits at that position, so
+// a digit past the end of the list is a no-op rather than a literal in the
+// filter. Digits are counted against the visible list, so the numbering stays
+// meaningful when a query narrowed it.
+func (m Model) indexJump(key string) (string, bool) {
+	if _, ok := m.indexFilterQuery(m.filterInput.Value()); !ok {
+		return "", false
+	}
+	if len(key) != 1 || key[0] < '1' || key[0] > '9' {
+		return "", false
+	}
+	if n := int(key[0] - '0'); n <= len(m.filtered) {
+		return m.filtered[n-1].item.name, true
+	}
+	return "", true
+}
+
 func (m *Model) applyFilter() {
-	pattern := m.filterInput.Value()
-	if query, ok := m.aliasFilterQuery(pattern); ok {
+	raw := m.filterInput.Value()
+	if query, ok := m.aliasFilterQuery(raw); ok {
 		m.filtered = m.filterAliases(query)
 		return
 	}
-	if pattern == "" {
-		m.filtered = make([]filteredItem, len(m.allItems))
-		for i, item := range m.allItems {
-			m.filtered[i] = filteredItem{item: item}
-		}
+	// Index mode numbers whatever is displayed, so anything typed after the
+	// sigil filters exactly as it would on its own.
+	if query, ok := m.indexFilterQuery(raw); ok {
+		m.filtered = m.filterSessions(query)
 		return
+	}
+	m.filtered = m.filterSessions(raw)
+}
+
+// filterSessions narrows the loaded list by pattern: everything when it's
+// empty, the single target when it is an alias typed exactly, and a fuzzy match
+// otherwise.
+func (m *Model) filterSessions(pattern string) []filteredItem {
+	if pattern == "" {
+		filtered := make([]filteredItem, len(m.allItems))
+		for i, item := range m.allItems {
+			filtered[i] = filteredItem{item: item}
+		}
+		return filtered
 	}
 
 	if item, ok := m.aliasMatch(pattern); ok {
-		m.filtered = []filteredItem{{item: item}}
-		return
+		return []filteredItem{{item: item}}
 	}
 
 	if m.separatorAware {
@@ -641,13 +706,14 @@ func (m *Model) applyFilter() {
 	}
 
 	matches := fuzzy.FindFrom(pattern, m.allItems)
-	m.filtered = make([]filteredItem, len(matches))
+	filtered := make([]filteredItem, len(matches))
 	for i, match := range matches {
-		m.filtered[i] = filteredItem{
+		filtered[i] = filteredItem{
 			item:           m.allItems[match.Index],
 			matchedIndexes: match.MatchedIndexes,
 		}
 	}
+	return filtered
 }
 
 func (m *Model) cursorUp(n int) {
@@ -801,12 +867,20 @@ func (m Model) View() tea.View {
 		matchStyle := lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(1)).Bold(true)
 		normalStyle := lipgloss.NewStyle()
 		windowStyle := lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(8)).Faint(true)
+		indexStyle := lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(4))
+
+		// Index mode numbers the rows so the jump target can be read off the
+		// list instead of counted.
+		_, indexMode := m.indexFilterQuery(m.filterInput.Value())
 
 		for i := m.offset; i < end; i++ {
 			item := m.filtered[i]
 			prefix := "  "
 			if i == m.cursor {
 				prefix = cursorStyle.Render("> ")
+			}
+			if indexMode {
+				prefix += indexGutter(i, indexStyle)
 			}
 
 			var tag string
@@ -855,6 +929,15 @@ func (m Model) View() tea.View {
 	// scrollback back untouched when it quits.
 	v.AltScreen = true
 	return v
+}
+
+// indexGutter renders the jump number for the row at position i, or blanks of
+// the same width once the numbers run out, so every name stays aligned.
+func indexGutter(i int, style lipgloss.Style) string {
+	if i >= maxIndexJump {
+		return "  "
+	}
+	return style.Render(fmt.Sprintf("%d ", i+1))
 }
 
 // headerLines is the filter row plus the blank line under it, which the

--- a/seshcli/deps.go
+++ b/seshcli/deps.go
@@ -38,19 +38,19 @@ import (
 
 // BaseDeps holds config-free dependencies that can be constructed eagerly.
 type BaseDeps struct {
-	Exec        execwrap.Exec
-	Os          oswrap.Os
-	Path        pathwrap.Path
-	Runtime     runtimewrap.Runtime
-	Home        home.Home
-	Shell       shell.Shell
-	Json        json.Json
-	Replacer    replacer.Replacer
-	Git         git.Git
-	Github      github.Github
-	Dir         dir.Dir
-	Zoxide      zoxide.Zoxide
-	Tmuxinator  tmuxinator.Tmuxinator
+	Exec       execwrap.Exec
+	Os         oswrap.Os
+	Path       pathwrap.Path
+	Runtime    runtimewrap.Runtime
+	Home       home.Home
+	Shell      shell.Shell
+	Json       json.Json
+	Replacer   replacer.Replacer
+	Git        git.Git
+	Github     github.Github
+	Dir        dir.Dir
+	Zoxide     zoxide.Zoxide
+	Tmuxinator tmuxinator.Tmuxinator
 }
 
 // Deps holds all dependencies including config-dependent ones.

--- a/seshcli/picker.go
+++ b/seshcli/picker.go
@@ -79,6 +79,10 @@ func NewPickerCommand(base *BaseDeps) *cobra.Command {
 			} else if deps.Config.TUI.Placeholder != "" {
 				pickerOpts.Placeholder = &deps.Config.TUI.Placeholder
 			}
+			if cmd.Flags().Changed("query") {
+				query, _ := cmd.Flags().GetString("query")
+				pickerOpts.Query = &query
+			}
 
 			chosen, err := deps.Picker.Pick(fetchFunc, pickerOpts)
 			if err != nil {
@@ -107,6 +111,7 @@ func NewPickerCommand(base *BaseDeps) *cobra.Command {
 	cmd.Flags().BoolP("separator-aware", "s", false, "match spaces to separators (-_/\\)")
 	cmd.Flags().StringP("prompt", "p", "", "prompt shown in the picker TUI")
 	cmd.Flags().String("placeholder", "", "placeholder text in the picker TUI")
+	cmd.Flags().StringP("query", "q", "", "prefill the picker's filter with this query")
 	cmd.Flags().Bool("no-alias-auto", false, "don't auto-connect when an alias is fully typed")
 	cmd.Flags().Bool("preview", false, "show a preview of the highlighted session beside the list")
 	cmd.Flags().Bool("no-preview", false, "hide the preview pane")


### PR DESCRIPTION
Two small navigation additions to the picker TUI. They share a branch because the second builds on the filter-parsing the first introduced.

Closes #427.

## `#{1-9}` index jump

Typing `#` as the first character numbers the rows and turns the next digit into a jump — the fastest way to reach one of your first few sessions without reading their names:

```
filter: #

> 1 sesh
  2 dotfiles
  3 my-project
```

Pressing <kbd>3</kbd> connects to `my-project` immediately. Only `1`–`9` jump, and only the first nine rows are numbered.

The numbers follow the visible list, so anything typed after the sigil narrows it first and renumbers what's left — `#a` then <kbd>2</kbd> jumps to the second match for `a`. A digit with no row at that position does nothing rather than falling through to the filter.

Only a leading `#` counts, so `feat#123` filters normally. If `alias_filter_prefix = "#"` is configured, alias mode wins and this mode is unreachable rather than the two fighting over the same keystroke.

## `--query` / `-q`

Opens the picker with its filter already typed, for keybinds that scope the list to one slice of your sessions:

```sh
bind-key "P" display-popup -h 90% -w 50% -E "sesh picker -q work/"
```

The value goes in as if typed by hand, so the list narrows the moment sessions load, backspace widens it again, and the sigils work — `-q '#'` opens straight into index mode, `-q /` into alias mode.

Two deliberate non-behaviors:

- A query matching a single session does **not** auto-select it. The row is highlighted and the picker waits for <kbd>enter</kbd>.
- A query that spells out an alias with `alias_auto_connect` on does **not** fire auto-connect. That stays a reward for an actual keystroke, so a scripted `--query` never connects somewhere you didn't look. Completing the alias by hand afterward still works.

This is flag-only, with no `[tui]` equivalent: a persistent default query would silently hide sessions on every launch.

## Notes

- No config-model changes, so `sesh.schema.json` is untouched.
- `man/sesh.1` is already missing `--prompt`, `--placeholder`, and `--preview`, so `--query` wasn't added to it in isolation.
- README documents both under **Picker TUI**.

## Testing

`go test ./...` — 539 passing across 30 packages, including new coverage for index-mode parsing, out-of-range digits, sigil precedence, query prefill, editability, and the two auto-connect non-behaviors above.