### PR TITLE
native picker uses pane titles over window names

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,6 +708,7 @@ prompt = "> "
 placeholder = "Filter sessions... "
 show_icons = false
 show_windows = false
+window_name_format = "#{window_name}"
 alias_auto_connect_delay = "150ms"
 alias_filter_prefix = "/"
 preview = false
@@ -726,6 +727,12 @@ With `show_windows = true`, each row also lists the names of the windows inside 
 ```
 
 Window names are display-only: selecting a row still returns just the session name, and typing a window name does not match its session. The names for live tmux sessions are fetched in a single tmux call, so the option costs the same regardless of how many sessions you have.
+
+`window_name_format` accepts any tmux format. tmux interprets conditionals, fallback variables, and `#()` commands. For example, this format uses the pane title when it exists and uses the window name otherwise:
+
+```toml
+window_name_format = "#{?#{pane_title},#{pane_title},#{window_name}}"
+```
 
 `alias_auto_connect_delay` and `alias_filter_prefix` tune aliases — see [Session Aliases](#session-aliases).
 

--- a/lister/bench_test.go
+++ b/lister/bench_test.go
@@ -45,7 +45,7 @@ func (t *benchTmux) ListSessions() ([]*model.TmuxSession, error) {
 	return t.sessions, nil
 }
 
-func (t *benchTmux) ListAllWindowNames() (map[string][]string, error) {
+func (t *benchTmux) ListAllWindowNames(string) (map[string][]string, error) {
 	return t.windowNames, nil
 }
 

--- a/lister/list_test.go
+++ b/lister/list_test.go
@@ -304,7 +304,7 @@ func TestList_ShowWindows(t *testing.T) {
 		mockTmux.On("ListSessions").Return([]*model.TmuxSession{
 			{Name: "sesh", Path: "/p"},
 		}, nil)
-		mockTmux.EXPECT().ListAllWindowNames().Return(map[string][]string{
+		mockTmux.EXPECT().ListAllWindowNames("").Return(map[string][]string{
 			"sesh": {"editor", "server"},
 		}, nil).Once()
 

--- a/lister/tmux.go
+++ b/lister/tmux.go
@@ -42,7 +42,7 @@ func listTmux(l *RealLister) (model.SeshSessions, error) {
 // single tmux call. Failures are non-fatal: the picker simply renders sessions
 // without their window names.
 func tmuxWindowNames(l *RealLister) map[string][]string {
-	windowNames, err := l.tmux.ListAllWindowNames()
+	windowNames, err := l.tmux.ListAllWindowNames(l.config.TUI.WindowNameFormat)
 	if err != nil {
 		return nil
 	}

--- a/lister/tmux_test.go
+++ b/lister/tmux_test.go
@@ -235,15 +235,19 @@ func TestAttachWindowNames(t *testing.T) {
 func TestTmuxWindowNames(t *testing.T) {
 	t.Run("returns nil when tmux fails", func(t *testing.T) {
 		mockTmux := new(tmux.MockTmux)
-		mockTmux.EXPECT().ListAllWindowNames().Return(nil, assert.AnError)
+		mockTmux.EXPECT().ListAllWindowNames("").Return(nil, assert.AnError)
 		l := &RealLister{tmux: mockTmux}
 		assert.Nil(t, tmuxWindowNames(l))
 	})
 
 	t.Run("returns the window names", func(t *testing.T) {
 		mockTmux := new(tmux.MockTmux)
-		mockTmux.EXPECT().ListAllWindowNames().Return(map[string][]string{"sesh": {"editor"}}, nil)
-		l := &RealLister{tmux: mockTmux}
+		format := "#{?#{pane_title},#{pane_title},#{window_name}}"
+		mockTmux.EXPECT().ListAllWindowNames(format).Return(map[string][]string{"sesh": {"editor"}}, nil)
+		l := &RealLister{
+			config: model.Config{TUI: model.TUIConfig{WindowNameFormat: format}},
+			tmux:   mockTmux,
+		}
 		assert.Equal(t, map[string][]string{"sesh": {"editor"}}, tmuxWindowNames(l))
 	})
 }

--- a/model/config.go
+++ b/model/config.go
@@ -8,6 +8,10 @@ const DefaultAliasAutoConnectDelay = "150ms"
 // [tui] alias_filter_prefix is not set.
 const DefaultAliasFilterPrefix = "/"
 
+// DefaultWindowNameFormat is the tmux format used for window names when
+// [tui] window_name_format is not set.
+const DefaultWindowNameFormat = "#{window_name}"
+
 const (
 	// DefaultPreviewWidth is the share of the terminal, in percent, guaranteed
 	// to the picker's preview pane when [tui] preview_width is not set.
@@ -114,10 +118,13 @@ type (
 
 	TUIConfig struct {
 		// TODO: keybindings and more
-		ShowIcons   bool   `toml:"show_icons"`
-		ShowWindows bool   `toml:"show_windows"`
-		Prompt      string `toml:"prompt"`
-		Placeholder string `toml:"placeholder"`
+		ShowIcons   bool `toml:"show_icons"`
+		ShowWindows bool `toml:"show_windows"`
+		// WindowNameFormat is the tmux format rendered for each window when
+		// ShowWindows is enabled. Empty means DefaultWindowNameFormat.
+		WindowNameFormat string `toml:"window_name_format"`
+		Prompt           string `toml:"prompt"`
+		Placeholder      string `toml:"placeholder"`
 		// AliasAutoConnectDelay is the grace period between typing an alias and
 		// auto-connecting to it, giving longer aliases that share a prefix time
 		// to be typed. Any duration string time.ParseDuration accepts.

--- a/sesh.schema.json
+++ b/sesh.schema.json
@@ -116,6 +116,11 @@
           "type": "boolean",
           "description": "Show the window names of each session in the picker TUI (display only, never part of the selected value)"
         },
+        "window_name_format": {
+          "type": "string",
+          "description": "tmux format rendered for each window when show_windows is enabled. tmux interprets the value, including conditionals and #() commands.",
+          "default": "#{window_name}"
+        },
         "prompt": {
           "type": "string",
           "description": "The prompt shown in the picker TUI"

--- a/tmux/list_tmux_win.go
+++ b/tmux/list_tmux_win.go
@@ -32,19 +32,21 @@ func (t *RealTmux) ListWindows(targetSession string) ([]*model.TmuxWindow, error
 	return parseTmuxWindowsOutput(output)
 }
 
-func listAllWindowNamesFormat() string {
+func listAllWindowNamesFormat(format string) string {
+	if format == "" {
+		format = model.DefaultWindowNameFormat
+	}
 	variables := []string{
 		"#{session_name}",
-		"#{pane_title}",
+		format,
 	}
 	return strings.Join(variables, separator)
 }
 
-// ListAllWindowNames returns the window names of every session, keyed by
-// session name, in a single tmux invocation. The picker uses this so showing
-// window names doesn't cost one shell call per session.
-func (t *RealTmux) ListAllWindowNames() (map[string][]string, error) {
-	output, err := t.shell.ListCmd(t.bin, "list-windows", "-a", "-F", listAllWindowNamesFormat())
+// ListAllWindowNames returns the formatted window names of every session,
+// keyed by session name, in a single tmux invocation.
+func (t *RealTmux) ListAllWindowNames(format string) (map[string][]string, error) {
+	output, err := t.shell.ListCmd(t.bin, "list-windows", "-a", "-F", listAllWindowNamesFormat(format))
 	if err != nil {
 		return nil, err
 	}

--- a/tmux/list_tmux_win.go
+++ b/tmux/list_tmux_win.go
@@ -35,7 +35,7 @@ func (t *RealTmux) ListWindows(targetSession string) ([]*model.TmuxWindow, error
 func listAllWindowNamesFormat() string {
 	variables := []string{
 		"#{session_name}",
-		"#{window_name}",
+		"#{pane_title}",
 	}
 	return strings.Join(variables, separator)
 }

--- a/tmux/list_tmux_win_test.go
+++ b/tmux/list_tmux_win_test.go
@@ -57,11 +57,11 @@ func TestListAllWindowNames(t *testing.T) {
 	t.Run("groups window names by session", func(t *testing.T) {
 		mockShell := &shell.MockShell{}
 		tmux := &RealTmux{shell: mockShell, bin: "tmux"}
-		mockShell.EXPECT().ListCmd("tmux", "list-windows", "-a", "-F", mock.Anything).Return(
+		mockShell.EXPECT().ListCmd("tmux", "list-windows", "-a", "-F", "#{session_name}::#{window_name}").Return(
 			[]string{"sesh::editor", "sesh::server", "dotfiles::nvim"},
 			nil,
 		)
-		windowNames, err := tmux.ListAllWindowNames()
+		windowNames, err := tmux.ListAllWindowNames("")
 		assert.Nil(t, err)
 		assert.Equal(t, map[string][]string{
 			"sesh":     {"editor", "server"},
@@ -72,10 +72,11 @@ func TestListAllWindowNames(t *testing.T) {
 	t.Run("returns error from shell", func(t *testing.T) {
 		mockShell := &shell.MockShell{}
 		tmux := &RealTmux{shell: mockShell, bin: "tmux"}
-		mockShell.EXPECT().ListCmd("tmux", "list-windows", "-a", "-F", mock.Anything).Return(
+		format := "#{?#{pane_title},#{pane_title},#{window_name}}"
+		mockShell.EXPECT().ListCmd("tmux", "list-windows", "-a", "-F", "#{session_name}::"+format).Return(
 			nil, assert.AnError,
 		)
-		windowNames, err := tmux.ListAllWindowNames()
+		windowNames, err := tmux.ListAllWindowNames(format)
 		assert.Error(t, err)
 		assert.Nil(t, windowNames)
 	})

--- a/tmux/tmux.go
+++ b/tmux/tmux.go
@@ -9,7 +9,7 @@ import (
 type Tmux interface {
 	ListSessions() ([]*model.TmuxSession, error)
 	ListWindows(targetSession string) ([]*model.TmuxWindow, error)
-	ListAllWindowNames() (map[string][]string, error)
+	ListAllWindowNames(format string) (map[string][]string, error)
 	NewSession(sessionName string, startDir string) (string, error)
 	NewWindowInSession(name string, startDir string, targetSession string) (string, error)
 	IsAttached() bool


### PR DESCRIPTION
## Purpose

Let users configure the tmux format shown for live session windows in the native picker.

## Context

The native picker previously used a fixed tmux field for each window. A fixed `#{window_name}` can show a shell or wrapper process instead of useful application context. A fixed `#{pane_title}` can also be unsuitable for users who want the standard window name.

This change adds `[tui] window_name_format`. The default is `#{window_name}`, which preserves the standard behavior. Users can set any tmux format string, including conditionals, fallback variables, and `#()` commands.

For example:

```toml
[tui]
show_windows = true
window_name_format = "#{?#{pane_title},#{pane_title},#{window_name}}"
```

The format is passed directly to `tmux list-windows`. The config schema and README include the new field.

## Verification

- `go test ./...`
- `go test ./tmux ./lister`
- Validated `sesh.schema.json` with `python3 -m json.tool`
- Ran `git diff --check`