### PR TITLE
Fix broken star history chart links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1213,4 +1213,4 @@ Made with [contrib.rocks](https://contrib.rocks).
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=joshmedeski/sesh&type=Date)](https://www.star-history.com/#joshmedeski/sesh&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=joshmedeski/sesh&type=Date)](https://star-history.dera.page/#joshmedeski/sesh&Date)

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -560,4 +560,4 @@ Sesh 是我广受欢迎的 [t-smart-tmux-session-manager](https://github.com/jos
 
 ## Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=joshmedeski/sesh&type=Date)](https://www.star-history.com/#joshmedeski/sesh&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=joshmedeski/sesh&type=Date)](https://star-history.dera.page/#joshmedeski/sesh&Date)


### PR DESCRIPTION
The star history chart in the README and the Chinese README is currently broken because the original service can no longer reliably fetch stargazer data due to GitHub API restrictions. This switches the chart image and its link to a working alternative so the star history renders again.

Both the chart image and the wrapping link now point to the new domain, keeping the existing repo and date parameters.