### PR TITLE
Adding opt-in watch mode for live previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,14 @@ bind-key "T" run-shell "sesh connect \"$(
 
 You can customize this however you want, see `man fzf` for more info on the different options.
 
+To continuously refresh previews of active tmux sessions, add `--watch` to the preview command:
+
+```sh
+--preview 'sesh preview --watch {}'
+```
+
+Watch mode polls only active tmux sessions; directory and configured-session previews still render once. The default interval is 500 milliseconds and can be changed with `--interval 100ms`.
+
 #### tmux + [television](https://github.com/alexpasmantier/television)
 
 If you prefer to use television instead of fzf, you can add a binding to your tmux config that opens the [sesh channel](https://alexpasmantier.github.io/television/community/channels-unix/#sesh) in a tmux popup.

--- a/seshcli/preview.go
+++ b/seshcli/preview.go
@@ -32,10 +32,12 @@ func watchPreview(ctx context.Context, w io.Writer, preview previewFunc, name st
 			return err
 		}
 
-		// Redraw only when the capture changed: fzf clears and repaints
-		// the preview window on every write, so rewriting an identical
-		// frame makes an idle session churn twice a second for nothing.
-		if output != last {
+		// Redraw only when there is new content to show. Rewriting an
+		// identical frame makes fzf clear and repaint a preview that did
+		// not change, and an empty capture (the session went away
+		// mid-watch with nothing else matching the name) would blank the
+		// preview instead of keeping the last frame on screen.
+		if output != "" && output != last {
 			frame := output
 			if last != "" {
 				frame = previewClearScreen + frame

--- a/seshcli/preview.go
+++ b/seshcli/preview.go
@@ -14,14 +14,10 @@ const previewClearScreen = "\033[2J\033[H"
 
 type previewFunc func(string) (string, error)
 
-func writePreview(w io.Writer, preview previewFunc, name string, clear bool) error {
+func writePreview(w io.Writer, preview previewFunc, name string) error {
 	output, err := preview(name)
 	if err != nil {
 		return err
-	}
-
-	if clear {
-		output = previewClearScreen + output
 	}
 
 	_, err = fmt.Fprint(w, output)
@@ -29,12 +25,26 @@ func writePreview(w io.Writer, preview previewFunc, name string, clear bool) err
 }
 
 func watchPreview(ctx context.Context, w io.Writer, preview previewFunc, name string, ticks <-chan time.Time) error {
-	clear := false
+	last := ""
 	for {
-		if err := writePreview(w, preview, name, clear); err != nil {
+		output, err := preview(name)
+		if err != nil {
 			return err
 		}
-		clear = true
+
+		// Redraw only when the capture changed: fzf clears and repaints
+		// the preview window on every write, so rewriting an identical
+		// frame makes an idle session churn twice a second for nothing.
+		if output != last {
+			frame := output
+			if last != "" {
+				frame = previewClearScreen + frame
+			}
+			if _, err := fmt.Fprint(w, frame); err != nil {
+				return err
+			}
+			last = output
+		}
 
 		select {
 		case <-ctx.Done():
@@ -68,7 +78,7 @@ func NewPreviewCommand(base *BaseDeps) *cobra.Command {
 			interval, _ := cmd.Flags().GetDuration("interval")
 
 			if !watch {
-				return writePreview(cmd.OutOrStdout(), deps.Previewer.Preview, name, false)
+				return writePreview(cmd.OutOrStdout(), deps.Previewer.Preview, name)
 			}
 			if interval <= 0 {
 				return errors.New("preview interval must be greater than zero")
@@ -76,7 +86,7 @@ func NewPreviewCommand(base *BaseDeps) *cobra.Command {
 
 			_, sessionExists := deps.Lister.FindTmuxSession(deps.Icon.RemoveIcon(name))
 			if !sessionExists {
-				return writePreview(cmd.OutOrStdout(), deps.Previewer.Preview, name, false)
+				return writePreview(cmd.OutOrStdout(), deps.Previewer.Preview, name)
 			}
 
 			ticker := time.NewTicker(interval)

--- a/seshcli/preview.go
+++ b/seshcli/preview.go
@@ -1,14 +1,54 @@
 package seshcli
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
+	"time"
 
 	"github.com/spf13/cobra"
 )
 
+const previewClearScreen = "\033[2J\033[H"
+
+type previewFunc func(string) (string, error)
+
+func writePreview(w io.Writer, preview previewFunc, name string, clear bool) error {
+	output, err := preview(name)
+	if err != nil {
+		return err
+	}
+
+	if clear {
+		output = previewClearScreen + output
+	}
+
+	_, err = fmt.Fprint(w, output)
+	return err
+}
+
+func watchPreview(ctx context.Context, w io.Writer, preview previewFunc, name string, ticks <-chan time.Time) error {
+	clear := false
+	for {
+		if err := writePreview(w, preview, name, clear); err != nil {
+			return err
+		}
+		clear = true
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case _, ok := <-ticks:
+			if !ok {
+				return nil
+			}
+		}
+	}
+}
+
 func NewPreviewCommand(base *BaseDeps) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "preview",
 		Aliases: []string{"p"},
 		Short:   "Preview a session or directory",
@@ -24,15 +64,30 @@ func NewPreviewCommand(base *BaseDeps) *cobra.Command {
 			}
 
 			name := args[0]
+			watch, _ := cmd.Flags().GetBool("watch")
+			interval, _ := cmd.Flags().GetDuration("interval")
 
-			output, err := deps.Previewer.Preview(name)
-			if err != nil {
-				return err
+			if !watch {
+				return writePreview(cmd.OutOrStdout(), deps.Previewer.Preview, name, false)
+			}
+			if interval <= 0 {
+				return errors.New("preview interval must be greater than zero")
 			}
 
-			fmt.Print(output)
+			_, sessionExists := deps.Lister.FindTmuxSession(deps.Icon.RemoveIcon(name))
+			if !sessionExists {
+				return writePreview(cmd.OutOrStdout(), deps.Previewer.Preview, name, false)
+			}
 
-			return nil
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+
+			return watchPreview(cmd.Context(), cmd.OutOrStdout(), deps.Previewer.Preview, name, ticker.C)
 		},
 	}
+
+	cmd.Flags().BoolP("watch", "w", false, "continuously refresh the preview")
+	cmd.Flags().Duration("interval", 500*time.Millisecond, "refresh interval when watching")
+
+	return cmd
 }

--- a/seshcli/preview_test.go
+++ b/seshcli/preview_test.go
@@ -1,0 +1,69 @@
+package seshcli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWritePreview(t *testing.T) {
+	var output bytes.Buffer
+
+	err := writePreview(&output, func(name string) (string, error) {
+		assert.Equal(t, "work", name)
+		return "first frame", nil
+	}, "work", false)
+
+	require.NoError(t, err)
+	assert.Equal(t, "first frame", output.String())
+}
+
+func TestWritePreviewReturnsPreviewError(t *testing.T) {
+	expected := errors.New("capture failed")
+
+	err := writePreview(&bytes.Buffer{}, func(string) (string, error) {
+		return "", expected
+	}, "work", false)
+
+	assert.ErrorIs(t, err, expected)
+}
+
+func TestWatchPreviewRefreshesAndClearsPreviousFrame(t *testing.T) {
+	var output bytes.Buffer
+	frames := []string{"first frame", "second frame"}
+	calls := 0
+	ticks := make(chan time.Time, 1)
+	ticks <- time.Time{}
+	close(ticks)
+
+	err := watchPreview(context.Background(), &output, func(string) (string, error) {
+		frame := frames[calls]
+		calls++
+		return frame, nil
+	}, "work", ticks)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls)
+	assert.Equal(t, "first frame"+previewClearScreen+"second frame", output.String())
+}
+
+func TestWatchPreviewStopsWhenContextIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var output bytes.Buffer
+	calls := 0
+
+	err := watchPreview(ctx, &output, func(string) (string, error) {
+		calls++
+		return "frame", nil
+	}, "work", make(chan time.Time))
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, "frame", output.String())
+}

--- a/seshcli/preview_test.go
+++ b/seshcli/preview_test.go
@@ -72,6 +72,26 @@ func TestWatchPreviewSkipsUnchangedFrames(t *testing.T) {
 	assert.Equal(t, "same frame"+previewClearScreen+"new frame", output.String())
 }
 
+func TestWatchPreviewKeepsLastFrameWhenSessionDisappears(t *testing.T) {
+	var output bytes.Buffer
+	frames := []string{"last frame", "", ""}
+	calls := 0
+	ticks := make(chan time.Time, 2)
+	ticks <- time.Time{}
+	ticks <- time.Time{}
+	close(ticks)
+
+	err := watchPreview(context.Background(), &output, func(string) (string, error) {
+		frame := frames[calls]
+		calls++
+		return frame, nil
+	}, "work", ticks)
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, calls)
+	assert.Equal(t, "last frame", output.String())
+}
+
 func TestWatchPreviewStopsWhenContextIsCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/seshcli/preview_test.go
+++ b/seshcli/preview_test.go
@@ -17,7 +17,7 @@ func TestWritePreview(t *testing.T) {
 	err := writePreview(&output, func(name string) (string, error) {
 		assert.Equal(t, "work", name)
 		return "first frame", nil
-	}, "work", false)
+	}, "work")
 
 	require.NoError(t, err)
 	assert.Equal(t, "first frame", output.String())
@@ -28,7 +28,7 @@ func TestWritePreviewReturnsPreviewError(t *testing.T) {
 
 	err := writePreview(&bytes.Buffer{}, func(string) (string, error) {
 		return "", expected
-	}, "work", false)
+	}, "work")
 
 	assert.ErrorIs(t, err, expected)
 }
@@ -50,6 +50,26 @@ func TestWatchPreviewRefreshesAndClearsPreviousFrame(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2, calls)
 	assert.Equal(t, "first frame"+previewClearScreen+"second frame", output.String())
+}
+
+func TestWatchPreviewSkipsUnchangedFrames(t *testing.T) {
+	var output bytes.Buffer
+	frames := []string{"same frame", "same frame", "new frame"}
+	calls := 0
+	ticks := make(chan time.Time, 2)
+	ticks <- time.Time{}
+	ticks <- time.Time{}
+	close(ticks)
+
+	err := watchPreview(context.Background(), &output, func(string) (string, error) {
+		frame := frames[calls]
+		calls++
+		return frame, nil
+	}, "work", ticks)
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, calls)
+	assert.Equal(t, "same frame"+previewClearScreen+"new frame", output.String())
 }
 
 func TestWatchPreviewStopsWhenContextIsCanceled(t *testing.T) {


### PR DESCRIPTION
Closes #416

This adds an opt-in watch mode to `sesh preview`. You add `--watch` to keep refreshing active tmux previews while the picker is open.

```sh
sesh preview --watch {}
```

I defaulted polling to 500ms, but you can change it with `--interval` to whatever suits your setup:

```sh
sesh preview --watch --interval 100ms {}
```

Normal previews still work like before. It only polls active tmux sessions, so directory and configured-session previews still render once.

Polling stops when the preview command exits, so nothing keeps updating in the background after closing the picker.

Tested with:

- `just mock`
- `just test`
- `just build`
- An active tmux session to check the preview updates live
