### PR TITLE
feat!: create or connect to windows in an existing session

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,12 +93,19 @@ jobs:
       - name: Run benchmarks on the merge base
         if: github.event_name == 'pull_request'
         run: |
+          # Mocks are gitignored, so they survive the checkout below. Mockery
+          # cannot regenerate a mock for a package that no longer compiles, so
+          # a mock generated at one revision referencing a type that does not
+          # exist at the other kills it before it can replace itself. Clear
+          # them out first; every mock_*.go here is generated.
           head_sha="$(git rev-parse HEAD)"
           git checkout --detach --quiet ${{ github.event.pull_request.base.sha }}
+          find . -name 'mock_*.go' -delete
           go tool mockery
           go test -run='^$' -bench=. -benchmem -benchtime=100ms -count=6 \
             ./lister/... ./picker/... | tee base.txt
           git checkout --detach --quiet "$head_sha"
+          find . -name 'mock_*.go' -delete
           go tool mockery
       - name: Compare against the merge base
         run: |

--- a/connector/connect.go
+++ b/connector/connect.go
@@ -6,24 +6,39 @@ import (
 	"github.com/joshmedeski/sesh/v2/model"
 )
 
+// TODO: make it configurable to change the order of connection establishments?
+// ["tmux", "config", "dir", "zoxide"]
+// TODO: make it configurable to disable certain strategies (including flags for optimized fzf commands)
+// sesh connect --config (sesh list --config | fzf)
+var strategies = []func(*RealConnector, string) (model.Connection, error){
+	tmuxPaneStrategy,
+	tmuxStrategy,
+	tmuxinatorStrategy,
+	configStrategy,
+	configWildcardStrategy,
+	dirStrategy,
+	zoxideStrategy,
+}
+
+// Resolve runs the strategy chain to work out what a name refers to, without
+// touching tmux. Window and pane connects share it so they identify a session
+// exactly the way `sesh connect` does.
+func (c *RealConnector) Resolve(name string) (model.Connection, error) {
+	name = c.resolveAlias(name)
+	for _, strategy := range strategies {
+		connection, err := strategy(c, name)
+		if err != nil {
+			return model.Connection{}, fmt.Errorf("failed to establish connection: %w", err)
+		}
+		if connection.Found {
+			return connection, nil
+		}
+	}
+	return model.Connection{Found: false}, nil
+}
+
 // TODO: send to logging (local txt file?)
 func (c *RealConnector) Connect(name string, opts model.ConnectOpts) (string, error) {
-	name = c.resolveAlias(name)
-
-	// TODO: make it configurable to change the order of connection establishments?
-	// ["tmux", "config", "dir", "zoxide"]
-	// TODO: make it configurable to disable certain strategies (including flags for optimized fzf commands)
-	// sesh connect --config (sesh list --config | fzf)
-	strategies := []func(*RealConnector, string) (model.Connection, error){
-		tmuxPaneStrategy,
-		tmuxStrategy,
-		tmuxinatorStrategy,
-		configStrategy,
-		configWildcardStrategy,
-		dirStrategy,
-		zoxideStrategy,
-	}
-
 	connectStrategy := map[string]func(c *RealConnector, connection model.Connection, opts model.ConnectOpts) (string, error){
 		"tmux-pane":       connectToTmuxPane,
 		"tmux":            connectToTmux,
@@ -34,18 +49,18 @@ func (c *RealConnector) Connect(name string, opts model.ConnectOpts) (string, er
 		"zoxide":          connectToTmux,
 	}
 
-	for _, strategy := range strategies {
-		if connection, err := strategy(c, name); err != nil {
-			return "", fmt.Errorf("failed to establish connection: %w", err)
-		} else if connection.Found {
-			// TODO: allow CLI flag to disable zoxide and overwrite all settings?
-			// sesh connect --ignore-zoxide "dotfiles"
-			if connection.AddToZoxide {
-				c.zoxide.Add(connection.Session.Path)
-			}
-			return connectStrategy[connection.Session.Src](c, connection, opts)
-		}
+	connection, err := c.Resolve(name)
+	if err != nil {
+		return "", err
+	}
+	if !connection.Found {
+		return "", fmt.Errorf("no connection found for '%s'", name)
 	}
 
-	return "", fmt.Errorf("no connection found for '%s'", name)
+	// TODO: allow CLI flag to disable zoxide and overwrite all settings?
+	// sesh connect --ignore-zoxide "dotfiles"
+	if connection.AddToZoxide {
+		c.zoxide.Add(connection.Session.Path)
+	}
+	return connectStrategy[connection.Session.Src](c, connection, opts)
 }

--- a/connector/connect_window.go
+++ b/connector/connect_window.go
@@ -1,0 +1,108 @@
+package connector
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/joshmedeski/sesh/v2/model"
+)
+
+// ConnectWindow selects the named window in the target session, creating it
+// when it isn't there. It returns the window's "session:index" target.
+//
+// An unnamed window has nothing to match on, so it is always created. So is one
+// asked for with opts.New, which allows windows to share a name; a later
+// connect to that name reuses the lowest-indexed one.
+func (c *RealConnector) ConnectWindow(opts model.WindowConnectOpts) (string, error) {
+	session, err := c.targetSession(opts.Session)
+	if err != nil {
+		return "", err
+	}
+
+	name, startDir := opts.Name, opts.Path
+	if startDir == "" {
+		// A directory argument names the window after its basename and roots
+		// it there, so `sesh window ~/c/sesh` opens a window called sesh. The
+		// name is derived before matching, so running it twice selects the
+		// window the first run created instead of opening a duplicate.
+		if dirName, dirPath, ok := c.windowDir(name); ok {
+			name, startDir = dirName, dirPath
+		} else {
+			startDir = session.Path
+		}
+	}
+
+	if name != "" && !opts.New {
+		windows, err := c.tmux.ListWindows(session.Name)
+		if err != nil {
+			return "", fmt.Errorf("failed to list windows in '%s': %w", session.Name, err)
+		}
+		for _, window := range windows {
+			if window.Name != name {
+				continue
+			}
+			// Target by index: a name shared with a session resolves
+			// ambiguously (see #280), an index never does.
+			target := fmt.Sprintf("%s:%d", session.Name, window.Index)
+			return c.reuseWindow(session.Name, target, opts)
+		}
+	}
+
+	target, err := c.tmux.NewWindowInSession(model.TmuxWindowOpts{
+		Name:          name,
+		StartDir:      startDir,
+		TargetSession: session.Name,
+		Command:       opts.Command,
+		Background:    opts.Background,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to create window: %w", err)
+	}
+	if opts.Background {
+		return target, nil
+	}
+	// new-window already made it the session's active window.
+	if _, err := c.focusSession(session.Name, opts.Switch); err != nil {
+		return "", err
+	}
+	return target, nil
+}
+
+// reuseWindow drops a command into a window that already exists. The window
+// already has a running process, so the command goes in as keystrokes rather
+// than becoming the pane's process the way it does on create.
+func (c *RealConnector) reuseWindow(sessionName string, target string, opts model.WindowConnectOpts) (string, error) {
+	if opts.Command != "" {
+		if _, err := c.tmux.SendKeys(target, opts.Command); err != nil {
+			return "", fmt.Errorf("failed to send command to '%s': %w", target, err)
+		}
+	}
+	if opts.Background {
+		return target, nil
+	}
+	if _, err := c.tmux.SelectWindow(target); err != nil {
+		return "", fmt.Errorf("failed to select window '%s': %w", target, err)
+	}
+	if _, err := c.focusSession(sessionName, opts.Switch); err != nil {
+		return "", err
+	}
+	return target, nil
+}
+
+// windowDir reads a window argument as a directory, reporting the window name
+// and start directory it implies. Anything that isn't a directory is left to be
+// used as a plain window name.
+func (c *RealConnector) windowDir(name string) (string, string, bool) {
+	if name == "" {
+		return "", "", false
+	}
+	expanded, err := c.home.ExpandPath(name)
+	if err != nil {
+		return "", "", false
+	}
+	isDir, absPath := c.dir.Dir(expanded)
+	if !isDir {
+		return "", "", false
+	}
+	return filepath.Base(absPath), absPath, true
+}

--- a/connector/connect_window_test.go
+++ b/connector/connect_window_test.go
@@ -1,0 +1,223 @@
+package connector
+
+import (
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/dir"
+	"github.com/joshmedeski/sesh/v2/focuser"
+	"github.com/joshmedeski/sesh/v2/home"
+	"github.com/joshmedeski/sesh/v2/lister"
+	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/tmux"
+	"github.com/joshmedeski/sesh/v2/zoxide"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// windowConnector wires the mocks every window connect test needs, with the
+// target session already attached so the tests only have to describe the
+// window behaviour they care about.
+func windowConnector(t *testing.T) (*RealConnector, *tmux.MockTmux, *lister.MockLister, *dir.MockDir, *home.MockHome) {
+	mTmux := tmux.NewMockTmux(t)
+	mLister := lister.NewMockLister(t)
+	mDir := dir.NewMockDir(t)
+	mHome := home.NewMockHome(t)
+
+	c := NewConnector(
+		model.Config{}, mDir, mHome, mLister, nil, nil, mTmux, nil, nil, nil,
+	).(*RealConnector)
+
+	return c, mTmux, mLister, mDir, mHome
+}
+
+func attachedTo(mLister *lister.MockLister, name string, path string) {
+	mLister.EXPECT().GetAttachedTmuxSession().Return(model.SeshSession{Name: name, Path: path}, true)
+}
+
+// notADirectory keeps a plain window name from being read as a path.
+func notADirectory(mHome *home.MockHome, mDir *dir.MockDir, name string) {
+	mHome.EXPECT().ExpandPath(name).Return(name, nil)
+	mDir.EXPECT().Dir(name).Return(false, "")
+}
+
+func TestConnectWindow(t *testing.T) {
+	t.Run("sends the command into a window that already exists", func(t *testing.T) {
+		c, mTmux, mLister, mDir, mHome := windowConnector(t)
+		attachedTo(mLister, "second-brain", "/home/dev/brain")
+		notADirectory(mHome, mDir, "notes")
+		mTmux.EXPECT().ListWindows("second-brain").Return([]*model.TmuxWindow{
+			{Name: "shell", Index: 1},
+			{Name: "notes", Index: 4},
+		}, nil)
+		mTmux.EXPECT().SendKeys("second-brain:4", "claude").Return("", nil)
+		mTmux.EXPECT().SelectWindow("second-brain:4").Return("", nil)
+		mTmux.EXPECT().SwitchOrAttach("second-brain", model.ConnectOpts{}).Return("", nil)
+
+		target, err := c.ConnectWindow(model.WindowConnectOpts{Name: "notes", Command: "claude"})
+
+		require.NoError(t, err)
+		assert.Equal(t, "second-brain:4", target)
+	})
+
+	t.Run("creates the window when the name doesn't match", func(t *testing.T) {
+		c, mTmux, mLister, mDir, mHome := windowConnector(t)
+		attachedTo(mLister, "second-brain", "/home/dev/brain")
+		notADirectory(mHome, mDir, "notes")
+		mTmux.EXPECT().ListWindows("second-brain").Return([]*model.TmuxWindow{{Name: "shell", Index: 1}}, nil)
+		mTmux.EXPECT().NewWindowInSession(model.TmuxWindowOpts{
+			Name:          "notes",
+			StartDir:      "/home/dev/brain",
+			TargetSession: "second-brain",
+			Command:       "claude",
+		}).Return("second-brain:2", nil)
+		mTmux.EXPECT().SwitchOrAttach("second-brain", model.ConnectOpts{}).Return("", nil)
+
+		target, err := c.ConnectWindow(model.WindowConnectOpts{Name: "notes", Command: "claude"})
+
+		require.NoError(t, err)
+		assert.Equal(t, "second-brain:2", target)
+	})
+
+	t.Run("always creates when no name is given", func(t *testing.T) {
+		c, mTmux, mLister, _, _ := windowConnector(t)
+		attachedTo(mLister, "second-brain", "/home/dev/brain")
+		mTmux.EXPECT().NewWindowInSession(model.TmuxWindowOpts{
+			StartDir:      "/home/dev/brain",
+			TargetSession: "second-brain",
+		}).Return("second-brain:2", nil)
+		mTmux.EXPECT().SwitchOrAttach("second-brain", model.ConnectOpts{}).Return("", nil)
+
+		target, err := c.ConnectWindow(model.WindowConnectOpts{})
+
+		require.NoError(t, err)
+		assert.Equal(t, "second-brain:2", target)
+	})
+
+	t.Run("--new creates even when the name matches, without listing windows", func(t *testing.T) {
+		c, mTmux, mLister, mDir, mHome := windowConnector(t)
+		attachedTo(mLister, "second-brain", "/home/dev/brain")
+		notADirectory(mHome, mDir, "claude")
+		mTmux.EXPECT().NewWindowInSession(model.TmuxWindowOpts{
+			Name:          "claude",
+			StartDir:      "/home/dev/brain",
+			TargetSession: "second-brain",
+			Command:       "claude",
+			Background:    true,
+		}).Return("second-brain:5", nil)
+
+		target, err := c.ConnectWindow(model.WindowConnectOpts{
+			Name: "claude", Command: "claude", New: true, Background: true,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "second-brain:5", target)
+	})
+
+	t.Run("reuse picks the lowest-indexed window when names are shared", func(t *testing.T) {
+		c, mTmux, mLister, mDir, mHome := windowConnector(t)
+		attachedTo(mLister, "second-brain", "/home/dev/brain")
+		notADirectory(mHome, mDir, "claude")
+		mTmux.EXPECT().ListWindows("second-brain").Return([]*model.TmuxWindow{
+			{Name: "claude", Index: 2},
+			{Name: "claude", Index: 5},
+		}, nil)
+		mTmux.EXPECT().SendKeys("second-brain:2", "another prompt").Return("", nil)
+
+		target, err := c.ConnectWindow(model.WindowConnectOpts{
+			Name: "claude", Command: "another prompt", Background: true,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "second-brain:2", target)
+	})
+
+	t.Run("background leaves the client where it is", func(t *testing.T) {
+		c, mTmux, mLister, mDir, mHome := windowConnector(t)
+		attachedTo(mLister, "second-brain", "/home/dev/brain")
+		notADirectory(mHome, mDir, "notes")
+		mTmux.EXPECT().ListWindows("second-brain").Return(nil, nil)
+		mTmux.EXPECT().NewWindowInSession(model.TmuxWindowOpts{
+			Name:          "notes",
+			StartDir:      "/home/dev/brain",
+			TargetSession: "second-brain",
+			Background:    true,
+		}).Return("second-brain:2", nil)
+
+		target, err := c.ConnectWindow(model.WindowConnectOpts{Name: "notes", Background: true})
+
+		require.NoError(t, err)
+		assert.Equal(t, "second-brain:2", target)
+	})
+
+	t.Run("names a directory argument after its basename and roots it there", func(t *testing.T) {
+		c, mTmux, mLister, mDir, mHome := windowConnector(t)
+		attachedTo(mLister, "second-brain", "/home/dev/brain")
+		mHome.EXPECT().ExpandPath("~/c/sesh").Return("/home/dev/c/sesh", nil)
+		mDir.EXPECT().Dir("/home/dev/c/sesh").Return(true, "/home/dev/c/sesh")
+		mTmux.EXPECT().ListWindows("second-brain").Return(nil, nil)
+		mTmux.EXPECT().NewWindowInSession(model.TmuxWindowOpts{
+			Name:          "sesh",
+			StartDir:      "/home/dev/c/sesh",
+			TargetSession: "second-brain",
+		}).Return("second-brain:2", nil)
+		mTmux.EXPECT().SwitchOrAttach("second-brain", model.ConnectOpts{}).Return("", nil)
+
+		target, err := c.ConnectWindow(model.WindowConnectOpts{Name: "~/c/sesh"})
+
+		require.NoError(t, err)
+		assert.Equal(t, "second-brain:2", target)
+	})
+
+	t.Run("reuses the window a directory argument created on an earlier run", func(t *testing.T) {
+		c, mTmux, mLister, mDir, mHome := windowConnector(t)
+		attachedTo(mLister, "second-brain", "/home/dev/brain")
+		mHome.EXPECT().ExpandPath("~/c/sesh").Return("/home/dev/c/sesh", nil)
+		mDir.EXPECT().Dir("/home/dev/c/sesh").Return(true, "/home/dev/c/sesh")
+		mTmux.EXPECT().ListWindows("second-brain").Return([]*model.TmuxWindow{{Name: "sesh", Index: 3}}, nil)
+		mTmux.EXPECT().SelectWindow("second-brain:3").Return("", nil)
+		mTmux.EXPECT().SwitchOrAttach("second-brain", model.ConnectOpts{}).Return("", nil)
+
+		target, err := c.ConnectWindow(model.WindowConnectOpts{Name: "~/c/sesh"})
+
+		require.NoError(t, err)
+		assert.Equal(t, "second-brain:3", target)
+	})
+
+	t.Run("switches the client explicitly when triggered from outside tmux", func(t *testing.T) {
+		c, mTmux, mLister, _, _ := windowConnector(t)
+		mLister.EXPECT().FindTmuxSession("second-brain").Return(model.SeshSession{
+			Src: "tmux", Name: "second-brain", Path: "/home/dev/brain",
+		}, true)
+		mTmux.EXPECT().IsAttached().Return(false)
+		mTmux.EXPECT().NewWindowInSession(model.TmuxWindowOpts{
+			StartDir:      "/home/dev/brain",
+			TargetSession: "second-brain",
+			Command:       "claude",
+		}).Return("second-brain:2", nil)
+		mTmux.EXPECT().ListClients().Return([]string{"/dev/ttys002"}, nil)
+		mTmux.EXPECT().SwitchClientTarget("/dev/ttys002", "second-brain").Return("", nil)
+
+		mZoxide := zoxide.NewMockZoxide(t)
+		mZoxide.EXPECT().Add("/home/dev/brain").Return(nil)
+		c.zoxide = mZoxide
+		mFocuser := focuser.NewMockFocuser(t)
+		mFocuser.EXPECT().Activate("").Return(false, nil)
+		c.focuser = mFocuser
+
+		target, err := c.ConnectWindow(model.WindowConnectOpts{
+			Session: "second-brain", Command: "claude", Switch: true,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "second-brain:2", target)
+	})
+
+	t.Run("errors when no session is given and tmux isn't attached", func(t *testing.T) {
+		c, _, mLister, _, _ := windowConnector(t)
+		mLister.EXPECT().GetAttachedTmuxSession().Return(model.SeshSession{}, false)
+
+		_, err := c.ConnectWindow(model.WindowConnectOpts{Name: "notes"})
+
+		assert.ErrorContains(t, err, "use --target")
+	})
+}

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -15,6 +15,7 @@ import (
 
 type Connector interface {
 	Connect(name string, opts model.ConnectOpts) (string, error)
+	ConnectWindow(opts model.WindowConnectOpts) (string, error)
 }
 
 type RealConnector struct {

--- a/connector/session.go
+++ b/connector/session.go
@@ -1,0 +1,68 @@
+package connector
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/joshmedeski/sesh/v2/model"
+)
+
+// targetSession resolves the session a window or pane connect should land in.
+// An empty name means the attached session, which is what makes `sesh window
+// connect notes` work with no flags from inside tmux.
+func (c *RealConnector) targetSession(name string) (model.SeshSession, error) {
+	if name != "" {
+		return c.ensureSession(name)
+	}
+	session, exists := c.lister.GetAttachedTmuxSession()
+	if !exists {
+		return model.SeshSession{}, errors.New("not inside a tmux session, use --target to specify one")
+	}
+	return session, nil
+}
+
+// ensureSession resolves a name to a running tmux session, starting it when it
+// isn't running yet. Unlike Connect it never moves the client, so a background
+// window or pane connect can target a session that doesn't exist yet without
+// yanking the user out of the one they're in.
+func (c *RealConnector) ensureSession(name string) (model.SeshSession, error) {
+	connection, err := c.Resolve(name)
+	if err != nil {
+		return model.SeshSession{}, err
+	}
+	if !connection.Found {
+		return model.SeshSession{}, fmt.Errorf("no session found for '%s'", name)
+	}
+	if connection.Session.Src == "tmux-pane" {
+		return model.SeshSession{}, fmt.Errorf("'%s' is a pane, not a session", name)
+	}
+	if connection.AddToZoxide {
+		c.zoxide.Add(connection.Session.Path)
+	}
+	if !connection.New {
+		return connection.Session, nil
+	}
+	if connection.Session.Src == "tmuxinator" {
+		if _, err := c.tmuxinator.Start(connection.Session.Name); err != nil {
+			return model.SeshSession{}, fmt.Errorf("failed to start tmuxinator session: %w", err)
+		}
+		return connection.Session, nil
+	}
+	if _, err := c.tmux.NewSession(connection.Session.Name, connection.Session.Path); err != nil {
+		return model.SeshSession{}, fmt.Errorf("failed to create tmux session: %w", err)
+	}
+	c.startup.Exec(connection.Session)
+	return connection.Session, nil
+}
+
+// focusSession brings the client to a session, honouring the same
+// switch-vs-attach rules as Connect.
+func (c *RealConnector) focusSession(sessionName string, doSwitch bool) (string, error) {
+	// When invoked from outside tmux (e.g. osascript/browser dispatcher),
+	// `switch-client -t` has no current client to act on. Find the active
+	// client, switch it explicitly, and bring the terminal to the front.
+	if doSwitch && !c.tmux.IsAttached() {
+		return c.connectDetached(sessionName)
+	}
+	return c.tmux.SwitchOrAttach(sessionName, model.ConnectOpts{Switch: doSwitch})
+}

--- a/connector/tmux.go
+++ b/connector/tmux.go
@@ -29,14 +29,7 @@ func connectToTmux(c *RealConnector, connection model.Connection, opts model.Con
 		}
 	}
 
-	// When invoked from outside tmux (e.g. osascript/browser dispatcher),
-	// `switch-client -t` has no current client to act on. Find the active
-	// client, switch it explicitly, and bring the terminal to the front.
-	if opts.Switch && !c.tmux.IsAttached() {
-		return c.connectDetached(connection.Session.Name)
-	}
-
-	return c.tmux.SwitchOrAttach(connection.Session.Name, opts)
+	return c.focusSession(connection.Session.Name, opts.Switch)
 }
 
 func (c *RealConnector) connectDetached(sessionName string) (string, error) {

--- a/justfile
+++ b/justfile
@@ -1,5 +1,9 @@
 # Generate mocks
+# Stale mocks are cleared first: mockery cannot regenerate a mock for a package
+# that no longer compiles, so a mock left over from before a signature change
+# blocks its own replacement.
 mock:
+    find . -name 'mock_*.go' -delete
     GOFLAGS="-buildvcs=false" go tool mockery
 
 # Run tests with coverage

--- a/model/connect_opts.go
+++ b/model/connect_opts.go
@@ -33,3 +33,19 @@ type WorktreeEntry struct {
 	Title  string // issue title; empty when unknown or not yet fetched
 	State  string // "OPEN" | "CLOSED"; empty when unknown
 }
+
+// WindowConnectOpts identifies a window to connect to and what to run in it.
+// Name is the window's identity: when it matches an existing window that window
+// is reused, and when it is empty there is nothing to match on so a window is
+// always created.
+type WindowConnectOpts struct {
+	Name string
+	// New skips the match and always creates, for when the name is wanted as a
+	// label rather than as an identity to reuse.
+	New        bool
+	Session    string // target session; empty => the attached session
+	Path       string // start directory; empty => the target session's root
+	Command    string
+	Background bool // create without selecting it or moving the client
+	Switch     bool // switch rather than attach, for triggers outside tmux
+}

--- a/model/tmux_opts.go
+++ b/model/tmux_opts.go
@@ -1,0 +1,12 @@
+package model
+
+// TmuxWindowOpts are the arguments for `tmux new-window`.
+type TmuxWindowOpts struct {
+	Name          string
+	StartDir      string
+	TargetSession string
+	// Command becomes the new pane's process, so the window closes when the
+	// command exits. Empty starts the default shell.
+	Command    string
+	Background bool // -d: create the window without making it the active one
+}

--- a/seshcli/window.go
+++ b/seshcli/window.go
@@ -2,105 +2,182 @@ package seshcli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/joshmedeski/sesh/v2/model"
 )
+
+// addTargetFlags wires --target and the deprecated --session alias it replaced.
+// --session lost its -s shorthand to --switch, which now means the same thing
+// on every sesh command.
+func addTargetFlags(cmd *cobra.Command) {
+	cmd.Flags().StringP("target", "t", "", "target session (default: current attached session)")
+	cmd.Flags().String("session", "", "target session")
+	_ = cmd.Flags().MarkDeprecated("session", "use --target instead")
+}
+
+// targetFlag reads the target session, preferring --target over the --session
+// alias it replaced.
+func targetFlag(cmd *cobra.Command) string {
+	if cmd.Flags().Changed("target") {
+		target, _ := cmd.Flags().GetString("target")
+		return target
+	}
+	target, _ := cmd.Flags().GetString("session")
+	return target
+}
+
+// addConnectFlags wires the flags shared by window and pane connect.
+//
+// switchShorthand is false on the parent `sesh window` command, which used to
+// read -s as --session. Leaving the shorthand off there turns that old form
+// into a loud "unknown shorthand flag" instead of silently doing something
+// different; it can be added back once the old form has aged out.
+func addConnectFlags(cmd *cobra.Command, switchShorthand bool) {
+	cmd.Flags().StringP("command", "c", "", "command to run in the target")
+	cmd.Flags().StringP("path", "p", "", "start directory (default: the target session's root)")
+	cmd.Flags().BoolP("background", "b", false, "create without selecting it or moving the client")
+	usage := "Switch the session (rather than attach). This is useful for actions triggered outside the terminal."
+	if switchShorthand {
+		cmd.Flags().BoolP("switch", "s", false, usage)
+	} else {
+		cmd.Flags().Bool("switch", false, usage)
+	}
+}
 
 func NewWindowCommand(base *BaseDeps) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "window",
+		Use:     "window [name|directory]",
 		Aliases: []string{"w"},
-		Short:   "List or switch/create windows in a tmux session",
+		Short:   "List windows, or connect to one in a tmux session",
+		Long: "List the windows of a tmux session, or with an argument connect to one of them.\n\n" +
+			"`sesh window <name>` is shorthand for `sesh window connect <name>`.",
+		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			deps, err := buildDeps(cmd, base)
-			if err != nil {
-				return err
-			}
-
-			targetSession, _ := cmd.Flags().GetString("session")
-			jsonOutput, _ := cmd.Flags().GetBool("json")
-
-			if targetSession == "" {
-				if !deps.Tmux.IsAttached() {
-					return fmt.Errorf("not inside a tmux session, use --session to specify one")
-				}
-			} else {
-				sessions, err := deps.Tmux.ListSessions()
-				if err != nil {
-					return err
-				}
-				found := false
-				for _, s := range sessions {
-					if s.Name == targetSession {
-						found = true
-						break
-					}
-				}
-				if !found {
-					return fmt.Errorf("session '%s' not found", targetSession)
-				}
-			}
-
 			if len(args) == 0 {
-				windows, err := deps.Tmux.ListWindows(targetSession)
-				if err != nil {
-					return err
-				}
-				if jsonOutput {
-					out, err := json.Marshal(windows)
-					if err != nil {
-						return err
-					}
-					fmt.Println(string(out))
-					return nil
-				}
-				for _, w := range windows {
-					fmt.Println(w.Name)
-				}
-				return nil
+				return listWindows(cmd, base)
 			}
-
-			name := strings.Join(args, " ")
-
-			windows, err := deps.Tmux.ListWindows(targetSession)
-			if err != nil {
-				return err
-			}
-			for _, w := range windows {
-				if w.Name == name {
-					target := name
-					if targetSession != "" {
-						target = fmt.Sprintf("%s:%s", targetSession, name)
-					}
-					if _, err := deps.Tmux.SelectWindow(target); err != nil {
-						return fmt.Errorf("failed to select window '%s': %w", name, err)
-					}
-					return nil
-				}
-			}
-
-			expanded, err := base.Home.ExpandPath(name)
-			if err != nil {
-				return err
-			}
-			isDir, absPath := base.Dir.Dir(expanded)
-			if !isDir {
-				return fmt.Errorf("'%s' is not an existing window or valid directory", name)
-			}
-
-			windowName := filepath.Base(absPath)
-			if _, err := deps.Tmux.NewWindowInSession(windowName, absPath, targetSession); err != nil {
-				return fmt.Errorf("failed to create window: %w", err)
-			}
-			return nil
+			return connectWindow(cmd, base, strings.Join(args, " "))
 		},
 	}
 
-	cmd.Flags().StringP("session", "s", "", "target session (default: current attached session)")
+	addTargetFlags(cmd)
 	cmd.Flags().BoolP("json", "j", false, "output as json (list mode only)")
+	addConnectFlags(cmd, false)
+	addWindowConnectFlags(cmd)
+	cmd.AddCommand(newWindowConnectCommand(base))
 
 	return cmd
+}
+
+func newWindowConnectCommand(base *BaseDeps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "connect [name|directory]",
+		Aliases: []string{"cn"},
+		Short:   "Select a window, creating it if it doesn't exist",
+		Long: "Select the named window in the target session, creating it if it isn't there.\n\n" +
+			"With --command, a created window runs the command as its process and closes when it\n" +
+			"exits, while an existing window has the command typed into the shell already running\n" +
+			"in it. Without a name there is nothing to match, so a window is always created.",
+		Args: cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return connectWindow(cmd, base, strings.Join(args, " "))
+		},
+	}
+
+	addTargetFlags(cmd)
+	addConnectFlags(cmd, true)
+	addWindowConnectFlags(cmd)
+
+	return cmd
+}
+
+// addWindowConnectFlags adds the window-only flags. --new has no pane
+// equivalent because a pane is always created anyway.
+func addWindowConnectFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("new", false, "always create, even when the name matches a window that exists")
+}
+
+func listWindows(cmd *cobra.Command, base *BaseDeps) error {
+	deps, err := buildDeps(cmd, base)
+	if err != nil {
+		return err
+	}
+
+	targetSession := targetFlag(cmd)
+	if err := requireSession(deps, targetSession); err != nil {
+		return err
+	}
+
+	windows, err := deps.Tmux.ListWindows(targetSession)
+	if err != nil {
+		return err
+	}
+
+	if jsonOutput, _ := cmd.Flags().GetBool("json"); jsonOutput {
+		out, err := json.Marshal(windows)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(out))
+		return nil
+	}
+	for _, w := range windows {
+		fmt.Println(w.Name)
+	}
+	return nil
+}
+
+func connectWindow(cmd *cobra.Command, base *BaseDeps, name string) error {
+	deps, err := buildDeps(cmd, base)
+	if err != nil {
+		return err
+	}
+
+	command, _ := cmd.Flags().GetString("command")
+	path, _ := cmd.Flags().GetString("path")
+	background, _ := cmd.Flags().GetBool("background")
+	switchFlag, _ := cmd.Flags().GetBool("switch")
+	forceNew, _ := cmd.Flags().GetBool("new")
+
+	target, err := deps.Connector.ConnectWindow(model.WindowConnectOpts{
+		Name:       name,
+		New:        forceNew,
+		Session:    targetFlag(cmd),
+		Path:       path,
+		Command:    command,
+		Background: background,
+		Switch:     switchFlag,
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Println(target)
+	return nil
+}
+
+// requireSession keeps the listing commands honest about their target: an empty
+// target only means "the attached session" when there is one, and a named
+// session has to already be running to have anything to list.
+func requireSession(deps *Deps, targetSession string) error {
+	if targetSession == "" {
+		if !deps.Tmux.IsAttached() {
+			return errors.New("not inside a tmux session, use --target to specify one")
+		}
+		return nil
+	}
+	sessions, err := deps.Tmux.ListSessions()
+	if err != nil {
+		return err
+	}
+	for _, s := range sessions {
+		if s.Name == targetSession {
+			return nil
+		}
+	}
+	return fmt.Errorf("session '%s' not found", targetSession)
 }

--- a/seshcli/window.go
+++ b/seshcli/window.go
@@ -31,45 +31,45 @@ func targetFlag(cmd *cobra.Command) string {
 	return target
 }
 
-// addConnectFlags wires the flags shared by window and pane connect.
-//
-// switchShorthand is false on the parent `sesh window` command, which used to
-// read -s as --session. Leaving the shorthand off there turns that old form
-// into a loud "unknown shorthand flag" instead of silently doing something
-// different; it can be added back once the old form has aged out.
-func addConnectFlags(cmd *cobra.Command, switchShorthand bool) {
-	cmd.Flags().StringP("command", "c", "", "command to run in the target")
-	cmd.Flags().StringP("path", "p", "", "start directory (default: the target session's root)")
-	cmd.Flags().BoolP("background", "b", false, "create without selecting it or moving the client")
-	usage := "Switch the session (rather than attach). This is useful for actions triggered outside the terminal."
-	if switchShorthand {
-		cmd.Flags().BoolP("switch", "s", false, usage)
-	} else {
-		cmd.Flags().Bool("switch", false, usage)
-	}
-}
-
 func NewWindowCommand(base *BaseDeps) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "window [name|directory]",
+		Use:     "window",
 		Aliases: []string{"w"},
-		Short:   "List windows, or connect to one in a tmux session",
-		Long: "List the windows of a tmux session, or with an argument connect to one of them.\n\n" +
-			"`sesh window <name>` is shorthand for `sesh window connect <name>`.",
-		Args: cobra.ArbitraryArgs,
+		Short:   "List or connect to the windows of a tmux session",
+		Args:    cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return listWindows(cmd, base)
+				return cmd.Help()
 			}
-			return connectWindow(cmd, base, strings.Join(args, " "))
+			// `sesh window <name>` used to select-or-create that window.
+			// Naming its replacement beats cobra's bare "unknown command".
+			name := strings.Join(args, " ")
+			return fmt.Errorf(
+				"unknown command %q for %q, to connect to the %s window run: sesh window connect %s",
+				name, cmd.CommandPath(), name, name,
+			)
+		},
+	}
+
+	cmd.AddCommand(newWindowConnectCommand(base))
+	cmd.AddCommand(newWindowListCommand(base))
+
+	return cmd
+}
+
+func newWindowListCommand(base *BaseDeps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"l", "ls"},
+		Short:   "List the windows of a tmux session",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listWindows(cmd, base)
 		},
 	}
 
 	addTargetFlags(cmd)
-	cmd.Flags().BoolP("json", "j", false, "output as json (list mode only)")
-	addConnectFlags(cmd, false)
-	addWindowConnectFlags(cmd)
-	cmd.AddCommand(newWindowConnectCommand(base))
+	cmd.Flags().BoolP("json", "j", false, "output as json")
 
 	return cmd
 }
@@ -77,12 +77,13 @@ func NewWindowCommand(base *BaseDeps) *cobra.Command {
 func newWindowConnectCommand(base *BaseDeps) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "connect [name|directory]",
-		Aliases: []string{"cn"},
+		Aliases: []string{"cn", "c"},
 		Short:   "Select a window, creating it if it doesn't exist",
 		Long: "Select the named window in the target session, creating it if it isn't there.\n\n" +
 			"With --command, a created window runs the command as its process and closes when it\n" +
-			"exits, while an existing window has the command typed into the shell already running\n" +
-			"in it. Without a name there is nothing to match, so a window is always created.",
+			"exits, while an existing window has the command typed into whatever is already running\n" +
+			"in it. Without a name there is nothing to match, so a window is always created; --new\n" +
+			"forces that for a name you want as a label rather than as something to reuse.",
 		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return connectWindow(cmd, base, strings.Join(args, " "))
@@ -90,16 +91,13 @@ func newWindowConnectCommand(base *BaseDeps) *cobra.Command {
 	}
 
 	addTargetFlags(cmd)
-	addConnectFlags(cmd, true)
-	addWindowConnectFlags(cmd)
+	cmd.Flags().StringP("command", "c", "", "command to run in the target")
+	cmd.Flags().StringP("path", "p", "", "start directory (default: the target session's root)")
+	cmd.Flags().BoolP("background", "b", false, "create without selecting it or moving the client")
+	cmd.Flags().BoolP("switch", "s", false, "Switch the session (rather than attach). This is useful for actions triggered outside the terminal.")
+	cmd.Flags().Bool("new", false, "always create, even when the name matches a window that exists")
 
 	return cmd
-}
-
-// addWindowConnectFlags adds the window-only flags. --new has no pane
-// equivalent because a pane is always created anyway.
-func addWindowConnectFlags(cmd *cobra.Command) {
-	cmd.Flags().Bool("new", false, "always create, even when the name matches a window that exists")
 }
 
 func listWindows(cmd *cobra.Command, base *BaseDeps) error {
@@ -160,7 +158,7 @@ func connectWindow(cmd *cobra.Command, base *BaseDeps, name string) error {
 	return nil
 }
 
-// requireSession keeps the listing commands honest about their target: an empty
+// requireSession keeps the listing command honest about its target: an empty
 // target only means "the attached session" when there is one, and a named
 // session has to already be running to have anything to list.
 func requireSession(deps *Deps, targetSession string) error {

--- a/seshcli/window_test.go
+++ b/seshcli/window_test.go
@@ -1,0 +1,71 @@
+package seshcli
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTargetFlag(t *testing.T) {
+	t.Run("reads --target", func(t *testing.T) {
+		cmd := NewWindowCommand(nil)
+		require.NoError(t, cmd.Flags().Parse([]string{"--target", "brain"}))
+		assert.Equal(t, "brain", targetFlag(cmd))
+	})
+
+	t.Run("still accepts the deprecated --session alias", func(t *testing.T) {
+		cmd := NewWindowCommand(nil)
+		cmd.SetErr(&bytes.Buffer{})
+		require.NoError(t, cmd.Flags().Parse([]string{"--session", "brain"}))
+		assert.Equal(t, "brain", targetFlag(cmd))
+	})
+
+	t.Run("prefers --target when both are given", func(t *testing.T) {
+		cmd := NewWindowCommand(nil)
+		cmd.SetErr(&bytes.Buffer{})
+		require.NoError(t, cmd.Flags().Parse([]string{"--session", "old", "--target", "new"}))
+		assert.Equal(t, "new", targetFlag(cmd))
+	})
+
+	t.Run("is empty when neither is given", func(t *testing.T) {
+		cmd := NewWindowCommand(nil)
+		require.NoError(t, cmd.Flags().Parse(nil))
+		assert.Equal(t, "", targetFlag(cmd))
+	})
+}
+
+// -s used to mean --session on `sesh window`. It now means --switch everywhere,
+// so the parent command deliberately has no -s shorthand: the old form has to
+// fail loudly rather than quietly connect to a window named like the session.
+func TestParentWindowCommandRejectsSessionShorthand(t *testing.T) {
+	cmd := NewWindowCommand(nil)
+	err := cmd.Flags().Parse([]string{"-s", "brain"})
+	assert.ErrorContains(t, err, "unknown shorthand flag: 's'")
+}
+
+func TestWindowConnectAcceptsSwitchShorthand(t *testing.T) {
+	cmd := NewWindowCommand(nil)
+	connect, _, err := cmd.Find([]string{"connect"})
+	require.NoError(t, err)
+	require.NoError(t, connect.Flags().Parse([]string{"-s"}))
+
+	switched, err := connect.Flags().GetBool("switch")
+	require.NoError(t, err)
+	assert.True(t, switched)
+}
+
+// `sesh window <name>` predates the connect subcommand and has to keep working.
+func TestWindowArgsStayWithTheParentCommand(t *testing.T) {
+	cmd := NewWindowCommand(nil)
+
+	found, args, err := cmd.Find([]string{"notes"})
+	require.NoError(t, err)
+	assert.Equal(t, "window", found.Name())
+	assert.Equal(t, []string{"notes"}, args)
+
+	found, _, err = cmd.Find([]string{"connect", "notes"})
+	require.NoError(t, err)
+	assert.Equal(t, "connect", found.Name())
+}

--- a/seshcli/window_test.go
+++ b/seshcli/window_test.go
@@ -4,41 +4,72 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+func windowSubcommand(t *testing.T, name string) *cobra.Command {
+	t.Helper()
+	cmd, _, err := NewWindowCommand(nil).Find([]string{name})
+	require.NoError(t, err)
+	require.Equal(t, name, cmd.Name())
+	return cmd
+}
+
 func TestTargetFlag(t *testing.T) {
 	t.Run("reads --target", func(t *testing.T) {
-		cmd := NewWindowCommand(nil)
+		cmd := windowSubcommand(t, "connect")
 		require.NoError(t, cmd.Flags().Parse([]string{"--target", "brain"}))
 		assert.Equal(t, "brain", targetFlag(cmd))
 	})
 
 	t.Run("still accepts the deprecated --session alias", func(t *testing.T) {
-		cmd := NewWindowCommand(nil)
+		cmd := windowSubcommand(t, "list")
 		cmd.SetErr(&bytes.Buffer{})
 		require.NoError(t, cmd.Flags().Parse([]string{"--session", "brain"}))
 		assert.Equal(t, "brain", targetFlag(cmd))
 	})
 
 	t.Run("prefers --target when both are given", func(t *testing.T) {
-		cmd := NewWindowCommand(nil)
+		cmd := windowSubcommand(t, "connect")
 		cmd.SetErr(&bytes.Buffer{})
 		require.NoError(t, cmd.Flags().Parse([]string{"--session", "old", "--target", "new"}))
 		assert.Equal(t, "new", targetFlag(cmd))
 	})
 
 	t.Run("is empty when neither is given", func(t *testing.T) {
-		cmd := NewWindowCommand(nil)
+		cmd := windowSubcommand(t, "connect")
 		require.NoError(t, cmd.Flags().Parse(nil))
 		assert.Equal(t, "", targetFlag(cmd))
 	})
 }
 
-// -s used to mean --session on `sesh window`. It now means --switch everywhere,
-// so the parent command deliberately has no -s shorthand: the old form has to
-// fail loudly rather than quietly connect to a window named like the session.
+// `sesh window <name>` used to select-or-create that window. It is a
+// subcommand entrypoint now, so the old form has to fail with a message that
+// names its replacement rather than a bare "unknown command".
+func TestWindowRejectsTheLegacyPositionalForm(t *testing.T) {
+	cmd := NewWindowCommand(nil)
+
+	err := cmd.RunE(cmd, []string{"claude"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown command "claude"`)
+	assert.Contains(t, err.Error(), "sesh window connect claude")
+}
+
+func TestWindowWithNoArgsPrintsHelp(t *testing.T) {
+	cmd := NewWindowCommand(nil)
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+
+	require.NoError(t, cmd.RunE(cmd, nil))
+	assert.Contains(t, out.String(), "connect")
+	assert.Contains(t, out.String(), "list")
+}
+
+// -s used to mean --session on `sesh window`. It means --switch everywhere now,
+// and the entrypoint has no flags of its own for the old form to land on.
 func TestParentWindowCommandRejectsSessionShorthand(t *testing.T) {
 	cmd := NewWindowCommand(nil)
 	err := cmd.Flags().Parse([]string{"-s", "brain"})
@@ -46,26 +77,25 @@ func TestParentWindowCommandRejectsSessionShorthand(t *testing.T) {
 }
 
 func TestWindowConnectAcceptsSwitchShorthand(t *testing.T) {
-	cmd := NewWindowCommand(nil)
-	connect, _, err := cmd.Find([]string{"connect"})
-	require.NoError(t, err)
-	require.NoError(t, connect.Flags().Parse([]string{"-s"}))
+	cmd := windowSubcommand(t, "connect")
+	require.NoError(t, cmd.Flags().Parse([]string{"-s"}))
 
-	switched, err := connect.Flags().GetBool("switch")
+	switched, err := cmd.Flags().GetBool("switch")
 	require.NoError(t, err)
 	assert.True(t, switched)
 }
 
-// `sesh window <name>` predates the connect subcommand and has to keep working.
-func TestWindowArgsStayWithTheParentCommand(t *testing.T) {
+func TestWindowSubcommandRouting(t *testing.T) {
 	cmd := NewWindowCommand(nil)
 
-	found, args, err := cmd.Find([]string{"notes"})
-	require.NoError(t, err)
-	assert.Equal(t, "window", found.Name())
-	assert.Equal(t, []string{"notes"}, args)
-
-	found, _, err = cmd.Find([]string{"connect", "notes"})
-	require.NoError(t, err)
-	assert.Equal(t, "connect", found.Name())
+	for _, tc := range []struct{ arg, want string }{
+		{"connect", "connect"},
+		{"cn", "connect"},
+		{"list", "list"},
+		{"ls", "list"},
+	} {
+		found, _, err := cmd.Find([]string{tc.arg})
+		require.NoError(t, err)
+		assert.Equal(t, tc.want, found.Name(), "routing %q", tc.arg)
+	}
 }

--- a/startup/startup.go
+++ b/startup/startup.go
@@ -68,7 +68,11 @@ func (s *RealStartup) Exec(session model.SeshSession) (string, error) {
 		}
 
 		// create the new window
-		if ret, err := s.tmux.NewWindowInSession(windowConfig.Name, windowConfig.Path, session.Name); err != nil {
+		if ret, err := s.tmux.NewWindowInSession(model.TmuxWindowOpts{
+			Name:          windowConfig.Name,
+			StartDir:      windowConfig.Path,
+			TargetSession: session.Name,
+		}); err != nil {
 			return ret, err
 		}
 		if ret, err := s.tmux.SendKeys(session.Name, windowConfig.StartupScript); err != nil {

--- a/tmux/new_win.go
+++ b/tmux/new_win.go
@@ -1,10 +1,35 @@
 package tmux
 
-func (t *RealTmux) NewWindowInSession(name string, startDir string, targetSession string) (string, error) {
-	args := []string{"new-window", "-n", name, "-c", startDir}
-	if targetSession != "" {
-		// trailing colon forces session (not window) target resolution
-		args = append(args, "-t", targetSession+":")
+import (
+	"strings"
+
+	"github.com/joshmedeski/sesh/v2/model"
+)
+
+// windowTargetFormat makes tmux print the window it just created, so callers
+// can hand a concrete target to a script or a later send-keys instead of
+// guessing an index.
+const windowTargetFormat = "#{session_name}:#{window_index}"
+
+// NewWindowInSession creates a window and returns its "session:index" target.
+func (t *RealTmux) NewWindowInSession(opts model.TmuxWindowOpts) (string, error) {
+	args := []string{"new-window", "-P", "-F", windowTargetFormat}
+	if opts.Name != "" {
+		args = append(args, "-n", opts.Name)
 	}
-	return t.shell.Cmd("tmux", args...)
+	if opts.StartDir != "" {
+		args = append(args, "-c", opts.StartDir)
+	}
+	if opts.Background {
+		args = append(args, "-d")
+	}
+	if opts.TargetSession != "" {
+		// trailing colon forces session (not window) target resolution
+		args = append(args, "-t", opts.TargetSession+":")
+	}
+	if opts.Command != "" {
+		args = append(args, "--", opts.Command)
+	}
+	target, err := t.shell.Cmd(t.bin, args...)
+	return strings.TrimSpace(target), err
 }

--- a/tmux/new_win_test.go
+++ b/tmux/new_win_test.go
@@ -3,35 +3,70 @@ package tmux
 import (
 	"testing"
 
+	"github.com/joshmedeski/sesh/v2/model"
 	"github.com/joshmedeski/sesh/v2/shell"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewWindowInSession(t *testing.T) {
+	const format = "#{session_name}:#{window_index}"
+
 	t.Run("targets the session unambiguously with a trailing colon", func(t *testing.T) {
 		mockShell := &shell.MockShell{}
 		tmux := &RealTmux{shell: mockShell, bin: "tmux"}
 		mockShell.EXPECT().
-			Cmd("tmux", "new-window", "-n", "agent", "-c", "/home/dev/project", "-t", "project:").
-			Return("", nil)
+			Cmd("tmux", "new-window", "-P", "-F", format, "-n", "agent", "-c", "/home/dev/project", "-t", "project:").
+			Return("project:2\n", nil)
 
-		result, err := tmux.NewWindowInSession("agent", "/home/dev/project", "project")
+		result, err := tmux.NewWindowInSession(model.TmuxWindowOpts{
+			Name: "agent", StartDir: "/home/dev/project", TargetSession: "project",
+		})
 
 		assert.Nil(t, err)
-		assert.Equal(t, "", result)
+		assert.Equal(t, "project:2", result)
 	})
 
 	t.Run("omits the target when no session is provided", func(t *testing.T) {
 		mockShell := &shell.MockShell{}
 		tmux := &RealTmux{shell: mockShell, bin: "tmux"}
 		mockShell.EXPECT().
-			Cmd("tmux", "new-window", "-n", "agent", "-c", "/home/dev/project").
+			Cmd("tmux", "new-window", "-P", "-F", format, "-n", "agent", "-c", "/home/dev/project").
 			Return("", nil)
 
-		result, err := tmux.NewWindowInSession("agent", "/home/dev/project", "")
+		result, err := tmux.NewWindowInSession(model.TmuxWindowOpts{
+			Name: "agent", StartDir: "/home/dev/project",
+		})
 
 		assert.Nil(t, err)
 		assert.Equal(t, "", result)
+	})
+
+	t.Run("passes the command after -- so it becomes the pane process", func(t *testing.T) {
+		mockShell := &shell.MockShell{}
+		tmux := &RealTmux{shell: mockShell, bin: "tmux"}
+		mockShell.EXPECT().
+			Cmd("tmux", "new-window", "-P", "-F", format, "-c", "/home/dev/project", "-d", "-t", "project:", "--", `claude "do the thing"`).
+			Return("project:3", nil)
+
+		result, err := tmux.NewWindowInSession(model.TmuxWindowOpts{
+			StartDir: "/home/dev/project", TargetSession: "project",
+			Command: `claude "do the thing"`, Background: true,
+		})
+
+		assert.Nil(t, err)
+		assert.Equal(t, "project:3", result)
+	})
+
+	t.Run("uses the configured tmux binary", func(t *testing.T) {
+		mockShell := &shell.MockShell{}
+		tmux := &RealTmux{shell: mockShell, bin: "/opt/bin/tmux"}
+		mockShell.EXPECT().
+			Cmd("/opt/bin/tmux", "new-window", "-P", "-F", format).
+			Return("", nil)
+
+		_, err := tmux.NewWindowInSession(model.TmuxWindowOpts{})
+
+		assert.Nil(t, err)
 	})
 }
 

--- a/tmux/tmux.go
+++ b/tmux/tmux.go
@@ -11,7 +11,7 @@ type Tmux interface {
 	ListWindows(targetSession string) ([]*model.TmuxWindow, error)
 	ListAllWindowNames() (map[string][]string, error)
 	NewSession(sessionName string, startDir string) (string, error)
-	NewWindowInSession(name string, startDir string, targetSession string) (string, error)
+	NewWindowInSession(opts model.TmuxWindowOpts) (string, error)
 	IsAttached() bool
 	AttachSession(targetSession string) (string, error)
 	SendKeys(name string, command string) (string, error)


### PR DESCRIPTION
Closes #452

`sesh connect -c` only ran a command when it *created* the session — "will be ignored if the session exists" — so there was no way to drop a new unit of work into a session that was already running. The workaround was shelling out to `tmux new-window -t <session>`, which gives up everything sesh knows: name resolution across tmux/zoxide/config/tmuxinator, the session root, and the switch-vs-attach handling that makes triggering sesh from outside the terminal work at all.

## What this adds

```bash
sesh window connect claude -t 'second brain' -s -c 'claude "<prompt>"'
```

Cold or warm, that's one idempotent line: the session is resolved through the full strategy chain and created if it isn't running, the window is selected if it exists and created if it doesn't, and the client is moved to it — including from outside tmux, where `switch-client` has no current client to act on.

**Identity is the name.** A named window is matched first and created only on a miss. An unnamed one has nothing to match on, so it's always created. `--new` forces creation for a name you want as a label rather than as something to reuse.

**The command reaches the window two different ways, by design.** On create it's passed to `new-window` and becomes the pane's process, so the window closes when it exits. On reuse the window already has a process, so it goes in as keystrokes — which is what makes sending a follow-up prompt into a running `claude` conversation work. The flip side, worth knowing: those keystrokes land in whatever is running, not necessarily a shell.

Windows are targeted by index once resolved, so a window sharing a name with a session can't resolve ambiguously (#280). The directory heuristic behind `sesh window connect ~/c/sesh` is preserved and now derives the name *before* matching, so a second run selects the window the first one created instead of opening a duplicate.

Internally, the strategy chain moves out of `Connect` into `Connector.Resolve`, and `ensureSession` creates a session without moving the client, so a `--background` connect can target a session that isn't running yet without yanking you out of the one you're in. `focusSession` is now shared by `Connect` and `ConnectWindow`, so the detached-client and terminal-focus path behaves identically in both.

## Breaking changes

**`sesh window` is now a subcommand entrypoint.** It no longer lists, and `sesh window <name>` no longer connects:

| Before | After |
| --- | --- |
| `sesh window` | `sesh window list` |
| `sesh window <name>` | `sesh window connect <name>` |
| `sesh window -s <session>` | `sesh window list -t <session>` |

The old positional form fails with a message naming its replacement rather than cobra's bare "unknown command", since it's the form most likely to be sitting in someone's keybindings. `--session` still works as a deprecated alias for `--target`.

`-s` now means `--switch` on `window connect`, matching `sesh connect`. Splitting the command also fixes a pre-existing wart where `-j` was silently ignored outside list mode, and windows named `connect` or `list` are no longer unreachable.

## Why there's no `sesh pane`

The issue proposed `sesh create window` *and* `sesh create pane`. The pane half was built and then deliberately dropped.

Panes have no name to be identified by. tmux pane titles look like a stand-in, but they're set by the shell running inside the pane — an interactive fish overwrites a title we set within a single prompt:

```
immediately after we set it: notes
after the shell drew one prompt: /u/local
```

Without identity, `pane connect` can only ever create, which makes it a wrapper around a single `split-window` call. Its printed target isn't dependable either: pane indexes renumber on every split, so three consecutive splits all reported `finaltest:1.1` while four distinct panes existed. Use `tmux split-window` and `tmux send-keys` directly for panes.

## Testing

Unit tests cover the connector strategies with mocked tmux/lister (create, reuse, `--new`, the directory heuristic, shared-name resolution order, the detached-switch path) and the tmux argument construction. CLI tests cover subcommand routing, the target-flag precedence, and the legacy-form error.

Verified end to end against real tmux 3.7c, including that a created window's command genuinely is the pane process — three windows, one running `true`, one `sleep 400`, one with no command; the `true` window was gone afterward while the other two survived.
