### PR TITLE
Support custom icons for configured sessions and wildcards in the picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,6 +709,50 @@ Window names are display-only: selecting a row still returns just the session na
 
 `alias_auto_connect_delay` and `alias_filter_prefix` tune aliases — see [Session Aliases](#session-aliases).
 
+#### Custom icons
+
+With `show_icons = true`, each row gets a glyph for where the session came from — tmux, config, zoxide, tmuxinator. That says where it was found, not what it is, so `[[session]]` and `[[wildcard]]` blocks can name their own icon instead. It can be any string: a nerd font glyph or an emoji.
+
+```toml
+[[session]]
+name = "sesh"
+path = "~/c/sesh"
+icon = ""
+
+[[session]]
+name = "notes"
+path = "~/second-brain"
+icon = "📓"
+
+[[wildcard]]
+pattern = "~/c/work/*"
+icon = "🏠"
+```
+
+```
+>  sesh
+  📓 notes
+  🏠 work-api
+   dotfiles
+```
+
+The most specific match wins: an exact `[[session]]` name, then its `path` — so the same directory listed by zoxide under a derived name still gets the icon — then a `[[wildcard]]` pattern. If several patterns match, the first in config order wins, as it does for `startup_command`. Anything with no icon of its own keeps its source glyph, and `icon = ""` counts as unset.
+
+Custom icons render unstyled: emoji bring their own color, and nerd font glyphs take the default foreground. The icon column is padded to the widest icon you configured, so a double-width emoji on one row doesn't push its name out of line with the rest.
+
+If one icon still sits a column off, add a trailing space to it:
+
+```toml
+[[session]]
+name = "update"
+path = "~/c/update"
+icon = "⬆️ "   # note the trailing space
+```
+
+Terminals disagree about how wide an emoji is, and nothing in a TUI can ask which way yours went. Emoji written with a variation selector — `⬆️` is `U+2B06` plus `U+FE0F`, as are `🖼️` and `🖥️` — measure as two cells but are drawn in one by WezTerm and others, which leaves that row short. A trailing space is counted into the row but not into the column width, so it fixes the one icon without shifting anything else.
+
+This is picker-only. `sesh list --icons` keeps the source glyphs, because the scripts and external pickers that parse its output trim a known-width glyph — see [#246](https://github.com/joshmedeski/sesh/issues/246). Custom icons are also suppressed entirely with `show_icons = false`.
+
 #### Starting with a filter
 
 `--query` (`-q`) opens the picker with its filter already typed out, which is handy for tmux keybinds that scope the list to one slice of your sessions:
@@ -808,6 +852,8 @@ path = "~/c/dotfiles/.config/tmux"
 startup_command = "nvim tmux.conf"
 preview_command = "bat --color=always ~/c/dotfiles/.config/tmux/tmux.conf"
 ```
+
+A session can also set `icon` to replace the source glyph it gets in the picker — see [Custom icons](#custom-icons).
 
 ### Session Aliases
 
@@ -942,6 +988,7 @@ Available fields:
 | `preview_command` | Command to run when previewing the session |
 | `disable_startup_command` | Set to `true` to suppress the startup command |
 | `windows` | Window layout to use (array of window names from `[[window]]` configs) |
+| `icon` | Icon shown for matching sessions in the picker — see [Custom icons](#custom-icons) |
 
 **Note:** Patterns use Go's `filepath.Match` syntax which supports `*` (any sequence), `?` (single character), and `[...]` (character classes). You can also use `/**` at the end of a pattern for recursive matching -- `~/projects/**` matches `~/projects/foo`, `~/projects/foo/bar`, and any deeper nesting. A single `*` only matches one level: `~/projects/*` matches `~/projects/foo` but not `~/projects/foo/bar`. Explicit `[[session]]` configs always take priority over wildcard matches. If multiple wildcards match, the first one in config order wins.
 

--- a/configurator/configurator_test.go
+++ b/configurator/configurator_test.go
@@ -335,6 +335,24 @@ alias = "dot"
 		"alias_auto_connect is opt-in per session")
 }
 
+func TestGetConfig_SessionIcons(t *testing.T) {
+	config, err := configFromTOML(t, `
+[[session]]
+name = "notes"
+path = "~/second-brain"
+icon = "📓"
+
+[[session]]
+name = "dotfiles"
+path = "~/.config"
+`)
+	assert.NoError(t, err)
+	require.Len(t, config.SessionConfigs, 2)
+	assert.Equal(t, "📓", config.SessionConfigs[0].Icon)
+	assert.Equal(t, "", config.SessionConfigs[1].Icon,
+		"a session without an icon keeps its source glyph")
+}
+
 func TestGetConfig_DuplicateAliases(t *testing.T) {
 	_, err := configFromTOML(t, `
 [[session]]

--- a/configurator/wildcard_test.go
+++ b/configurator/wildcard_test.go
@@ -20,6 +20,7 @@ pattern = "~/work/*"
 startup_command = "make dev"
 preview_command = "ls -la"
 disable_startup_command = true
+icon = "🏠"
 `)
 		config := model.Config{}
 		err := toml.Unmarshal(input, &config)
@@ -31,6 +32,8 @@ disable_startup_command = true
 		assert.Equal(t, "make dev", config.WildcardConfigs[1].StartupCommand)
 		assert.Equal(t, "ls -la", config.WildcardConfigs[1].PreviewCommand)
 		assert.True(t, config.WildcardConfigs[1].DisableStartCommand)
+		assert.Equal(t, "🏠", config.WildcardConfigs[1].Icon)
+		assert.Equal(t, "", config.WildcardConfigs[0].Icon)
 	})
 }
 

--- a/model/config.go
+++ b/model/config.go
@@ -96,6 +96,10 @@ type (
 		// fully typed in the picker, without pressing enter. Opt-in per session
 		// since it is only desirable for sessions you jump to constantly.
 		AliasAutoConnect bool `toml:"alias_auto_connect"`
+		// Icon replaces the source glyph this session gets in the picker with
+		// any string — a nerd font glyph or an emoji. Picker-only: `sesh list`
+		// consumers trim a known-width glyph, so a custom one would break them.
+		Icon string `toml:"icon"`
 		DefaultSessionConfig
 	}
 
@@ -143,5 +147,8 @@ type (
 		DisableStartCommand bool     `toml:"disable_startup_command"`
 		PreviewCommand      string   `toml:"preview_command"`
 		Windows             []string `toml:"windows"`
+		// Icon replaces the source glyph every session under this pattern gets
+		// in the picker. See SessionConfig.Icon.
+		Icon string `toml:"icon"`
 	}
 )

--- a/picker/icons.go
+++ b/picker/icons.go
@@ -1,0 +1,109 @@
+package picker
+
+import (
+	"path/filepath"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/joshmedeski/sesh/v2/home"
+	"github.com/joshmedeski/sesh/v2/model"
+)
+
+// WildcardFinder resolves a path to the [[wildcard]] block that matches it. The
+// picker borrows the lister's matching so an icon covers exactly the paths that
+// startup_command and preview_command already do, first match in config order
+// included.
+type WildcardFinder interface {
+	FindConfigWildcard(path string) (model.WildcardConfig, bool)
+}
+
+// buildIconResolver indexes the icons declared in config into a lookup for the
+// picker. It returns nil when nothing declares one, so the common case costs the
+// TUI nothing per row.
+//
+// The most specific match wins: an exact [[session]] name, then a [[session]]
+// path, then a [[wildcard]] pattern. Sessions are indexed by path as well as by
+// name because the same directory is often listed by another source under a
+// derived name — a zoxide entry for a configured session's path still gets its
+// icon.
+func buildIconResolver(config model.Config, h home.Home, wildcards WildcardFinder) IconFunc {
+	byName := make(map[string]string)
+	byPath := make(map[string]string)
+	for _, session := range config.SessionConfigs {
+		if session.Icon == "" {
+			continue
+		}
+		if session.Name != "" {
+			byName[session.Name] = session.Icon
+		}
+		if session.Path == "" {
+			continue
+		}
+		// An unexpandable path is skipped rather than fatal: the icon is
+		// cosmetic, and the lister already reports a broken path.
+		if path, err := h.ExpandPath(session.Path); err == nil {
+			byPath[filepath.Clean(path)] = session.Icon
+		}
+	}
+
+	hasWildcardIcon := false
+	for _, wildcard := range config.WildcardConfigs {
+		if wildcard.Icon != "" {
+			hasWildcardIcon = true
+			break
+		}
+	}
+
+	if len(byName) == 0 && len(byPath) == 0 && !hasWildcardIcon {
+		return nil
+	}
+
+	return func(session model.SeshSession) string {
+		if icn, ok := byName[session.Name]; ok {
+			return icn
+		}
+		if session.Path == "" {
+			return ""
+		}
+		if icn, ok := byPath[filepath.Clean(session.Path)]; ok {
+			return icn
+		}
+		if !hasWildcardIcon || wildcards == nil {
+			return ""
+		}
+		// A first match that declares no icon still wins, matching how the rest
+		// of the wildcard config resolves: the session falls back to its source
+		// glyph rather than searching on for a later pattern with an icon.
+		if wildcard, ok := wildcards.FindConfigWildcard(session.Path); ok {
+			return wildcard.Icon
+		}
+		return ""
+	}
+}
+
+// iconColWidth is the display width the picker's icon column needs: one cell for
+// the single-width source glyphs, more when a configured icon is wider (emoji
+// are two cells).
+//
+// It is measured across the whole config rather than the visible rows so the
+// column keeps one width — scrolling past an emoji can't shift the names, and a
+// row with a narrow icon lines up with one that has a wide icon.
+//
+// Trailing spaces are ignored, so padding an icon by hand to match how the
+// terminal draws it doesn't widen the column for every other row. See
+// Model.iconCell.
+func iconColWidth(config model.Config) int {
+	width := 1
+	for _, session := range config.SessionConfigs {
+		width = max(width, iconWidth(session.Icon))
+	}
+	for _, wildcard := range config.WildcardConfigs {
+		width = max(width, iconWidth(wildcard.Icon))
+	}
+	return width
+}
+
+func iconWidth(icn string) int {
+	return lipgloss.Width(strings.TrimRight(icn, " "))
+}

--- a/picker/icons_test.go
+++ b/picker/icons_test.go
@@ -1,0 +1,151 @@
+package picker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/joshmedeski/sesh/v2/home"
+	"github.com/joshmedeski/sesh/v2/lister"
+	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/oswrap"
+)
+
+// nerdGlyph is a nerd font icon (the Go language logo), written as an escape so
+// the source stays readable. It occupies a single cell, like the source glyphs.
+const nerdGlyph = "\ue627"
+
+// iconTestHome expands paths the way the real home wrapper does, without the
+// env-var handling the icon tests don't exercise.
+func iconTestHome(t *testing.T) home.Home {
+	mockOs := oswrap.NewMockOs(t)
+	mockOs.On("UserHomeDir").Return("/home/user", nil).Maybe()
+	mockOs.On("ExpandEnv", mock.AnythingOfType("string")).
+		Return(func(s string) string { return s }).Maybe()
+	return home.NewHome(mockOs)
+}
+
+// iconTestWildcards builds the real lister so wildcard icons are matched by the
+// same code that matches startup_command and preview_command.
+func iconTestWildcards(t *testing.T, config model.Config) WildcardFinder {
+	return lister.NewLister(config, iconTestHome(t), nil, nil, nil)
+}
+
+func TestBuildIconResolver_NilWithoutIcons(t *testing.T) {
+	config := model.Config{
+		SessionConfigs:  []model.SessionConfig{{Name: "sesh", Path: "~/c/sesh"}},
+		WildcardConfigs: []model.WildcardConfig{{Pattern: "~/c/*"}},
+	}
+	assert.Nil(t, buildIconResolver(config, iconTestHome(t), iconTestWildcards(t, config)),
+		"a config with no icons should cost the picker no per-row lookup")
+}
+
+func TestBuildIconResolver_SessionName(t *testing.T) {
+	config := model.Config{
+		SessionConfigs: []model.SessionConfig{{Name: "notes", Path: "~/second-brain", Icon: "📓"}},
+	}
+	resolve := buildIconResolver(config, iconTestHome(t), nil)
+
+	assert.Equal(t, "📓", resolve(model.SeshSession{Src: "tmux", Name: "notes"}),
+		"a session listed under its configured name gets its icon")
+	assert.Equal(t, "", resolve(model.SeshSession{Src: "tmux", Name: "other"}))
+}
+
+func TestBuildIconResolver_SessionPath(t *testing.T) {
+	config := model.Config{
+		SessionConfigs: []model.SessionConfig{{Name: "notes", Path: "~/second-brain", Icon: "📓"}},
+	}
+	resolve := buildIconResolver(config, iconTestHome(t), nil)
+
+	assert.Equal(t, "📓", resolve(model.SeshSession{Src: "zoxide", Name: "~/second-brain", Path: "/home/user/second-brain"}),
+		"the same directory found by another source gets the configured icon")
+	assert.Equal(t, "📓", resolve(model.SeshSession{Src: "zoxide", Name: "brain", Path: "/home/user/second-brain/"}),
+		"a trailing slash must not defeat the path match")
+}
+
+func TestBuildIconResolver_Wildcard(t *testing.T) {
+	config := model.Config{
+		WildcardConfigs: []model.WildcardConfig{{Pattern: "~/c/nu*", Icon: "🏠"}},
+	}
+	resolve := buildIconResolver(config, iconTestHome(t), iconTestWildcards(t, config))
+
+	assert.Equal(t, "🏠", resolve(model.SeshSession{Src: "zoxide", Name: "nutiliti", Path: "/home/user/c/nutiliti"}))
+	assert.Equal(t, "", resolve(model.SeshSession{Src: "zoxide", Name: "sesh", Path: "/home/user/c/sesh"}))
+}
+
+func TestBuildIconResolver_SessionBeatsWildcard(t *testing.T) {
+	config := model.Config{
+		SessionConfigs:  []model.SessionConfig{{Name: "sesh", Path: "~/c/sesh", Icon: "📔"}},
+		WildcardConfigs: []model.WildcardConfig{{Pattern: "~/c/*", Icon: "🏠"}},
+	}
+	resolve := buildIconResolver(config, iconTestHome(t), iconTestWildcards(t, config))
+
+	assert.Equal(t, "📔", resolve(model.SeshSession{Src: "tmux", Name: "sesh", Path: "/home/user/c/sesh"}),
+		"the more specific [[session]] icon wins over the pattern")
+	assert.Equal(t, "🏠", resolve(model.SeshSession{Src: "zoxide", Name: "other", Path: "/home/user/c/other"}),
+		"a path the session block doesn't cover still gets the wildcard icon")
+}
+
+func TestBuildIconResolver_SessionWithoutIconFallsThroughToWildcard(t *testing.T) {
+	config := model.Config{
+		SessionConfigs:  []model.SessionConfig{{Name: "sesh", Path: "~/c/sesh"}},
+		WildcardConfigs: []model.WildcardConfig{{Pattern: "~/c/*", Icon: "🏠"}},
+	}
+	resolve := buildIconResolver(config, iconTestHome(t), iconTestWildcards(t, config))
+
+	assert.Equal(t, "🏠", resolve(model.SeshSession{Src: "tmux", Name: "sesh", Path: "/home/user/c/sesh"}),
+		"an [[session]] with no icon of its own is not treated as an override")
+}
+
+func TestBuildIconResolver_EmptyIconIsUnset(t *testing.T) {
+	config := model.Config{
+		SessionConfigs: []model.SessionConfig{{Name: "sesh", Path: "~/c/sesh", Icon: ""}},
+	}
+	resolve := buildIconResolver(config, iconTestHome(t), nil)
+
+	assert.Nil(t, resolve, `icon = "" is unset, so the source glyph is kept`)
+}
+
+func TestBuildIconResolver_FirstWildcardMatchWins(t *testing.T) {
+	config := model.Config{
+		WildcardConfigs: []model.WildcardConfig{
+			{Pattern: "~/c/*", Icon: "🏠"},
+			{Pattern: "~/c/nu*", Icon: "📓"},
+		},
+	}
+	resolve := buildIconResolver(config, iconTestHome(t), iconTestWildcards(t, config))
+
+	assert.Equal(t, "🏠", resolve(model.SeshSession{Src: "zoxide", Name: "nutiliti", Path: "/home/user/c/nutiliti"}),
+		"wildcards resolve in config order, as they do for startup_command")
+}
+
+func TestBuildIconResolver_FirstWildcardMatchWithoutIconFallsBack(t *testing.T) {
+	config := model.Config{
+		WildcardConfigs: []model.WildcardConfig{
+			{Pattern: "~/c/*", StartupCommand: "nvim"},
+			{Pattern: "~/c/nu*", Icon: "📓"},
+		},
+	}
+	resolve := buildIconResolver(config, iconTestHome(t), iconTestWildcards(t, config))
+
+	assert.Equal(t, "", resolve(model.SeshSession{Src: "zoxide", Name: "nutiliti", Path: "/home/user/c/nutiliti"}),
+		"the first matching pattern still wins, so the row keeps its source glyph")
+}
+
+func TestIconColWidth(t *testing.T) {
+	assert.Equal(t, 1, iconColWidth(model.Config{}),
+		"the source glyphs need a single cell")
+
+	assert.Equal(t, 1, iconColWidth(model.Config{
+		SessionConfigs: []model.SessionConfig{{Name: "sesh", Icon: nerdGlyph}},
+	}), "a single-width nerd font glyph keeps the column as it was")
+
+	assert.Equal(t, 2, iconColWidth(model.Config{
+		SessionConfigs: []model.SessionConfig{{Name: "notes", Icon: "📓"}},
+	}), "a double-width emoji widens the column")
+
+	assert.Equal(t, 2, iconColWidth(model.Config{
+		WildcardConfigs: []model.WildcardConfig{{Pattern: "~/c/*", Icon: "🏠"}},
+	}), "an emoji on a wildcard widens the column too")
+}

--- a/picker/picker.go
+++ b/picker/picker.go
@@ -8,6 +8,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/joshmedeski/sesh/v2/home"
 	"github.com/joshmedeski/sesh/v2/model"
 	"github.com/joshmedeski/sesh/v2/previewer"
 )
@@ -35,10 +36,16 @@ type Picker interface {
 type RealPicker struct {
 	config    model.Config
 	previewer previewer.Previewer
+	// home expands the paths on [[session]] blocks so a configured icon can be
+	// matched against the absolute path a session is listed with.
+	home home.Home
+	// wildcards matches a session path to a [[wildcard]] block, for icons
+	// declared on a pattern rather than a single session.
+	wildcards WildcardFinder
 }
 
-func NewPicker(config model.Config, previewer previewer.Previewer) Picker {
-	return &RealPicker{config: config, previewer: previewer}
+func NewPicker(config model.Config, previewer previewer.Previewer, home home.Home, wildcards WildcardFinder) Picker {
+	return &RealPicker{config: config, previewer: previewer, home: home, wildcards: wildcards}
 }
 
 // buildAliases collects the aliases defined on [[session]] blocks, keyed by
@@ -181,6 +188,8 @@ func (p *RealPicker) Pick(fetchFunc FetchFunc, opts PickerOptions) (string, erro
 		AliasFilterPrefix:       aliasFilterPrefix(p.config.TUI.AliasFilterPrefix),
 		AliasAutoConnectDelay:   aliasAutoConnectDelay(p.config.TUI.AliasAutoConnectDelay),
 		DisableAliasAutoConnect: disableAliasAutoConnect,
+		Icon:                    buildIconResolver(p.config, p.home, p.wildcards),
+		IconWidth:               iconColWidth(p.config),
 		Preview:                 preview,
 		PreviewWidth:            previewWidth(p.config.TUI.PreviewWidth),
 		PreviewMinWidth:         previewMinWidth(p.config.TUI.PreviewMinWidth),

--- a/picker/picker_test.go
+++ b/picker/picker_test.go
@@ -650,6 +650,130 @@ func newTestModelWithWindows() Model {
 	return m
 }
 
+// newIconModel returns a loaded model with icons on and the given custom icons
+// keyed by session name, sized as if the widest of them set the column.
+func newIconModel(icons map[string]string) Model {
+	sessions := testSessions()
+	width := 1
+	for _, icn := range icons {
+		width = max(width, iconWidth(icn))
+	}
+	m := New(testFetchFunc(sessions), testOptionsWith(func(o *Options) {
+		o.ShowIcons = true
+		o.IconWidth = width
+		o.Icon = func(s model.SeshSession) string { return icons[s.Name] }
+	}))
+	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
+	m = result.(Model)
+	m.width = 60
+	m.height = 24
+	return m
+}
+
+// iconRow returns the rendered row for a session, ANSI stripped.
+func iconRow(t *testing.T, m Model, name string) string {
+	t.Helper()
+	for _, line := range strings.Split(ansi.Strip(fmt.Sprintf("%v", m.View())), "\n") {
+		if strings.Contains(line, name) {
+			return line
+		}
+	}
+	t.Fatalf("expected a row for the %s session", name)
+	return ""
+}
+
+func TestView_CustomIcon(t *testing.T) {
+	m := newIconModel(map[string]string{"notes": "📓"})
+
+	assert.Contains(t, iconRow(t, m, "notes"), "📓 notes",
+		"a configured icon replaces the source glyph")
+	assert.NotContains(t, iconRow(t, m, "dotfiles"), "📓",
+		"a session with no icon configured keeps its source glyph")
+}
+
+func TestView_CustomIcon_NamesStayAligned(t *testing.T) {
+	m := newIconModel(map[string]string{"notes": "📓"})
+
+	// Every name has to start in the same column, whether its row carries a
+	// double-width emoji or a single-width source glyph.
+	custom := iconRow(t, m, "notes")
+	glyph := iconRow(t, m, "dotfiles")
+	assert.Equal(t,
+		lipgloss.Width(custom)-lipgloss.Width("notes"),
+		lipgloss.Width(glyph)-lipgloss.Width("dotfiles"),
+		"a wide icon must not push its name past the other rows")
+}
+
+func TestView_CustomIcon_SingleWidthLeavesLayoutUnchanged(t *testing.T) {
+	plain := newIconModel(nil)
+	custom := newIconModel(map[string]string{"notes": nerdGlyph})
+
+	assert.Equal(t,
+		lipgloss.Width(iconRow(t, plain, "dotfiles")),
+		lipgloss.Width(iconRow(t, custom, "dotfiles")),
+		"a single-width icon must not widen the column for anyone")
+}
+
+func TestView_CustomIcon_TrailingSpaceWidensOneIconOnly(t *testing.T) {
+	// A terminal that draws an emoji narrower than it measures leaves that row
+	// short; a trailing space in the config makes it up without moving the rest.
+	m := newIconModel(map[string]string{"notes": "📓", "dotfiles": "⬆️ "})
+
+	assert.Equal(t, 2, m.iconWidth,
+		"the padded icon must not widen the column for every row")
+	assert.Equal(t,
+		lipgloss.Width(m.iconCell(sessionItem{src: "tmux", icon: "📓"}))+1,
+		lipgloss.Width(m.iconCell(sessionItem{src: "tmux", icon: "⬆️ "})),
+		"the trailing space is added to the cell but not counted towards it")
+	assert.Equal(t,
+		lipgloss.Width(m.iconCell(sessionItem{src: "tmux", icon: "📓"})),
+		lipgloss.Width(m.iconCell(sessionItem{src: "tmux"})),
+		"rows without a custom icon are unaffected")
+}
+
+func TestView_CustomIcon_SuppressedWithoutIcons(t *testing.T) {
+	sessions := testSessions()
+	m := New(testFetchFunc(sessions), testOptionsWith(func(o *Options) {
+		o.IconWidth = 2
+		o.Icon = func(s model.SeshSession) string { return "📓" }
+	}))
+	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
+	m = result.(Model)
+	m.width = 60
+	m.height = 24
+
+	assert.NotContains(t, fmt.Sprintf("%v", m.View()), "📓",
+		"the icon column is an icons-on feature, custom icons included")
+}
+
+func TestView_CustomIcon_RowsFitContentWidth(t *testing.T) {
+	dir := model.SeshSessionMap{
+		"s1": {Name: "sesh", Src: "tmux", WindowNames: []string{
+			"editor", "server", "logs", "database", "tests", "docs", "shell",
+		}},
+	}
+	sessions := model.SeshSessions{OrderedIndex: []string{"s1"}, Directory: dir}
+	m := New(testFetchFunc(sessions), testOptionsWith(func(o *Options) {
+		o.ShowIcons = true
+		o.ShowWindows = true
+		o.IconWidth = 2
+		o.Icon = func(s model.SeshSession) string { return "📓" }
+	}))
+	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
+	m = result.(Model)
+	m.width = 60
+	m.height = 24
+
+	for _, line := range strings.Split(fmt.Sprintf("%v", m.View()), "\n") {
+		if strings.Contains(line, "sesh") {
+			assert.LessOrEqual(t, lipgloss.Width(line), m.contentWidth(),
+				"a wide icon must be counted against the row's width budget")
+			return
+		}
+	}
+	t.Fatal("expected a row for the sesh session")
+}
+
 func TestView_ShowWindows(t *testing.T) {
 	m := newTestModelWithWindows()
 	out := fmt.Sprintf("%v", m.View())
@@ -732,7 +856,7 @@ func TestApplyFilter_DoesNotMatchWindowNames(t *testing.T) {
 }
 
 func TestSessionItems_StringIgnoresWindowNames(t *testing.T) {
-	items := buildItems(sessionsWithWindows(), false)
+	items := buildItems(sessionsWithWindows(), false, nil)
 	for i := range items {
 		assert.Equal(t, items[i].name, items.String(i),
 			"fuzzy source must expose the session name only")

--- a/picker/tui.go
+++ b/picker/tui.go
@@ -21,6 +21,7 @@ type sessionItem struct {
 	name       string // raw session name (no icons/ANSI)
 	searchName string // normalized name used for fuzzy matching
 	src        string // source type (tmux, config, zoxide, tmuxinator)
+	icon       string // custom icon from config, "" to use the source glyph
 }
 
 // sessionItems implements fuzzy.Source for fuzzy matching.
@@ -39,6 +40,10 @@ type filteredItem struct {
 
 // FetchFunc loads sessions asynchronously. It is called in a goroutine by Init().
 type FetchFunc func() (model.SeshSessions, error)
+
+// IconFunc resolves the icon configured for a session, returning "" when none
+// is and the source glyph should be used instead.
+type IconFunc func(session model.SeshSession) string
 
 // PreviewFunc renders the preview of a single session. It is called from a
 // tea.Cmd, never from Update or View: some strategies shell out, and blocking
@@ -110,6 +115,12 @@ type Options struct {
 	AliasAutoConnectDelay time.Duration
 	// DisableAliasAutoConnect suppresses auto-connect for this invocation.
 	DisableAliasAutoConnect bool
+	// Icon resolves the icon configured for a session. Nil means no session
+	// declares one, so every row keeps its source glyph.
+	Icon IconFunc
+	// IconWidth is the display width the icon column is padded to. Anything
+	// below 1 means the single cell the source glyphs need.
+	IconWidth int
 	// Preview starts the picker with the preview pane showing. It can still be
 	// toggled at runtime, and is ignored on a terminal narrower than
 	// PreviewMinWidth.
@@ -145,6 +156,11 @@ type Model struct {
 	fetchFunc      FetchFunc
 	loadErr        error
 
+	// iconFunc resolves a session's configured icon, and iconWidth is the width
+	// the icon column is padded to so wide icons keep the names aligned.
+	iconFunc  IconFunc
+	iconWidth int
+
 	// aliases is keyed by lowercased alias; aliasByName is keyed by session
 	// name so rows can be tagged while rendering.
 	aliases                 map[string]Alias
@@ -175,7 +191,9 @@ type Model struct {
 	previewSeq int
 }
 
-// srcIcon returns the nerd font icon and color for a session source.
+// srcIcon returns the nerd font icon and color for a session source. The icon
+// carries a trailing space, so it is the whole icon cell for the single-width
+// glyphs it comes from; iconCell pads it when a wider icon is in play.
 func srcIcon(src string) (string, color.Color) {
 	if g, ok := icon.Glyphs[src]; ok {
 		var ansi int
@@ -190,6 +208,42 @@ func srcIcon(src string) (string, color.Color) {
 		return g.Icon + " ", lipgloss.ANSIColor(ansi)
 	}
 	return "? ", lipgloss.ANSIColor(8)
+}
+
+// iconCell renders the icon column for a row: the icon configured for the
+// session, or the colored source glyph when it has none, followed by the gap
+// before the name. Every cell is padded to the same width so a double-width
+// emoji on one row can't push that row's name past the others.
+//
+// A configured icon is left unstyled — emoji carry their own color, and a nerd
+// font glyph inherits the default foreground.
+//
+// Trailing spaces in a configured icon are the user's own width override: they
+// are added to the cell but not counted towards it. Terminals disagree about how
+// wide an emoji is — an emoji written with a variation selector (⬆️ is U+2B06
+// plus U+FE0F) measures two cells here but is drawn in one by WezTerm and
+// others — and nothing in a TUI can ask the terminal which it did. A trailing
+// space makes up the difference for that one icon without shifting any other
+// row.
+func (m Model) iconCell(item sessionItem) string {
+	if item.icon == "" {
+		glyph, clr := srcIcon(item.src)
+		return padIcon(lipgloss.NewStyle().Foreground(clr).Render(glyph), m.iconWidth+1)
+	}
+	override := strings.TrimRight(item.icon, " ")
+	return item.icon + " " + padding(m.iconWidth+1-lipgloss.Width(override+" "))
+}
+
+// padIcon right-pads an icon cell to width.
+func padIcon(cell string, width int) string {
+	return cell + padding(width-lipgloss.Width(cell))
+}
+
+func padding(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	return strings.Repeat(" ", n)
 }
 
 // Powerline half circles used to round off the alias chip. They are nerd font
@@ -255,7 +309,7 @@ func normalizeSeparators(s string) string {
 	return separatorReplacer.Replace(s)
 }
 
-func buildItems(sessions model.SeshSessions, separatorAware bool) sessionItems {
+func buildItems(sessions model.SeshSessions, separatorAware bool, resolveIcon IconFunc) sessionItems {
 	items := make(sessionItems, 0, len(sessions.OrderedIndex))
 	for _, key := range sessions.OrderedIndex {
 		s := sessions.Directory[key]
@@ -263,11 +317,16 @@ func buildItems(sessions model.SeshSessions, separatorAware bool) sessionItems {
 		if separatorAware {
 			searchName = normalizeSeparators(s.Name)
 		}
+		var icn string
+		if resolveIcon != nil {
+			icn = resolveIcon(s)
+		}
 		items = append(items, sessionItem{
 			session:    s,
 			name:       s.Name,
 			searchName: searchName,
 			src:        s.Src,
+			icon:       icn,
 		})
 	}
 	return items
@@ -291,6 +350,8 @@ func New(fetchFunc FetchFunc, opts Options) Model {
 		showIcons:               opts.ShowIcons,
 		showWindows:             opts.ShowWindows,
 		separatorAware:          opts.SeparatorAware,
+		iconFunc:                opts.Icon,
+		iconWidth:               max(opts.IconWidth, 1),
 		loading:                 true,
 		fetchFunc:               fetchFunc,
 		aliases:                 opts.Aliases,
@@ -410,7 +471,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 		m.loading = false
-		m.allItems = buildItems(msg.sessions, m.separatorAware)
+		m.allItems = buildItems(msg.sessions, m.separatorAware, m.iconFunc)
 		m.applyFilter()
 		return m, m.schedulePreview()
 
@@ -573,7 +634,17 @@ func (m *Model) aliasMatch(raw string) (sessionItem, bool) {
 			return item, true
 		}
 	}
-	return sessionItem{name: alias.Target, searchName: alias.Target, src: "config"}, true
+	return m.configItem(alias.Target), true
+}
+
+// configItem builds the row for a [[session]] that isn't in the loaded list.
+// Only its name is known, so the icon is resolved from the name alone.
+func (m *Model) configItem(name string) sessionItem {
+	item := sessionItem{name: name, searchName: name, src: "config"}
+	if m.iconFunc != nil {
+		item.icon = m.iconFunc(model.SeshSession{Src: "config", Name: name})
+	}
+	return item
 }
 
 // aliasFilterQuery reports whether the raw input opens alias-filter mode and,
@@ -612,8 +683,7 @@ func (m *Model) aliasCandidates() []sessionItem {
 	}
 	sort.Strings(missing)
 	for _, key := range missing {
-		target := m.aliases[key].Target
-		candidates = append(candidates, sessionItem{name: target, searchName: target, src: "config"})
+		candidates = append(candidates, m.configItem(m.aliases[key].Target))
 	}
 
 	return candidates
@@ -929,9 +999,7 @@ func (m Model) View() tea.View {
 
 			var tag string
 			if m.showIcons {
-				icn, clr := srcIcon(item.item.src)
-				iconStyle := lipgloss.NewStyle().Foreground(clr)
-				tag = iconStyle.Render(icn)
+				tag = m.iconCell(item.item)
 			}
 			chip := m.aliasChip(item.item.name, item.chipMatchLen)
 			name := highlightMatches(item.item.name, item.matchedIndexes, matchStyle, normalStyle)

--- a/sesh.schema.json
+++ b/sesh.schema.json
@@ -201,6 +201,10 @@
             "description": "Connect to this session as soon as its alias is fully typed in the picker, without pressing enter. Requires `alias`.",
             "default": false
           },
+          "icon": {
+            "type": "string",
+            "description": "Icon shown for this session in the picker instead of its source glyph. Any string: a nerd font glyph or an emoji. Picker-only; `sesh list` keeps the source glyph."
+          },
           "startup_command": {
             "type": "string",
             "description": "Shell command to run when this session is created (overrides default)"
@@ -279,6 +283,10 @@
             "items": {
               "type": "string"
             }
+          },
+          "icon": {
+            "type": "string",
+            "description": "Icon shown for matching sessions in the picker instead of their source glyph. Any string: a nerd font glyph or an emoji. Picker-only; `sesh list` keeps the source glyph."
           }
         },
         "additionalProperties": false

--- a/seshcli/deps.go
+++ b/seshcli/deps.go
@@ -135,7 +135,7 @@ func (b *BaseDeps) BuildAll(configPath string) (*Deps, error) {
 	ic := icon.NewIcon(config)
 	p := previewer.NewPreviewer(usedLister, t, ic, b.Dir, b.Home, l, config, b.Shell)
 	cl := cloner.NewCloner(c, b.Git)
-	pk := picker.NewPicker(config, p)
+	pk := picker.NewPicker(config, p, b.Home, usedLister)
 	mk := mkdirer.NewMkdirer(b.Os, b.Home, c)
 
 	return &Deps{


### PR DESCRIPTION
Closes #428

Every picker row gets one of five glyphs derived from where the session came from. That says where it was found, not what it *is*, so a curated `[[session]]` or `[[wildcard]]` block can now declare an `icon` of its own — any string, a nerd font glyph or an emoji.

```toml
[[session]]
name = "notes"
path = "~/second-brain"
icon = "📓"

[[wildcard]]
pattern = "~/c/work/*"
icon = "🏠"
```

<img width="5104" height="2862" alt="SCR-20260726-qznu" src="https://github.com/user-attachments/assets/1c1037e9-d6e6-4505-b3aa-90d4b0fa8693" />

## Behavior

- **Resolution order**: exact `[[session]]` name, then its `path` — so the same directory listed by zoxide under a derived name still gets the icon — then a `[[wildcard]]` pattern. Wildcards are matched through the lister's own `FindConfigWildcard`, so they resolve exactly as they do for `startup_command`: first match in config order wins, even when that match declares no icon.
- `icon = ""` is unset, and the whole column stays gated on `show_icons`.
- Custom icons render unstyled — emoji carry their own color, nerd font glyphs take the default foreground.
- The resolver is `nil` when nothing configures an icon, so the common case costs no per-row lookup.

**Picker-only.** `sesh list` consumers trim a known-width glyph, so variable-width icons there are left to #246.

## Width handling

The icon column is padded to one width derived from the config rather than the visible rows, so scrolling past an emoji can't shift the names, and a wide icon is counted against the window-name and preview budgets via `lipgloss.Width`.

## Notes

- The `[[worktree]]` table from #409 isn't in yet, so worktree icons are left for when it lands; the resolver takes a one-line addition then.
- `icon.RemoveIcon` / `AddIcon` are untouched.

## Test plan

- `just test` passes across all packages.
- New coverage: resolution precedence, path and trailing-slash matching, wildcard order, empty-icon fallback, column width, render with a custom icon, alignment between wide and narrow rows, `show_icons = false`, and row width budget with a wide icon. TOML parsing for both new fields.
