### PR TITLE
fix: don't rerun the create path for wildcard-matched sessions

### DIFF
--- a/connector/config_wildcard.go
+++ b/connector/config_wildcard.go
@@ -25,6 +25,18 @@ func configWildcardStrategy(c *RealConnector, name string) (model.Connection, er
 		return model.Connection{}, err
 	}
 
+	// A wildcard match describes how to create the session, not that it is
+	// missing. Without this check the create path runs again on every reconnect,
+	// sending the startup command into a session that is already up.
+	if existing, ok := c.lister.FindTmuxSessionByBase(nameFromPath); ok {
+		return model.Connection{
+			Found:       true,
+			New:         false,
+			AddToZoxide: true,
+			Session:     existing,
+		}, nil
+	}
+
 	return model.Connection{
 		Found:       true,
 		New:         true,

--- a/connector/config_wildcard_test.go
+++ b/connector/config_wildcard_test.go
@@ -47,6 +47,7 @@ func TestConfigWildcardStrategy(t *testing.T) {
 			Windows:        []string{"code", "server"},
 		}, true)
 		mockNamer.On("Name", "/Users/test/projects/myapp").Return("myapp", nil)
+		mockLister.On("FindTmuxSessionByBase", "myapp").Return(model.SeshSession{}, false)
 
 		connection, err := configWildcardStrategy(c, "~/projects/myapp")
 		assert.Nil(t, err)
@@ -68,6 +69,7 @@ func TestConfigWildcardStrategy(t *testing.T) {
 			Windows: []string{"agent"},
 		}, true)
 		mockNamer.On("Name", "/Users/test/dev/my-app-dir").Return("my-app-dir", nil)
+		mockLister.On("FindTmuxSessionByBase", "my-app-dir").Return(model.SeshSession{}, false)
 
 		connection, err := configWildcardStrategy(c, "dev/my-app-dir")
 		assert.Nil(t, err)
@@ -84,6 +86,7 @@ func TestConfigWildcardStrategy(t *testing.T) {
 			DisableStartCommand: true,
 		}, true)
 		mockNamer.On("Name", "/Users/test/projects/quiet").Return("quiet", nil)
+		mockLister.On("FindTmuxSessionByBase", "quiet").Return(model.SeshSession{}, false)
 
 		connection, err := configWildcardStrategy(c, "~/projects/quiet")
 		assert.Nil(t, err)
@@ -111,5 +114,29 @@ func TestConfigWildcardStrategy(t *testing.T) {
 		connection, err := configWildcardStrategy(c, "~/projects/notadir")
 		assert.Nil(t, err)
 		assert.False(t, connection.Found)
+	})
+
+	t.Run("should reuse the existing session instead of recreating it", func(t *testing.T) {
+		// Regression: a wildcard match used to force New: true, so reconnecting
+		// reran the create path and sent the startup command into a live session.
+		mockHome.On("ExpandPath", "~/projects/running").Return("/Users/test/projects/running", nil)
+		mockDir.On("Dir", "/Users/test/projects/running").Return(true, "/Users/test/projects/running")
+		mockLister.On("FindConfigWildcard", "/Users/test/projects/running").Return(model.WildcardConfig{
+			Pattern:        "~/projects/*",
+			StartupCommand: "nvim",
+		}, true)
+		mockNamer.On("Name", "/Users/test/projects/running").Return("running", nil)
+		existing := model.SeshSession{
+			Src:  "tmux",
+			Name: "running",
+			Path: "/Users/test/projects/running",
+		}
+		mockLister.On("FindTmuxSessionByBase", "running").Return(existing, true)
+
+		connection, err := configWildcardStrategy(c, "~/projects/running")
+		assert.Nil(t, err)
+		assert.True(t, connection.Found)
+		assert.False(t, connection.New)
+		assert.Equal(t, existing, connection.Session)
 	})
 }


### PR DESCRIPTION
Fixes #453.

## Problem

`configWildcardStrategy` returned `New: true` unconditionally. Connecting by path to a
directory matching a `[[wildcard]]` pattern therefore took the create path even when the
tmux session was already running:

- `connectToTmux` reissued `tmux new-session` against a live session (the return value at
  `connector/tmux.go:24` is unchecked, so this failed silently), and
- `startup.Exec` ran and `send-keys`-ed the startup command into that session — falling
  through to `[default_session].startup_command` when the wildcard defined none of its own.

`configWildcardStrategy` sits *before* `dirStrategy` in the strategy list
(`connector/connect.go:17-25`), so the strategy that does check for an existing session
never got a chance to run.

This also affected `sesh worktree connect`. It correctly passes an empty command when
reconnecting to a worktree that already exists (`worktree/worktree.go:135-140`), but that
only governs `opts.Command`; the `else` branch ran the startup config regardless. The
symptom was an editor being typed into the worktree session on every reconnect.

## Fix

Give `configWildcardStrategy` the same `FindTmuxSessionByBase` branch that `dirStrategy`
(`connector/dir.go:20-27`) and `zoxideStrategy` (`connector/zoxide.go:26`) already have:
when the session exists, return it with `New: false`.

Dropping the wildcard's `WindowNames` / `DisableStartupCommand` on that branch is
intentional and matches `dirStrategy` — both are only read under `if connection.New`.

## Scope

`configStrategy` (`connector/config.go`) has the same unconditional `New: true`, but is
shielded in practice because `tmuxStrategy` matches a configured session by name first.
Left alone here to keep the change to the path that actually misbehaves; happy to fold it
in if you'd rather have the two consistent.

## Tests

Added `should reuse the existing session instead of recreating it`, which fails on `main`
(gets `Src: "config_wildcard"` with `New: true`, expects the existing tmux session with
`New: false`) and passes with the fix. Existing subtests gained the
`FindTmuxSessionByBase → false` mock.

`go build ./...`, `go vet ./...` clean; `go test ./...` passes.