### PR TITLE
docs: add Fedora Copr install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ yay -S sesh-bin
 </details>
 
 <details>
+  <summary>Fedora (Copr)</summary>
+
+Sesh is available from the [buckaroogeek/Tmux_sesh](https://copr.fedorainfracloud.org/coprs/buckaroogeek/Tmux_sesh/) Copr repository (Fedora and EPEL 10):
+
+```sh
+sudo dnf copr enable buckaroogeek/Tmux_sesh
+sudo dnf install tmux-sesh
+```
+
+</details>
+
+<details>
   <summary>Go</summary>
 
 Alternatively, you can install Sesh using Go's go install command:

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -57,6 +57,18 @@ yay -S sesh-bin
 </details>
 
 <details>
+  <summary>Fedora（Copr）</summary>
+
+可以从 [buckaroogeek/Tmux_sesh](https://copr.fedorainfracloud.org/coprs/buckaroogeek/Tmux_sesh/) Copr 仓库安装 sesh（支持 Fedora 和 EPEL 10）：
+
+```sh
+sudo dnf copr enable buckaroogeek/Tmux_sesh
+sudo dnf install tmux-sesh
+```
+
+</details>
+
+<details>
   <summary>Go</summary>
 
 或者，您可以使用 Go 的 `go install` 命令安装 Sesh：


### PR DESCRIPTION
Adds Fedora install instructions to the README (and the Chinese translation), pointing at the community-maintained [buckaroogeek/Tmux_sesh](https://copr.fedorainfracloud.org/coprs/buckaroogeek/Tmux_sesh/) Copr repository:

```sh
sudo dnf copr enable buckaroogeek/Tmux_sesh
sudo dnf install tmux-sesh
```

Note the package is named `tmux-sesh`, not `sesh`. The project builds for Fedora 43/44/rawhide (x86_64, aarch64, ppc64le, s390x) plus EPEL 10.

Closes #181