### PR TITLE
perf: memoize wildcard pattern expansion in FindConfigWildcard

### DIFF
--- a/lister/config_wildcard.go
+++ b/lister/config_wildcard.go
@@ -7,19 +7,53 @@ import (
 	"github.com/joshmedeski/sesh/v2/model"
 )
 
+// expandedWildcard pairs a [[wildcard]] block with its home-expanded pattern so
+// the expansion happens once per lister instead of once per lookup.
+type expandedWildcard struct {
+	config  model.WildcardConfig
+	pattern string
+}
+
+// expandedWildcards expands every configured wildcard pattern the first time it
+// is asked for and caches the result. The patterns come from config, so they
+// cannot change during a run, but the picker asks about every session on screen
+// — expanding per call made that O(sessions x patterns).
+//
+// Expansion is lazy rather than done in NewLister so a lister built for a
+// command that never resolves a wildcard pays nothing.
+//
+// A pattern that fails to expand is dropped, which keeps the previous
+// per-lookup `continue` behavior, and the surviving patterns stay in config
+// order so first-match-wins is unchanged.
+func (l *RealLister) expandedWildcards() []expandedWildcard {
+	l.wildcardsOnce.Do(func() {
+		expanded := make([]expandedWildcard, 0, len(l.config.WildcardConfigs))
+		for _, wc := range l.config.WildcardConfigs {
+			pattern, err := l.home.ExpandPath(wc.Pattern)
+			if err != nil {
+				continue
+			}
+			expanded = append(expanded, expandedWildcard{config: wc, pattern: pattern})
+		}
+		l.wildcards = expanded
+	})
+	return l.wildcards
+}
+
 func (l *RealLister) FindConfigWildcard(path string) (model.WildcardConfig, bool) {
+	wildcards := l.expandedWildcards()
+	if len(wildcards) == 0 {
+		return model.WildcardConfig{}, false
+	}
+
 	expandedPath, err := l.home.ExpandPath(path)
 	if err != nil {
 		return model.WildcardConfig{}, false
 	}
 
-	for _, wc := range l.config.WildcardConfigs {
-		expandedPattern, err := l.home.ExpandPath(wc.Pattern)
-		if err != nil {
-			continue
-		}
-		if matchWildcard(expandedPattern, expandedPath) {
-			return wc, true
+	for _, wc := range wildcards {
+		if matchWildcard(wc.pattern, expandedPath) {
+			return wc.config, true
 		}
 	}
 	return model.WildcardConfig{}, false

--- a/lister/lister.go
+++ b/lister/lister.go
@@ -1,6 +1,8 @@
 package lister
 
 import (
+	"sync"
+
 	"github.com/joshmedeski/sesh/v2/home"
 	"github.com/joshmedeski/sesh/v2/model"
 	"github.com/joshmedeski/sesh/v2/tmux"
@@ -27,8 +29,20 @@ type RealLister struct {
 	tmux       tmux.Tmux
 	zoxide     zoxide.Zoxide
 	tmuxinator tmuxinator.Tmuxinator
+
+	// wildcards caches config.WildcardConfigs with their patterns expanded, so
+	// resolving a wildcard for every session in a list expands each pattern
+	// once. See expandedWildcards.
+	wildcardsOnce sync.Once
+	wildcards     []expandedWildcard
 }
 
 func NewLister(config model.Config, home home.Home, tmux tmux.Tmux, zoxide zoxide.Zoxide, tmuxinator tmuxinator.Tmuxinator) Lister {
-	return &RealLister{config, home, tmux, zoxide, tmuxinator}
+	return &RealLister{
+		config:     config,
+		home:       home,
+		tmux:       tmux,
+		zoxide:     zoxide,
+		tmuxinator: tmuxinator,
+	}
 }

--- a/picker/bench_test.go
+++ b/picker/bench_test.go
@@ -263,15 +263,16 @@ func benchHome(b *testing.B) home.Home {
 }
 
 // benchWildcardCount is how many [[wildcard]] blocks the wildcard icon
-// benchmark declares. A config with this many patterns is unremarkable, and
-// FindConfigWildcard expands every one of them per session it is asked about.
+// benchmark declares. A config with this many patterns is unremarkable, and the
+// benchmark guards that the cost per session stays independent of it.
 const benchWildcardCount = 8
 
-// BenchmarkIconResolverWildcard sizes the O(N x W) path expansion behind the
-// resolver's wildcard fallback: one home.ExpandPath for the session plus one
-// per wildcard pattern, with no memoization, for every session on screen.
+// BenchmarkIconResolverWildcard sizes the path expansion behind the resolver's
+// wildcard fallback: one home.ExpandPath per session, plus a scan of the
+// patterns the lister expanded once when it was first asked. Allocations per
+// session should not scale with the number of patterns.
 //
-// "miss" is the worst case (no pattern matches, so all W are expanded);
+// "miss" is the worst case (no pattern matches, so all W are scanned);
 // "hit-last" is what a config whose catch-all sits at the bottom pays.
 func BenchmarkIconResolverWildcard(b *testing.B) {
 	cases := []struct {


### PR DESCRIPTION
Closes #442

## Problem

`RealLister.FindConfigWildcard` expanded *every* configured `[[wildcard]]` pattern on *every* call:

```go
expandedPath, err := l.home.ExpandPath(path)
for _, wc := range l.config.WildcardConfigs {
    expandedPattern, err := l.home.ExpandPath(wc.Pattern)
    ...
}
```

The picker's icon resolver calls it once per session, so a config with W patterns cost O(N × W) `home.ExpandPath` calls per list — exactly W allocations per session, scaling linearly in both directions.

## Fix

Patterns come from config and can't change during a run, so `RealLister` now expands them once behind a `sync.Once` (`expandedWildcards`) and `FindConfigWildcard` expands only the session path before scanning the cached pairs.

- Expansion is **lazy** rather than done in `NewLister`, so a lister built for a command that never resolves a wildcard pays nothing (and the existing test, which registers mock expectations *after* constructing the lister, keeps passing untouched).
- Patterns that fail to expand are still dropped, and surviving patterns stay in config order — **first-match-wins behavior is unchanged**.
- Non-picker callers (startup, preview) get the memoization for free.

## Results

`BenchmarkIconResolverWildcard`, 8 wildcard patterns, M4 Max:

| case | before | after |
|---|---|---|
| n=10/miss | 8467 ns, 3840 B, 80 allocs | 4281 ns, 0 B, **0 allocs** |
| n=100/miss | 77052 ns, 38400 B, 800 allocs | 43004 ns, 0 B, **0 allocs** |
| n=1000/miss | 779112 ns, 384000 B, 8000 allocs | 443054 ns, 0 B, **0 allocs** |

Allocs/op no longer scale with the number of wildcard patterns, and wall time roughly halves.

## Verification

- `go vet ./...` clean
- `go test -race ./lister/... ./picker/... ./seshcli/...` passes, with `config_wildcard` and `picker/icons` tests **unmodified**