### PR TITLE
ci: move artifact actions off Node.js 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,7 @@ jobs:
             cat benchstat.txt
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: benchmarks
@@ -139,7 +139,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v8
         with:
           name: benchmarks
       - name: Reduce to one sample per benchmark


### PR DESCRIPTION
Every `bench` job run is annotated with:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/upload-artifact@v5.

`upload-artifact@v5` had preliminary Node 24 support but still defaulted to `runs.using: node20`; v6 is the release that flipped the default. This goes to **v7**, the current major, and takes `download-artifact` to **v8** — the two actions are versioned one apart, so upload v7 pairs with download v8.

Both are `runs.using: node24`, confirmed against `action.yml` at those tags.

## Compatibility

Neither bump touches an input used here (`name`, `path`, `if-no-files-found`). Across the intervening majors:

- **upload v7** — adds an optional `archive: false` for uploading a single file unzipped; moves to ESM.
- **download v8** — skips unzipping non-zipped downloads based on `Content-Type`, adds `skip-decompress`; changes `digest-mismatch` to default to `error` rather than logging a warning. That last one is technically breaking, and is the behaviour we want for a CI artifact.
- Both require Actions Runner 2.327.1+, which `ubuntu-latest` is well past.

Dependabot's monthly `github-actions` group would have caught these eventually; sending it now since the deprecation is annotating every run.

Verification is the next run of this workflow: the `bench` job should complete without the Node 20 annotation. The `bench-history` job only runs on pushes to `main`, so its `download-artifact` bump gets exercised after merge.
