### PR TITLE
perf: coalesce styled runs in highlightMatches

### DIFF
--- a/picker/picker_test.go
+++ b/picker/picker_test.go
@@ -440,6 +440,35 @@ func TestHighlightMatches_WithIndexes(t *testing.T) {
 	assert.NotEmpty(t, result)
 }
 
+func TestHighlightMatches_CoalescesRuns(t *testing.T) {
+	match := lipgloss.NewStyle().Bold(true)
+	normal := lipgloss.NewStyle()
+
+	// Consecutive matched (and unmatched) runes must be rendered as a single
+	// styled run, not one per rune.
+	result := highlightMatches("hello", []int{0, 1, 3}, match, normal)
+	expected := match.Render("he") + normal.Render("l") + match.Render("l") + normal.Render("o")
+	assert.Equal(t, expected, result)
+}
+
+func TestHighlightMatches_MultiByte(t *testing.T) {
+	match := lipgloss.NewStyle().Bold(true)
+	normal := lipgloss.NewStyle()
+
+	// Indexes are rune offsets, so multi-byte names must highlight by rune.
+	result := highlightMatches("héllo", []int{1, 2}, match, normal)
+	expected := normal.Render("h") + match.Render("él") + normal.Render("lo")
+	assert.Equal(t, expected, result)
+}
+
+func TestHighlightMatches_OutOfRangeIndexes(t *testing.T) {
+	match := lipgloss.NewStyle().Bold(true)
+	normal := lipgloss.NewStyle()
+
+	result := highlightMatches("hi", []int{-1, 0, 9}, match, normal)
+	assert.Equal(t, match.Render("h")+normal.Render("i"), result)
+}
+
 func TestScrolling(t *testing.T) {
 	m := newTestModel()
 	// Short enough that the five test sessions can't all fit at once, which is

--- a/picker/tui.go
+++ b/picker/tui.go
@@ -1162,20 +1162,31 @@ func highlightMatches(s string, indexes []int, matchStyle, normalStyle lipgloss.
 		return normalStyle.Render(s)
 	}
 
-	matchSet := make(map[int]bool, len(indexes))
+	runes := []rune(s)
+	matchSet := make([]bool, len(runes))
 	for _, idx := range indexes {
-		matchSet[idx] = true
+		if idx >= 0 && idx < len(runes) {
+			matchSet[idx] = true
+		}
 	}
 
+	// Render one lipgloss call per run of same-styled runes rather than per
+	// rune: styling is by far the most expensive part of a keystroke, and a
+	// query usually produces only a handful of runs per name.
 	var result strings.Builder
-	runes := []rune(s)
-	for i, r := range runes {
-		ch := string(r)
-		if matchSet[i] {
-			result.WriteString(matchStyle.Render(ch))
-		} else {
-			result.WriteString(normalStyle.Render(ch))
+	for start := 0; start < len(runes); {
+		matched := matchSet[start]
+		end := start + 1
+		for end < len(runes) && matchSet[end] == matched {
+			end++
 		}
+		run := string(runes[start:end])
+		if matched {
+			result.WriteString(matchStyle.Render(run))
+		} else {
+			result.WriteString(normalStyle.Render(run))
+		}
+		start = end
 	}
 	return result.String()
 }


### PR DESCRIPTION
Closes #443.

## Problem

`highlightMatches` called `lipgloss.Style.Render` once per rune, so a 40-character session name cost 40 `Render` calls per visible row on every keystroke. Each call re-derived the style's border metrics even though the match and normal styles have no border set. A CPU profile of `BenchmarkKeystroke` (added in #444) put `Model.View` at 85.7% cumulative, of which `highlightMatches` → `lipgloss.Style.Render` was 83.6%.

For contrast, `filterSessions` — the fuzzy match I'd assumed was the hot path — is ~265 µs at *ten times* the list size.

## Change

Walk the runes and `Render` once per run of same-styled runes. A query typically produces a handful of runs per name rather than one per character. The match set also becomes a `[]bool` sized to the rune count instead of a `map[int]bool`; out-of-range indexes are still ignored, as before.

## Results

`BenchmarkKeystroke` (one `Update(tea.KeyPressMsg)` plus one `View()`) on an M4 Max:

| N | before | after | |
|---|---|---|---|
| 10 | 256 µs / 504 allocs | 47 µs / 178 allocs | 5.5× |
| 100 | 958 µs / 1936 allocs | 147 µs / 633 allocs | 6.5× |
| 1000 | 727 µs / 2245 allocs | 312 µs / 1418 allocs | 2.3× |

At n=100 a keystroke now sits close to the ~47 µs floor of `BenchmarkView` with an empty query, so highlighting is no longer the dominant cost.

## Correctness

The rendered bytes change while the output stays visually identical: one SGR pair wraps each run rather than each character. Fewer escapes per row is also less for the terminal to parse.

Grouping is safe by construction because `matchStyle` and `normalStyle` set only `Foreground` and `Bold` — per-run and per-rune output diverge only for styles with padding, margin, border, width, or alignment.

I also ran a throwaway differential test (not committed) comparing old per-rune output against new per-run output and pushing both through the preview pane's `Width`/`MaxWidth` clip at every width from 1 to overflow, asserting equal visible width and equal ANSI-stripped text. Long ASCII names, CJK, emoji, spaces and tabs all came out identical, with no orphaned escape sequence at any clip width. That clip path was the main concern, since a cut can now land inside a styled run rather than between two closed per-rune SGR pairs.

New tests: `TestHighlightMatches_CoalescesRuns` asserts the exact run-grouped output, so a regression back to per-rune rendering fails; `_MultiByte` pins indexes as rune offsets; `_OutOfRangeIndexes` covers the bounds guard. The two pre-existing tests pass unchanged.

## Manual verification

Highlight positions and colour confirmed unchanged in the session picker and the worktree picker, including with the preview pane open against names that overflow the list column.
