### PR TITLE
Add name_substitution rules for deriving session names

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,41 @@ dir_length = 2  # Uses last 2 directories: "projects/sesh" instead of just "sesh
 > [!NOTE]
 > Works great with [tmux-floax](https://github.com/omerxx/tmux-floax)
 
+### Session Name Substitution
+
+Some directories produce long, repetitive session names -- everything under
+`~/c/dotfiles/.config` shows up with that whole prefix. `name_substitution`
+rules rewrite the path a name is derived from so you can shorten or relabel it.
+
+```toml
+[[name_substitution]]
+find = "~/c/dotfiles/.config/"
+replace = ""
+```
+
+With that rule, connecting to `~/c/dotfiles/.config/nvim` creates a session
+named `nvim` instead of the full path. Rules are matched against the
+home-collapsed path (a leading `~`) for every path-derived source -- zoxide,
+directories, and wildcards. Existing tmux sessions keep their names, and if no
+rule matches, naming falls back to the usual git and directory strategies, so
+adding rules never changes how anything else is named.
+
+Rules apply in order, each one seeing the result of the previous, so they can
+compose. `find` is matched literally by default; set `regex = true` to treat it
+as a [Go regular expression](https://pkg.go.dev/regexp/syntax), which lets
+`replace` reference capture groups with `$1`, `$2`, and so on:
+
+```toml
+[[name_substitution]]
+find = ".*/workspace/[0-9]+_(.*)"
+replace = "ws-$1"
+regex = true
+```
+
+> [!NOTE]
+> tmux session names can't contain `.` or `:`, and spaces are turned into `_`,
+> so those characters in `replace` are normalized in the final name.
+
 ### Sorting
 
 If you'd like to change the order of the sessions shown, you can configure `sort_order` in your `sesh.toml` file

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -3,6 +3,7 @@ package configurator
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -170,6 +171,24 @@ func validateAliases(config *model.Config) error {
 	return nil
 }
 
+// validateNameSubstitutions rejects rules that can't be applied so the user
+// hears about a bad rule at load time instead of getting silently ignored
+// naming later. A rule needs something to look for, and a regex rule needs a
+// pattern that actually compiles.
+func validateNameSubstitutions(config *model.Config) error {
+	for i, rule := range config.NameSubstitutions {
+		if rule.Find == "" {
+			return fmt.Errorf("name_substitution rule %d has an empty find", i+1)
+		}
+		if rule.Regex {
+			if _, err := regexp.Compile(rule.Find); err != nil {
+				return fmt.Errorf("invalid name_substitution regex %q: %w", rule.Find, err)
+			}
+		}
+	}
+	return nil
+}
+
 func (c *RealConfigurator) getConfigFileFromPath(configPath string) (model.Config, error) {
 	file, err := c.os.ReadFile(configPath)
 	if err != nil {
@@ -192,6 +211,9 @@ func (c *RealConfigurator) getConfigFileFromPath(configPath string) (model.Confi
 
 	c.applyDefaults(&config)
 	if err := validateAliases(&config); err != nil {
+		return config, err
+	}
+	if err := validateNameSubstitutions(&config); err != nil {
 		return config, err
 	}
 	return config, nil
@@ -227,6 +249,9 @@ func (c *RealConfigurator) getConfigFileFromUserConfigDir() (model.Config, error
 
 	c.applyDefaults(&config)
 	if err := validateAliases(&config); err != nil {
+		return config, err
+	}
+	if err := validateNameSubstitutions(&config); err != nil {
 		return config, err
 	}
 	return config, nil

--- a/configurator/configurator_test.go
+++ b/configurator/configurator_test.go
@@ -416,3 +416,60 @@ func TestGetConfig_XDGConfigHomeNotSet(t *testing.T) {
 	assert.Len(t, config.SessionConfigs, 1)
 	assert.Equal(t, "test-session", config.SessionConfigs[0].Name)
 }
+
+func TestValidateNameSubstitutions(t *testing.T) {
+	tests := []struct {
+		name    string
+		rules   []model.NameSubstitution
+		wantErr string
+	}{
+		{
+			name:  "no rules is valid",
+			rules: nil,
+		},
+		{
+			name: "literal rule is valid",
+			rules: []model.NameSubstitution{
+				{Find: "~/c/dotfiles/.config/", Replace: ""},
+			},
+		},
+		{
+			name: "valid regex rule",
+			rules: []model.NameSubstitution{
+				{Find: `.*/workspace/(.*)`, Replace: "ws-$1", Regex: true},
+			},
+		},
+		{
+			name: "empty find is rejected",
+			rules: []model.NameSubstitution{
+				{Find: "", Replace: "x"},
+			},
+			wantErr: "name_substitution rule 1 has an empty find",
+		},
+		{
+			name: "invalid regex is rejected",
+			rules: []model.NameSubstitution{
+				{Find: `(unterminated`, Replace: "x", Regex: true},
+			},
+			wantErr: "invalid name_substitution regex",
+		},
+		{
+			name: "an invalid find that is not a regex is allowed as a literal",
+			rules: []model.NameSubstitution{
+				{Find: `(unterminated`, Replace: "x"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateNameSubstitutions(&model.Config{NameSubstitutions: test.rules})
+			if test.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.wantErr)
+		})
+	}
+}

--- a/model/config.go
+++ b/model/config.go
@@ -46,6 +46,7 @@ type (
 		WildcardConfigs         []WildcardConfig     `toml:"wildcard"`
 		WorktreeConfigs         []WorktreeConfig     `toml:"worktree"`
 		DirLength               int                  `toml:"dir_length"`
+		NameSubstitutions       []NameSubstitution   `toml:"name_substitution"`
 		GitNamerUseWorktreeRoot bool                 `toml:"git_namer_use_worktree_root"`
 		GitDirLength            int                  `toml:"git_dir_length"`
 		SeparatorAware          bool                 `toml:"separator_aware"`
@@ -75,6 +76,27 @@ type (
 		// AddCommand records a path to bump its frecency after connecting.
 		// The `{}` placeholder is replaced with the path.
 		AddCommand string `toml:"add_command"`
+	}
+
+	// NameSubstitution rewrites the path a session name is derived from before
+	// it becomes a tmux session name, so a deeply nested directory can be shown
+	// under a short, meaningful name (e.g. "~/c/dotfiles/.config/nvim" as
+	// "nvim"). Rules run against the home-collapsed path (a leading "~") for
+	// every path-derived source — zoxide, directories, and wildcards — but not
+	// against existing tmux sessions, which already have a name. When no rule
+	// matches, naming falls back to the usual git/directory strategies, so an
+	// empty or absent [[name_substitution]] list leaves behavior unchanged.
+	NameSubstitution struct {
+		// Find is the text to look for. By default it is matched literally; set
+		// Regex to treat it as a regular expression instead.
+		Find string `toml:"find"`
+		// Replace is the text Find is replaced with. When Regex is set it may
+		// reference capture groups with $1, $2, and so on.
+		Replace string `toml:"replace"`
+		// Regex interprets Find as a Go regular expression (regexp/syntax)
+		// rather than a literal string. Off by default so a path containing
+		// regex metacharacters such as "." is matched as written.
+		Regex bool `toml:"regex"`
 	}
 
 	DefaultSessionConfig struct {

--- a/namer/namer.go
+++ b/namer/namer.go
@@ -49,8 +49,11 @@ func (n *RealNamer) Name(path string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if name != "" {
-			return convertToValidName(name), nil
+		// A strategy only wins if its output survives normalization. A rule
+		// that rewrites the path to whitespace, for example, collapses to
+		// nothing here and must not be handed to tmux as a session name.
+		if valid := convertToValidName(name); valid != "" {
+			return valid, nil
 		}
 	}
 	return "", fmt.Errorf("could not determine name from path: %s", path)
@@ -73,8 +76,8 @@ func (n *RealNamer) RootName(path string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if name != "" {
-			return convertToValidName(name), nil
+		if valid := convertToValidName(name); valid != "" {
+			return valid, nil
 		}
 	}
 	return "", fmt.Errorf("could not determine root name from path: %s", path)

--- a/namer/namer.go
+++ b/namer/namer.go
@@ -39,6 +39,7 @@ func (n *RealNamer) Name(path string) (string, error) {
 	}
 
 	strategies := []func(*RealNamer, string) (string, error){
+		nameSubstitution,
 		gitName,
 		dirName,
 	}
@@ -62,6 +63,7 @@ func (n *RealNamer) RootName(path string) (string, error) {
 	}
 
 	strategies := []func(*RealNamer, string) (string, error){
+		nameSubstitution,
 		gitRootName,
 		dirName,
 	}

--- a/namer/substitute.go
+++ b/namer/substitute.go
@@ -1,0 +1,52 @@
+package namer
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/joshmedeski/sesh/v2/model"
+)
+
+// applySubstitutions runs every rule against name in order, feeding each rule
+// the output of the one before it, and returns the result. A literal rule
+// replaces all occurrences of Find; a regex rule replaces every match and may
+// use $1-style references to capture groups. An invalid regex is skipped so a
+// single bad rule can't break naming outright — the config loader validates
+// patterns up front, so this only guards against unexpected input.
+func applySubstitutions(name string, rules []model.NameSubstitution) string {
+	for _, rule := range rules {
+		if rule.Find == "" {
+			continue
+		}
+		if rule.Regex {
+			re, err := regexp.Compile(rule.Find)
+			if err != nil {
+				continue
+			}
+			name = re.ReplaceAllString(name, rule.Replace)
+			continue
+		}
+		name = strings.ReplaceAll(name, rule.Find, rule.Replace)
+	}
+	return name
+}
+
+// nameSubstitution is a naming strategy that applies the user's
+// [[name_substitution]] rules to the home-collapsed path. It returns a name
+// only when a rule actually changes the path; otherwise it returns an empty
+// string so the namer falls through to the git and directory strategies. This
+// keeps naming byte-identical to prior versions when no rule matches.
+func nameSubstitution(n *RealNamer, path string) (string, error) {
+	if len(n.config.NameSubstitutions) == 0 {
+		return "", nil
+	}
+	shortened, err := n.home.ShortenHome(path)
+	if err != nil {
+		return "", err
+	}
+	name := applySubstitutions(shortened, n.config.NameSubstitutions)
+	if name == shortened || name == "" {
+		return "", nil
+	}
+	return name, nil
+}

--- a/namer/substitute_test.go
+++ b/namer/substitute_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/joshmedeski/sesh/v2/model"
 	"github.com/joshmedeski/sesh/v2/pathwrap"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestApplySubstitutions(t *testing.T) {
@@ -95,7 +96,7 @@ func TestNameSubstitutionStrategy(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, "", name)
-		mockHome.AssertNotCalled(t, "ShortenHome")
+		mockHome.AssertNotCalled(t, "ShortenHome", mock.Anything)
 	})
 
 	t.Run("returns the rewritten name when a rule matches", func(t *testing.T) {
@@ -150,5 +151,33 @@ func TestNameUsesSubstitutionBeforeDirStrategy(t *testing.T) {
 	assert.NoError(t, err)
 	// convertToValidName collapses the space, so "cfg nvim" becomes "cfg_nvim".
 	assert.Equal(t, "cfg_nvim", name)
-	mockGit.AssertNotCalled(t, "ShowTopLevel")
+	mockGit.AssertNotCalled(t, "WorktreeList", mock.Anything)
+}
+
+func TestNameFallsThroughWhenSubstitutionCollapses(t *testing.T) {
+	mockPathwrap := new(pathwrap.MockPath)
+	mockGit := new(git.MockGit)
+	mockHome := new(home.MockHome)
+
+	path := "/home/john/c/api"
+	mockPathwrap.On("EvalSymlinks", path).Return(path, nil)
+	mockHome.On("ShortenHome", path).Return("~/c/api", nil)
+	// No git repo, so naming should fall through to the directory strategy.
+	mockGit.On("WorktreeList", path).Return(false, "", nil)
+
+	config := model.Config{
+		DirLength: 1,
+		NameSubstitutions: []model.NameSubstitution{
+			{Find: "~/c/api", Replace: " "},
+		},
+	}
+	n := &RealNamer{pathwrap: mockPathwrap, git: mockGit, home: mockHome, config: config}
+
+	name, err := n.Name(path)
+
+	assert.NoError(t, err)
+	// The whitespace-only replacement collapses to nothing under
+	// convertToValidName, so the substitution strategy must not win and the
+	// directory basename is used instead.
+	assert.Equal(t, "api", name)
 }

--- a/namer/substitute_test.go
+++ b/namer/substitute_test.go
@@ -1,0 +1,154 @@
+package namer
+
+import (
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/git"
+	"github.com/joshmedeski/sesh/v2/home"
+	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/pathwrap"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApplySubstitutions(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		rules    []model.NameSubstitution
+		expected string
+	}{
+		{
+			name:     "no rules leaves the name untouched",
+			input:    "~/c/dotfiles/.config/nvim",
+			rules:    nil,
+			expected: "~/c/dotfiles/.config/nvim",
+		},
+		{
+			name:     "literal prefix replacement",
+			input:    "~/c/dotfiles/.config/nvim",
+			rules:    []model.NameSubstitution{{Find: "~/c/dotfiles/.config/", Replace: ""}},
+			expected: "nvim",
+		},
+		{
+			name:     "literal replaces every occurrence",
+			input:    "~/work/work/api",
+			rules:    []model.NameSubstitution{{Find: "work/", Replace: ""}},
+			expected: "~/api",
+		},
+		{
+			name:  "rules apply in order and compose",
+			input: "~/c/projects/api",
+			rules: []model.NameSubstitution{
+				{Find: "~/c/projects/", Replace: "proj:"},
+				{Find: "proj:", Replace: "🚀 "},
+			},
+			expected: "🚀 api",
+		},
+		{
+			name:  "an empty find is skipped",
+			input: "~/c/api",
+			rules: []model.NameSubstitution{
+				{Find: "", Replace: "ignored"},
+				{Find: "~/c/", Replace: ""},
+			},
+			expected: "api",
+		},
+		{
+			name:     "literal find treats dots as literal, not wildcards",
+			input:    "~/c/dotXconfig/nvim",
+			rules:    []model.NameSubstitution{{Find: "~/c/dot.config/", Replace: ""}},
+			expected: "~/c/dotXconfig/nvim",
+		},
+		{
+			name:     "regex with a capture group",
+			input:    "~/c/workspace/1_docs",
+			rules:    []model.NameSubstitution{{Find: `.*/workspace/[0-9]+_(.*)`, Replace: "ws-$1", Regex: true}},
+			expected: "ws-docs",
+		},
+		{
+			name:     "regex metacharacters match when regex is enabled",
+			input:    "~/c/dotXconfig/nvim",
+			rules:    []model.NameSubstitution{{Find: `~/c/dot.config/`, Replace: "", Regex: true}},
+			expected: "nvim",
+		},
+		{
+			name:     "an invalid regex is skipped rather than applied",
+			input:    "~/c/api",
+			rules:    []model.NameSubstitution{{Find: `(unterminated`, Replace: "x", Regex: true}},
+			expected: "~/c/api",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, applySubstitutions(test.input, test.rules))
+		})
+	}
+}
+
+func TestNameSubstitutionStrategy(t *testing.T) {
+	t.Run("returns empty when no rules are configured", func(t *testing.T) {
+		mockHome := new(home.MockHome)
+		n := &RealNamer{home: mockHome, config: model.Config{}}
+
+		name, err := nameSubstitution(n, "/home/john/c/nvim")
+
+		assert.NoError(t, err)
+		assert.Equal(t, "", name)
+		mockHome.AssertNotCalled(t, "ShortenHome")
+	})
+
+	t.Run("returns the rewritten name when a rule matches", func(t *testing.T) {
+		mockHome := new(home.MockHome)
+		mockHome.On("ShortenHome", "/home/john/c/dotfiles/.config/nvim").
+			Return("~/c/dotfiles/.config/nvim", nil)
+		config := model.Config{NameSubstitutions: []model.NameSubstitution{
+			{Find: "~/c/dotfiles/.config/", Replace: ""},
+		}}
+		n := &RealNamer{home: mockHome, config: config}
+
+		name, err := nameSubstitution(n, "/home/john/c/dotfiles/.config/nvim")
+
+		assert.NoError(t, err)
+		assert.Equal(t, "nvim", name)
+	})
+
+	t.Run("falls through when no rule changes the path", func(t *testing.T) {
+		mockHome := new(home.MockHome)
+		mockHome.On("ShortenHome", "/home/john/c/api").Return("~/c/api", nil)
+		config := model.Config{NameSubstitutions: []model.NameSubstitution{
+			{Find: "~/nowhere/", Replace: ""},
+		}}
+		n := &RealNamer{home: mockHome, config: config}
+
+		name, err := nameSubstitution(n, "/home/john/c/api")
+
+		assert.NoError(t, err)
+		assert.Equal(t, "", name)
+	})
+}
+
+func TestNameUsesSubstitutionBeforeDirStrategy(t *testing.T) {
+	mockPathwrap := new(pathwrap.MockPath)
+	mockGit := new(git.MockGit)
+	mockHome := new(home.MockHome)
+
+	path := "/home/john/c/dotfiles/.config/nvim"
+	mockPathwrap.On("EvalSymlinks", path).Return(path, nil)
+	mockHome.On("ShortenHome", path).Return("~/c/dotfiles/.config/nvim", nil)
+
+	config := model.Config{
+		DirLength: 1,
+		NameSubstitutions: []model.NameSubstitution{
+			{Find: "~/c/dotfiles/.config/", Replace: "cfg "},
+		},
+	}
+	n := &RealNamer{pathwrap: mockPathwrap, git: mockGit, home: mockHome, config: config}
+
+	name, err := n.Name(path)
+
+	assert.NoError(t, err)
+	// convertToValidName collapses the space, so "cfg nvim" becomes "cfg_nvim".
+	assert.Equal(t, "cfg_nvim", name)
+	mockGit.AssertNotCalled(t, "ShowTopLevel")
+}

--- a/sesh.schema.json
+++ b/sesh.schema.json
@@ -42,6 +42,32 @@
       "minimum": 1,
       "default": 1
     },
+    "name_substitution": {
+      "type": "array",
+      "description": "Rewrite the path a session name is derived from before it becomes a tmux session name. Rules run against the home-collapsed path for every path-derived source (zoxide, directories, wildcards) but not existing tmux sessions. When no rule matches, naming falls back to the usual git/directory strategies.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "find": {
+            "type": "string",
+            "description": "Text to look for. Matched literally unless regex is true."
+          },
+          "replace": {
+            "type": "string",
+            "description": "Text that find is replaced with. With regex enabled it may reference capture groups as $1, $2, and so on."
+          },
+          "regex": {
+            "type": "boolean",
+            "description": "Treat find as a Go regular expression instead of a literal string.",
+            "default": false
+          }
+        },
+        "required": [
+          "find"
+        ],
+        "additionalProperties": false
+      }
+    },
     "git_namer_use_worktree_root": {
       "type": "boolean",
       "description": "Derive git session names from the current worktree's top-level directory instead of the main repo root. Useful when worktrees are added as siblings of the main clone (e.g. `git worktree add ../feat`).",


### PR DESCRIPTION
This implements the path/name substitution from #129 so a deeply nested directory can get a short, sensible session name instead of dragging its whole prefix around.

It adds an opt-in `[[name_substitution]]` list of find/replace rules that run against the home-collapsed path before a name is derived:

```toml
[[name_substitution]]
find = "~/c/dotfiles/.config/"
replace = ""
```

I tried to follow the direction you laid out in the issue thread. The rules apply to every path-derived source (zoxide, directories, wildcards) rather than zoxide only, existing tmux sessions are left alone since they already have names, and I kept the first version simple with no env-var expansion or priority field. Mechanically it slots in as a new naming strategy ahead of the git/directory ones in the `namer` package, and returns empty (falling through to the usual strategies) whenever no rule changes the path, so anyone without rules configured sees byte-identical behavior.

One place I made a call worth flagging: instead of auto-detecting regex, `find` is a literal match by default with an opt-in `regex = true` per rule. A lot of real path strings are also valid regexes (the `.` in `.config`, for one), so auto-detecting felt like a footgun where a literal rule could silently behave as a pattern. With the explicit flag, literal rules stay predictable and regex rules can use capture groups in `replace` (`$1`, `$2`, ...). Rules apply in order and compose. Happy to switch to auto-detect if you'd rather.

Regex patterns are validated at config load time next to the existing alias checks, so a bad pattern is a clear load error rather than silent breakage later. I also added the field to `sesh.schema.json` and a short README section under Directory Length.

Tested with `go test -race ./...` (all green); new coverage lives in `namer/substitute_test.go` and `configurator/configurator_test.go`.
