### PR TITLE
ci: measure benchmarks over a duration, not 100 iterations

### DIFF
--- a/.github/workflows/bench-calibrate.yml
+++ b/.github/workflows/bench-calibrate.yml
@@ -1,0 +1,91 @@
+# Measures the noise floor of the benchmark runner, so the regression
+# thresholds in CONTRIBUTING.md can be set from data instead of from a guess.
+#
+# The trick is that there is no code change: the suite runs twice on the same
+# commit, in the same job, on the same machine, and benchstat compares the two
+# halves against each other. Every delta it reports is therefore runner noise
+# by construction. A threshold tighter than the widest interval here cannot
+# distinguish a regression from a re-run.
+#
+# Run it by pushing a branch named `bench-calibrate/<something>`, or from the
+# Actions tab once this file is on the default branch. It is not part of the
+# Test workflow: it costs twice the suite for an answer that only changes when
+# the runner image or the benchmark set does.
+name: Benchmark calibration
+
+on:
+  push:
+    branches: ["bench-calibrate/**"]
+  workflow_dispatch:
+    inputs:
+      benchtime:
+        description: "-benchtime for each run (e.g. 100ms, 300ms, 1s)"
+        default: "100ms"
+        type: string
+      count:
+        description: "-count for each of the two runs"
+        default: "6"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  calibrate:
+    name: Noise floor 📐
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      BENCHTIME: ${{ inputs.benchtime || '100ms' }}
+      COUNT: ${{ inputs.count || '6' }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: "1.26"
+      - name: Create mocks
+        run: go tool mockery
+
+      # Build before timing anything, so the first run is not paying for
+      # compilation that the second one gets for free.
+      - name: Warm the build cache
+        run: go test -run='^$' -bench=. -benchtime=1x ./lister/... ./picker/... > /dev/null
+
+      - name: Run A
+        run: |
+          go test -run='^$' -bench=. -benchmem \
+            -benchtime="$BENCHTIME" -count="$COUNT" \
+            ./lister/... ./picker/... | tee a.txt
+
+      - name: Run B
+        run: |
+          go test -run='^$' -bench=. -benchmem \
+            -benchtime="$BENCHTIME" -count="$COUNT" \
+            ./lister/... ./picker/... | tee b.txt
+
+      # Two identical revisions, so every non-zero delta below is noise. The
+      # geomean row is the headline number; the widest single row is what a
+      # per-benchmark threshold actually has to clear.
+      - name: Compare the two runs
+        run: |
+          go tool benchstat a.txt b.txt > calibration.txt
+          {
+            echo "## Benchmark noise floor"
+            echo
+            echo "Same commit, run twice on one runner at \`-benchtime=$BENCHTIME -count=$COUNT\`."
+            echo "Every difference below is measurement noise, not a code change."
+            echo
+            echo '```'
+            cat calibration.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: bench-calibration
+          path: |
+            a.txt
+            b.txt
+            calibration.txt
+          if-no-files-found: warn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,9 @@ jobs:
   bench:
     name: Benchmarks 📊
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # A real -benchtime costs real time, and a pull request runs the suite
+    # twice: once for head and once for the merge base.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
         with:
@@ -76,9 +78,17 @@ jobs:
           go-version: "1.26"
       - name: Create mocks
         run: go tool mockery
+      # -benchtime is a duration, not an iteration count: `-benchtime=100x`
+      # pins every benchmark to 100 iterations, which for a nanosecond-scale
+      # one is microseconds of total work. That never reaches steady state, so
+      # it measures warmup and scheduler jitter instead of the code. Measured
+      # over 10 runs on an idle machine, 100x put RankMatches/n=10 at +-125%
+      # and BlacklistFilter/n=10 at +-70%, and read 2.9x high in absolute
+      # terms; 100ms holds both to +-1%. A threshold can only be as tight as
+      # the measurement under it.
       - name: Run benchmarks
         run: |
-          go test -run='^$' -bench=. -benchmem -benchtime=100x -count=6 \
+          go test -run='^$' -bench=. -benchmem -benchtime=100ms -count=6 \
             ./lister/... ./picker/... | tee head.txt
       - name: Run benchmarks on the merge base
         if: github.event_name == 'pull_request'
@@ -86,7 +96,7 @@ jobs:
           head_sha="$(git rev-parse HEAD)"
           git checkout --detach --quiet ${{ github.event.pull_request.base.sha }}
           go tool mockery
-          go test -run='^$' -bench=. -benchmem -benchtime=100x -count=6 \
+          go test -run='^$' -bench=. -benchmem -benchtime=100ms -count=6 \
             ./lister/... ./picker/... | tee base.txt
           git checkout --detach --quiet "$head_sha"
           go tool mockery
@@ -162,6 +172,18 @@ jobs:
           # a notification, not a gate.
           alert-threshold: "125%"
           fail-on-alert: false
-          comment-on-alert: true
+          # Alerts land in the job summary only. This action compares one point
+          # against the single previous point with a fixed ratio and no model
+          # of variance, which misfires two ways: it flags runner noise as a
+          # regression, and it ratchets, because one lucky-fast commit becomes
+          # the baseline that makes the next ordinary commit look slow. It
+          # alerted on all three commits it saw before this change, including
+          # one that touched only this YAML file.
+          #
+          # The comparison worth acting on is the benchstat table in the PR
+          # job, which has several samples and reports significance. This chart
+          # answers the question benchstat cannot -- "when did this get slow" --
+          # and wants a trend line for that, not a per-commit verdict.
+          comment-on-alert: false
           summary-always: true
           max-items-in-chart: 100

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ When adding a benchmark:
 ### Regression thresholds
 
 The benchmark job is **informational** — it does not fail a PR yet. We are
-watching the run-to-run variance on GitHub's runners before turning a gate on,
+measuring the run-to-run variance on GitHub's runners before turning a gate on,
 because a benchmark gate that cries wolf gets disabled within a month.
 
 When the job does start blocking, these are the thresholds:
@@ -99,6 +99,28 @@ Until then, if the benchstat table in your PR shows a regression past those
 numbers, treat it as a review comment on your own change: explain it in the PR
 or fix it.
 
+Trust `allocs/op` over `time/op` when the two disagree. A timing change with an
+unchanged allocation count, in a package the branch never touched, is noise
+until something explains it; that pattern accounted for every alert the history
+dashboard raised in its first three commits.
+
+Before tightening either threshold, measure what the runner can actually
+resolve. The **Benchmark calibration** workflow
+(`.github/workflows/bench-calibrate.yml`) runs the suite twice on the same
+commit and benchstats the two halves, so every delta it reports is noise by
+construction — a threshold tighter than its widest row cannot tell a regression
+from a re-run. Start it by pushing a `bench-calibrate/**` branch, or from the
+Actions tab.
+
+One lesson from setting these numbers, worth keeping in mind when adding a
+`-benchtime`: it takes a duration, and `-benchtime=100x` instead pins each
+benchmark to 100 iterations. On a nanosecond-scale benchmark that is
+microseconds of total work, too short to reach steady state, and it reports
+warmup rather than the code — spreads of ±70% to ±125% and absolute numbers
+almost 3x high, even on an idle machine. `-benchtime=100ms` holds the same
+benchmarks to ±1%. No threshold is meaningful under a measurement looser than
+the threshold itself.
+
 ### History dashboard
 
 benchstat only ever compares two commits, so it can tell you *whether* a PR
@@ -106,9 +128,17 @@ regressed something but never *when* something got slow. Every push to `main`
 therefore appends a point to a chart published by
 [github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark)
 at `https://joshmedeski.github.io/sesh/dev/bench`. If a benchmark comes in more
-than 25% slower than the previous point, the action leaves a comment on the
-offending commit — it never fails the build, since by then the code is already
-on `main`.
+than 25% slower than the previous point, the action says so in the job summary —
+it never fails the build, since by then the code is already on `main`.
+
+Read that alert as "look at the chart", not as a verdict. It compares a single
+point against the single point before it with a fixed ratio and no model of
+variance, so it flags runner noise, and it ratchets: one lucky-fast commit
+becomes the baseline that makes the next ordinary commit look like a
+regression. It used to comment on the commit it flagged, which put three
+permanent regression notices on `main` — one of them on a commit that changed
+nothing but a CI YAML file. Use the chart for the trend and the PR's benchstat
+table, which reports significance, for the verdict.
 
 The chart takes one sample per benchmark per commit: CI runs `-count=6` for
 benchstat's sake, and `.github/scripts/bench-median.py` collapses those to the


### PR DESCRIPTION
## The bug

`-benchtime` takes a duration. `-benchtime=100x` therefore did not mean "100ms" — it pinned every benchmark to **100 iterations**. For a nanosecond-scale benchmark that is microseconds of total work, nowhere near enough to reach steady state, so the benchmark job has been reporting warmup and scheduler jitter rather than the code.

Measured over 10 runs on an idle machine:

| benchmark | `-benchtime=100x` | `-benchtime=100ms` |
|---|---|---|
| `RankMatches/n=10/a` | 422n **± 125%** | 147n ± 1% |
| `BlacklistFilter/n=10` | 7.1µ **± 70%** | 4.3µ ± 1% |
| `BlacklistFilter/n=100` | 19.6µ **± 21%** | 13.0µ ± 1% |
| `RankMatches/n=1000/a` | 18.6µ **± 19%** | 12.9µ ± 1% |

Note the absolute numbers are wrong too, not just the spread: 422ns against a true 148ns, 2.9x high.

## Why it mattered

The history dashboard's alert threshold is 125%, so **the threshold sat below the noise floor of its own measurement.** It fired on every commit it ever evaluated — 3 for 3:

- **7fe1b19** (`perf: coalesce styled runs in highlightMatches`) — flagged `BlacklistFilter`, `FindTmuxSessionByBase`, `RankMatches`, none of which share code with the diff.
- **8ade5ae** — made `IconResolverWildcard` 1.9x *faster* and still got a regression alert.
- **c8114e2** — changed two lines of `test.yml` and **zero Go code**. Flagged at 1.30.

Every flagged benchmark had byte-identical `B/op` and `allocs/op`. I re-ran the full picker + lister suite locally at HEAD against 680152f and confirmed all of them are flat, so nothing here was real.

## Changes

1. **`-benchtime=100x` → `-benchtime=100ms`** in both invocations (head and merge base). The suite costs 71s instead of 4s locally, which is what a usable number costs. Bumped the bench job timeout 20 → 30 min since a PR runs the suite twice.
2. **`comment-on-alert: false`** on the history job. It compares one point to the single previous point with a fixed ratio and no model of variance, so it flags noise — and it ratchets, because one lucky-fast commit becomes the baseline that makes the next ordinary commit look slow. Alerts still land in the job summary (`summary-always` is on); they just stop writing permanent regression notices onto `main`. The comparison worth acting on is this job's benchstat table, which has several samples and reports significance.
3. **New `.github/workflows/bench-calibrate.yml`** so the thresholds in `CONTRIBUTING.md` can be set from runner data instead of a guess. It runs the suite twice on the same commit and benchstats the halves, so every delta is noise by construction; a threshold tighter than its widest row cannot tell a regression from a re-run. Triggers on push to `bench-calibrate/**` or from the Actions tab.
4. **`CONTRIBUTING.md`**: trust `allocs/op` over `time/op` when they disagree, calibrate before tightening a threshold, the `-benchtime` duration-vs-`x` lesson, and how to read a dashboard alert.

## Verification

- Both workflows parse; `bench-median.py` handles the new output unchanged.
- Dry-ran the calibration workflow's exact command sequence locally end to end.
- `just bench` already used the default `-benchtime`, which is why local numbers were always sane while CI's were not. Unchanged.

## Follow-ups not in this PR

- **The chart history is now discontinuous.** The old points are ~2.9x inflated, so the first commit after this lands will show a large fake *improvement*. Recommend wiping `dev/bench/data.js` on `gh-pages` — four points, three of them wrong.
- **The three bogus alert comments are still on `main`.** Worth deleting; the one on 7fe1b19 makes an optimization commit read as a regression.

https://claude.ai/code/session_01Tnua4HVKwm1vsFH3zzKN4w