### PR TITLE
fix: name the tmux client explicitly when switching sessions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,15 +90,23 @@ jobs:
         run: |
           go test -run='^$' -bench=. -benchmem -benchtime=100ms -count=6 \
             ./lister/... ./picker/... | tee head.txt
+      # Generated mocks are gitignored, so `git checkout` leaves the previous
+      # revision's copies behind. When a pull request changes a mocked
+      # interface, head's mocks don't compile against the merge base — and
+      # mockery loads every configured package before it writes anything, so
+      # it dies on the stale file instead of overwriting it. Delete them
+      # before each run, in both directions.
       - name: Run benchmarks on the merge base
         if: github.event_name == 'pull_request'
         run: |
           head_sha="$(git rev-parse HEAD)"
           git checkout --detach --quiet ${{ github.event.pull_request.base.sha }}
+          find . -name 'mock_*.go' -delete
           go tool mockery
           go test -run='^$' -bench=. -benchmem -benchtime=100ms -count=6 \
             ./lister/... ./picker/... | tee base.txt
           git checkout --detach --quiet "$head_sha"
+          find . -name 'mock_*.go' -delete
           go tool mockery
       - name: Compare against the merge base
         run: |

--- a/connector/tmux.go
+++ b/connector/tmux.go
@@ -40,18 +40,12 @@ func connectToTmux(c *RealConnector, connection model.Connection, opts model.Con
 }
 
 func (c *RealConnector) connectDetached(sessionName string) (string, error) {
-	switched := false
-	if clients, err := c.tmux.ListClients(); err == nil {
-		for _, client := range clients {
-			if client != "" {
-				c.tmux.SwitchClientTarget(client, sessionName)
-				switched = true
-				break
-			}
-		}
+	client := c.tmux.ResolveClient()
+	if client != "" {
+		c.tmux.SwitchClientTarget(client, sessionName)
 	}
 	c.focuser.Activate(c.config.Terminal)
-	if switched {
+	if client != "" {
 		return fmt.Sprintf("switching to tmux session: %s", sessionName), nil
 	}
 	return fmt.Sprintf("connected to tmux session: %s", sessionName), nil

--- a/connector/tmux_test.go
+++ b/connector/tmux_test.go
@@ -78,7 +78,7 @@ func TestConnectToTmuxDetachedSwitchesClientAndFocuses(t *testing.T) {
 
 	// Detached: not attached, --switch set
 	mTmux.EXPECT().IsAttached().Return(false)
-	mTmux.EXPECT().ListClients().Return([]string{"", "/dev/ttys002"}, nil)
+	mTmux.EXPECT().ResolveClient().Return("/dev/ttys002")
 	mTmux.EXPECT().SwitchClientTarget("/dev/ttys002", "nutiliti/2345").Return("", nil)
 	mFocuser.EXPECT().Activate("wezterm").Return(true, nil)
 
@@ -93,4 +93,27 @@ func TestConnectToTmuxDetachedSwitchesClientAndFocuses(t *testing.T) {
 	}
 	_, err := connectToTmux(c, conn, model.ConnectOpts{Switch: true})
 	require.NoError(t, err)
+}
+
+func TestConnectToTmuxDetachedWithNoClientStillFocuses(t *testing.T) {
+	mTmux := tmux.NewMockTmux(t)
+	mFocuser := focuser.NewMockFocuser(t)
+
+	// Nothing is attached to the server, so there is no client to switch.
+	mTmux.EXPECT().IsAttached().Return(false)
+	mTmux.EXPECT().ResolveClient().Return("")
+	mFocuser.EXPECT().Activate("wezterm").Return(true, nil)
+
+	c := NewConnector(
+		model.Config{Terminal: "wezterm"},
+		nil, nil, nil, nil, nil, mTmux, nil, nil, mFocuser,
+	).(*RealConnector)
+
+	conn := model.Connection{
+		Found: true, New: false,
+		Session: model.SeshSession{Src: "tmux", Name: "nutiliti/2345", Path: "/repo/w/2345"},
+	}
+	msg, err := connectToTmux(c, conn, model.ConnectOpts{Switch: true})
+	require.NoError(t, err)
+	assert.Equal(t, "connected to tmux session: nutiliti/2345", msg)
 }

--- a/model/tmux_client.go
+++ b/model/tmux_client.go
@@ -1,0 +1,12 @@
+package model
+
+// TmuxClient is a terminal attached to the tmux server. Sesh needs the whole
+// record rather than just the name: when several clients are attached, which
+// session each one is on and when it was last active is what decides which
+// client a switch should move.
+type TmuxClient struct {
+	Name      string
+	TTY       string
+	SessionID string // e.g. "$3"
+	Activity  int64  // unix seconds; higher is more recent
+}

--- a/seshcli/last.go
+++ b/seshcli/last.go
@@ -3,6 +3,7 @@ package seshcli
 import (
 	"fmt"
 
+	"github.com/joshmedeski/sesh/v2/model"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +23,9 @@ func NewLastCommand(base *BaseDeps) *cobra.Command {
 				// TODO: silently fail?
 				return fmt.Errorf("No last session found")
 			}
-			deps.Tmux.SwitchClient(lastSession.Name)
+			if _, err := deps.Tmux.SwitchOrAttach(lastSession.Name, model.ConnectOpts{}); err != nil {
+				return err
+			}
 			return nil
 		},
 	}

--- a/tmux/client.go
+++ b/tmux/client.go
@@ -1,0 +1,104 @@
+package tmux
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/joshmedeski/sesh/v2/model"
+)
+
+// seshClientEnv names the tmux client explicitly, for the cases sesh cannot
+// work out on its own: a wrapper that strips $TMUX, or a tmux binding that
+// already knows the answer.
+//
+//	bind-key s run-shell 'SESH_CLIENT=#{client_name} sesh connect foo'
+const seshClientEnv = "SESH_CLIENT"
+
+const clientFormat = "#{client_name}\t#{client_tty}\t#{session_id}\t#{client_activity}"
+
+func (t *RealTmux) ListClients() ([]model.TmuxClient, error) {
+	lines, err := t.shell.ListCmd(t.bin, "list-clients", "-F", clientFormat)
+	if err != nil {
+		return nil, err
+	}
+	clients := make([]model.TmuxClient, 0, len(lines))
+	for _, line := range lines {
+		fields := strings.Split(line, "\t")
+		if len(fields) != 4 || fields[0] == "" {
+			continue
+		}
+		activity, _ := strconv.ParseInt(fields[3], 10, 64)
+		clients = append(clients, model.TmuxClient{
+			Name:      fields[0],
+			TTY:       fields[1],
+			SessionID: fields[2],
+			Activity:  activity,
+		})
+	}
+	return clients, nil
+}
+
+// ResolveClient reports which tmux client sesh should act on.
+//
+// A tmux popup has no pane identity — it gets no $TMUX_PANE — so a bare
+// `switch-client -t` leaves tmux to work out who is asking. It falls back to
+// the most recently active client on the whole server, which may well be
+// attached to an unrelated session, and sesh then moves a terminal the user
+// isn't looking at. $TMUX still carries the id of the session the popup was
+// launched from, which is enough to name the right client explicitly.
+//
+// Returns "" when no client can be determined; callers then let tmux guess,
+// which is no worse than not resolving at all.
+func (t *RealTmux) ResolveClient() string {
+	if client := t.os.Getenv(seshClientEnv); client != "" {
+		return client
+	}
+	clients, err := t.ListClients()
+	if err != nil || len(clients) == 0 {
+		return ""
+	}
+	if sessionID := currentSessionID(t.os.Getenv("TMUX")); sessionID != "" {
+		if client := mostRecent(clients, sessionID); client != "" {
+			return client
+		}
+	}
+	return mostRecent(clients, "")
+}
+
+// switchClient moves the resolved client, falling back to letting tmux pick
+// one when sesh cannot name it.
+func (t *RealTmux) switchClient(targetSession string) (string, error) {
+	if client := t.ResolveClient(); client != "" {
+		return t.SwitchClientTarget(client, targetSession)
+	}
+	return t.SwitchClient(targetSession)
+}
+
+// currentSessionID pulls the session id out of $TMUX, which tmux sets to
+// "<socket path>,<server pid>,<session number>". The number is the session id
+// without its "$" sigil.
+func currentSessionID(tmuxEnv string) string {
+	fields := strings.Split(tmuxEnv, ",")
+	if len(fields) < 3 || fields[2] == "" {
+		return ""
+	}
+	return "$" + fields[2]
+}
+
+// mostRecent returns the name of the most recently active client, limited to
+// those attached to sessionID when it is non-empty. When several clients share
+// a session, the one touched last is the one the user is most likely watching.
+func mostRecent(clients []model.TmuxClient, sessionID string) string {
+	name := ""
+	var activity int64
+	for _, client := range clients {
+		if sessionID != "" && client.SessionID != sessionID {
+			continue
+		}
+		if name == "" || client.Activity > activity {
+			name = client.Name
+			activity = client.Activity
+		}
+	}
+	return name
+}

--- a/tmux/client_test.go
+++ b/tmux/client_test.go
@@ -1,0 +1,132 @@
+package tmux
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/oswrap"
+	"github.com/joshmedeski/sesh/v2/shell"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCurrentSessionID(t *testing.T) {
+	tests := []struct {
+		name     string
+		tmuxEnv  string
+		expected string
+	}{
+		{"popup and pane alike carry the session id", "/private/tmp/tmux-501/default,3746,31", "$31"},
+		{"outside tmux", "", ""},
+		{"truncated by a wrapper", "/private/tmp/tmux-501/default,3746", ""},
+		{"empty session field", "/private/tmp/tmux-501/default,3746,", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, currentSessionID(tt.tmuxEnv))
+		})
+	}
+}
+
+// clientLines renders what `tmux list-clients -F clientFormat` would print.
+func clientLines(lines ...string) []string {
+	return append(lines, "")
+}
+
+func TestResolveClient(t *testing.T) {
+	const (
+		onSession1   = "/dev/ttys001\t/dev/ttys001\t$1\t100"
+		onSession2   = "/dev/ttys002\t/dev/ttys002\t$2\t200"
+		alsoSession1 = "/dev/ttys003\t/dev/ttys003\t$1\t300"
+	)
+
+	tests := []struct {
+		name       string
+		seshClient string
+		tmuxEnv    string
+		clients    []string
+		clientsErr error
+		expected   string
+	}{
+		{
+			name:       "SESH_CLIENT wins outright",
+			seshClient: "/dev/ttys009",
+			tmuxEnv:    "/tmp/default,3746,1",
+			clients:    clientLines(onSession1),
+			expected:   "/dev/ttys009",
+		},
+		{
+			// The popup case: tmux would guess ttys002 as most recently
+			// active server-wide, but the popup was launched from $1.
+			name:     "prefers the client attached to the calling session",
+			tmuxEnv:  "/tmp/default,3746,1",
+			clients:  clientLines(onSession1, onSession2),
+			expected: "/dev/ttys001",
+		},
+		{
+			name:     "picks the most recently active of several on that session",
+			tmuxEnv:  "/tmp/default,3746,1",
+			clients:  clientLines(onSession1, alsoSession1),
+			expected: "/dev/ttys003",
+		},
+		{
+			name:     "falls back to most recently active when the session has no client",
+			tmuxEnv:  "/tmp/default,3746,7",
+			clients:  clientLines(onSession1, onSession2),
+			expected: "/dev/ttys002",
+		},
+		{
+			name:     "falls back to most recently active outside tmux",
+			tmuxEnv:  "",
+			clients:  clientLines(onSession1, onSession2),
+			expected: "/dev/ttys002",
+		},
+		{
+			name:     "no clients attached",
+			tmuxEnv:  "/tmp/default,3746,1",
+			clients:  clientLines(),
+			expected: "",
+		},
+		{
+			name:       "list-clients failed",
+			tmuxEnv:    "/tmp/default,3746,1",
+			clientsErr: errors.New("no server running"),
+			expected:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockOs := oswrap.NewMockOs(t)
+			mockShell := shell.NewMockShell(t)
+			mockOs.EXPECT().Getenv("SESH_CLIENT").Return(tt.seshClient)
+			if tt.seshClient == "" {
+				mockShell.EXPECT().ListCmd("tmux", "list-clients", "-F", clientFormat).
+					Return(tt.clients, tt.clientsErr)
+				mockOs.EXPECT().Getenv("TMUX").Return(tt.tmuxEnv).Maybe()
+			}
+			tm := NewTmux(mockOs, mockShell, "")
+			assert.Equal(t, tt.expected, tm.ResolveClient())
+		})
+	}
+}
+
+func TestSwitchOrAttachNamesTheResolvedClient(t *testing.T) {
+	mockOs := oswrap.NewMockOs(t)
+	mockShell := shell.NewMockShell(t)
+	mockOs.EXPECT().Getenv("SESH_CLIENT").Return("")
+	mockOs.EXPECT().Getenv("TMUX").Return("/tmp/default,3746,1")
+	mockShell.EXPECT().ListCmd("tmux", "list-clients", "-F", clientFormat).
+		Return([]string{
+			"/dev/ttys001\t/dev/ttys001\t$1\t100",
+			"/dev/ttys002\t/dev/ttys002\t$2\t200",
+		}, nil)
+	mockShell.EXPECT().Cmd("tmux", "switch-client", "-c", "/dev/ttys001", "-t", "dotfiles").
+		Return("", nil)
+
+	tm := NewTmux(mockOs, mockShell, "")
+	response, err := tm.SwitchOrAttach("dotfiles", model.ConnectOpts{Switch: true})
+	require.NoError(t, err)
+	assert.Equal(t, "switching to tmux session: dotfiles", response)
+}

--- a/tmux/switch_or_attach.go
+++ b/tmux/switch_or_attach.go
@@ -8,7 +8,7 @@ import (
 
 func (t *RealTmux) SwitchOrAttach(name string, opts model.ConnectOpts) (string, error) {
 	if opts.Switch || t.IsAttached() {
-		if _, err := t.SwitchClient(name); err != nil {
+		if _, err := t.switchClient(name); err != nil {
 			return "", fmt.Errorf("failed to switch to tmux session: %w", err)
 		} else {
 			return fmt.Sprintf("switching to tmux session: %s", name), nil

--- a/tmux/switch_or_attach_test.go
+++ b/tmux/switch_or_attach_test.go
@@ -11,6 +11,13 @@ import (
 	mock "github.com/stretchr/testify/mock"
 )
 
+// stubNoClients makes ResolveClient come up empty, so SwitchOrAttach falls back
+// to a bare `switch-client -t` and lets tmux pick the client itself.
+func stubNoClients(mockOs *oswrap.MockOs, mockShell *shell.MockShell, bin string) {
+	mockOs.On("Getenv", "SESH_CLIENT").Return("")
+	mockShell.On("ListCmd", bin, "list-clients", "-F", clientFormat).Return([]string{""}, nil)
+}
+
 func TestSwitchOrAttach(t *testing.T) {
 	mockOs := new(oswrap.MockOs)
 	mockShell := new(shell.MockShell)
@@ -19,6 +26,7 @@ func TestSwitchOrAttach(t *testing.T) {
 	t.Run("switches because of option", func(t *testing.T) {
 		mockOs.ExpectedCalls = nil
 		mockShell.ExpectedCalls = nil
+		stubNoClients(mockOs, mockShell, "tmux")
 		mockShell.On("Cmd", "tmux", "switch-client", "-t", mock.Anything).Return("", nil)
 		response, error := tmux.SwitchOrAttach("dotfiles", model.ConnectOpts{Switch: true})
 		assert.Equal(t, "switching to tmux session: dotfiles", response)
@@ -29,6 +37,7 @@ func TestSwitchOrAttach(t *testing.T) {
 		mockOs.ExpectedCalls = nil
 		mockShell.ExpectedCalls = nil
 		mockOs.On("Getenv", "TMUX").Return("/private/tmp/tmux-501/default,72439,4")
+		stubNoClients(mockOs, mockShell, "tmux")
 		mockShell.On("Cmd", "tmux", "switch-client", "-t", mock.Anything).Return("", nil)
 		response, error := tmux.SwitchOrAttach("dotfiles", model.ConnectOpts{Switch: false})
 		assert.Equal(t, "switching to tmux session: dotfiles", response)
@@ -39,6 +48,7 @@ func TestSwitchOrAttach(t *testing.T) {
 		mockOs.ExpectedCalls = nil
 		mockShell.ExpectedCalls = nil
 		mockOs.On("Getenv", "TMUX").Return("/private/tmp/tmux-501/default,72439,4")
+		stubNoClients(mockOs, mockShell, "tmux")
 		mockShell.On("Cmd", "tmux", "switch-client", "-t", mock.Anything).Return("", errors.New("can't find session: dotfiles"))
 		response, err := tmux.SwitchOrAttach("dotfiles", model.ConnectOpts{Switch: false})
 		assert.Equal(t, "", response)
@@ -70,6 +80,7 @@ func TestCustomBin(t *testing.T) {
 
 	t.Run("uses psmux binary for switch client", func(t *testing.T) {
 		mockOs.On("Getenv", "TMUX").Return("/private/tmp/tmux-501/default,72439,4")
+		stubNoClients(mockOs, mockShell, "psmux")
 		mockShell.On("Cmd", "psmux", "switch-client", "-t", "dotfiles").Return("", nil)
 		response, err := psmux.SwitchOrAttach("dotfiles", model.ConnectOpts{Switch: true})
 		assert.Nil(t, err)

--- a/tmux/tmux.go
+++ b/tmux/tmux.go
@@ -23,7 +23,8 @@ type Tmux interface {
 	ListTmuxPanes() ([]*model.TmuxPane, error)
 	SelectPane(windowIndex int, paneIndex int) (string, error)
 	GetCurrentSession() (string, error)
-	ListClients() ([]string, error)
+	ListClients() ([]model.TmuxClient, error)
+	ResolveClient() string
 	SwitchClientTarget(client string, targetSession string) (string, error)
 	RenameSession(target string, newName string) (string, error)
 }
@@ -68,10 +69,6 @@ func (t *RealTmux) NextWindowInSession(targetSession string) (string, error) {
 
 func (t *RealTmux) IsAttached() bool {
 	return len(t.os.Getenv("TMUX")) > 0
-}
-
-func (t *RealTmux) ListClients() ([]string, error) {
-	return t.shell.ListCmd(t.bin, "list-clients", "-F", "#{client_name}")
 }
 
 func (t *RealTmux) SwitchClientTarget(client string, targetSession string) (string, error) {

--- a/tmux/tmux_test.go
+++ b/tmux/tmux_test.go
@@ -3,6 +3,7 @@ package tmux
 import (
 	"testing"
 
+	"github.com/joshmedeski/sesh/v2/model"
 	"github.com/joshmedeski/sesh/v2/oswrap"
 	"github.com/joshmedeski/sesh/v2/shell"
 	"github.com/stretchr/testify/assert"
@@ -11,13 +12,22 @@ import (
 
 func TestListClients(t *testing.T) {
 	s := shell.NewMockShell(t)
-	s.EXPECT().ListCmd("tmux", "list-clients", "-F", "#{client_name}").
-		Return([]string{"/dev/ttys001", ""}, nil)
+	// ListCmd splits on newlines, so the trailing blank line comes through as
+	// an empty entry and has to be dropped.
+	s.EXPECT().ListCmd("tmux", "list-clients", "-F", clientFormat).
+		Return([]string{
+			"/dev/ttys001\t/dev/ttys001\t$1\t1788188899",
+			"/dev/ttys002\t/dev/ttys002\t$2\t1788188999",
+			"",
+		}, nil)
 	os := oswrap.NewMockOs(t)
 	tm := NewTmux(os, s, "")
 	clients, err := tm.ListClients()
 	require.NoError(t, err)
-	assert.Equal(t, []string{"/dev/ttys001", ""}, clients)
+	assert.Equal(t, []model.TmuxClient{
+		{Name: "/dev/ttys001", TTY: "/dev/ttys001", SessionID: "$1", Activity: 1788188899},
+		{Name: "/dev/ttys002", TTY: "/dev/ttys002", SessionID: "$2", Activity: 1788188999},
+	}, clients)
 }
 
 func TestSwitchClientTarget(t *testing.T) {


### PR DESCRIPTION
Closes #451

## The bug

A tmux popup has no pane identity — tmux gives it no `$TMUX_PANE` — so a bare `switch-client -t` leaves tmux to work out who is asking. It falls back to the most recently active client on the whole server, which may be attached to an unrelated session, and sesh then moves a terminal the user isn't looking at.

With a single client attached the guess can only land on the right one, which is why this looked intermittent, and why @Iduoad's `sleep 0.3` appeared to fix it — the sleep doesn't fix the switch, it just changes who wins the guess.

Reproduced from a popup on tmux 3.7c:

```
TMUX=/private/tmp/tmux-501/default,3746,31   # 3rd field = session id ($31)
TMUX_PANE=                                    # empty — popups have no pane identity
cur_client=/dev/ttys000  cur_session=nu/w/9327  # tmux's guess → a different session
```

`$31` was the session the popup was launched from; tmux picked a client attached to something else entirely.

## The fix

`$TMUX` still carries the id of the launching session, which is enough to name the right client. A single `ResolveClient` resolves it in order:

1. `$SESH_CLIENT` — for wrappers that strip `$TMUX`, or bindings that already know the answer:
   `bind-key s run-shell 'SESH_CLIENT=#{client_name} sesh connect foo'`
2. most recently active client attached to the calling session
3. most recently active client on the server
4. nothing → callers fall back to letting tmux guess

Every failure mode degrades to the previous behavior, so resolution can never block a switch.

## Multi-client robustness

The issue exposed that multi-client handling was never really modeled:

- `ListClients` returned only `#{client_name}`. It now returns tty, session id and last activity per client — the code previously could not see how many clients existed or which session each was on.
- `connectDetached` picked `clients[0]`, the first line of `list-clients` with no ordering guarantee. Now uses the same resolver.
- `sesh last` called `SwitchClient` with its error discarded. Now routes through `SwitchOrAttach`, which also makes it attach rather than fail when run from outside tmux.

## Compatibility

No config, flag, or output changes. `$SESH_CLIENT` is purely additive. The one real behavior change: with several clients attached, sesh now moves *your* client instead of whichever tmux picked — which is the bug.

## Testing

`go test ./...` green. New table tests cover all four resolution branches and `$TMUX` parsing (truncated, empty, absent), plus an end-to-end assertion on the exact `switch-client -c … -t …` argv for the popup case, and the no-client detached path.

Verified live against tmux 3.7c: `$TMUX` layout, `#{session_id}` inside `list-clients`, `client_activity` as a unix timestamp, and popups having an empty `TMUX_PANE`.

**Not verified end to end:** the multi-client case itself needs two real attached terminals, which I couldn't set up in the sandbox. Worth exercising by hand — popup + second attached client — before merging.

## Follow-ups (deliberately not in this PR)

- Diagnostics: a hidden `sesh clients` dumping session id, `TMUX_PANE`, resolved client and all attached clients. This repo has no `doctor` command, so adding a user-facing command felt like a separate call.
- `SESH_CLIENT` is currently documented only in a code comment — `README.md` documents no env vars, so it needs a home in the docs site.
