### PR TITLE
feat: ship an agent skill for starting work with sesh

### DIFF
--- a/.claude/skills/config-schema-sync/SKILL.md
+++ b/.claude/skills/config-schema-sync/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: config-schema-sync
 description: Use when reviewing, writing, or committing changes that touch model/config.go or any TOML config struct in this repo. Verifies that every added, renamed, or removed TOML field has a matching update in sesh.schema.json so the JSON schema used by TOML editors (via `#:schema` directive) stays in sync with the Go config model. Trigger whenever a diff touches files under model/, configurator/, or any struct tagged with `toml:"..."`.
+metadata:
+  internal: true
 ---
 
 # Config ↔ Schema Sync Check

--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,8 @@ mock_*
 # Go workspace file
 go.work
 
-# binary
-sesh
+# binary (repo root only; not the skills/sesh/ directory)
+/sesh
 
 dist/
 share/

--- a/README.md
+++ b/README.md
@@ -364,52 +364,73 @@ Use `Ctrl-s` to cycle through the sources, and `Ctrl-d` to kill the highlighted 
 
 ### Window management
 
-`sesh window` (alias `w`) lets you list, switch to, and create tmux windows within a session — similar to how `sesh list` and `sesh connect` work for sessions.
-
-#### List windows in the current session
+`sesh window` (alias `w`) lets you list, switch to, and create tmux windows within a session — similar to how `sesh list` and `sesh connect` work for sessions. It's a group of subcommands:
 
 ```sh
-sesh window
+sesh window list      # list the windows of a session
+sesh window connect   # select a window, creating it if it doesn't exist
+```
+
+#### List windows
+
+```sh
+sesh window list           # the session you're attached to
+sesh window list -t work   # another session
+sesh window list -j        # as json
 ```
 
 #### Switch to an existing window by name
 
 ```sh
-sesh window editor
+sesh window connect editor
 ```
 
-If a window named `editor` exists in the current session, sesh will switch to it.
+If a window named `editor` exists in the target session, sesh selects it. If it doesn't, sesh creates it.
 
 #### Create a new window at a directory
 
 ```sh
-sesh window ~/projects/my-app
+sesh window connect ~/projects/my-app
 ```
 
-If no window with that name exists, sesh will create a new window named after the directory (`my-app`) with its working directory set to the given path.
+A directory argument names the window after its basename (`my-app`) and roots it there. Running it again selects the window the first run created rather than opening a duplicate.
+
+#### Run a command in the window
+
+```sh
+sesh window connect claude -t 'second brain' -c 'claude "summarize my notes"'
+```
+
+On a **created** window the command becomes the window's process, so the window closes when it exits. On an **existing** window it's typed into whatever is already running there. Pass `--new` when every invocation should get its own fresh window instead of reusing the name.
 
 #### Target a specific session
 
-Use `--session` / `-s` to manage windows in a session other than the one you're currently attached to:
+Use `--target` / `-t` to manage windows in a session other than the one you're attached to:
 
 ```sh
-sesh window --session work
-sesh window ~/projects/my-app --session work
+sesh window list -t work
+sesh window connect ~/projects/my-app -t work
 ```
+
+The target is resolved the same way `sesh connect` resolves a session — across tmux, zoxide, config, and tmuxinator — and started if it isn't running yet, without moving you out of the session you're in. Use `-b` / `--background` to create the window without being taken to it, and `-s` / `--switch` when triggering sesh from outside the terminal.
+
+> [!NOTE]
+> `sesh window <name>` and `sesh window -s <session>` were replaced by `sesh window connect <name>` and `sesh window list -t <session>`. `--session` still works as a deprecated alias for `--target`, and `-s` now means `--switch` on `sesh window connect`, consistent with `sesh connect`.
 
 #### fzf integration
 
-You can combine `sesh window` with fzf to interactively switch windows:
+You can combine the two subcommands with fzf to interactively switch windows:
 
 ```sh
-sesh window $(sesh window | fzf)
+sesh window connect "$(sesh window list | fzf)"
 ```
 
 Or as a tmux keybind:
 
 ```sh
-bind-key "W" run-shell "sesh window \"$(sesh window | fzf-tmux -p 60%,50% --prompt '🪟  ')\""
+bind-key "W" run-shell "sesh window connect \"$(sesh window list | fzf-tmux -p 60%,50% --prompt '🪟  ')\""
 ```
+
 
 ### Create a directory and connect
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Sesh is a CLI that helps you create and manage tmux sessions quickly and easily 
 - [How to install](#how-to-install)
 - [Shell Completion](#shell-completion)
 - [Extensions](#extensions)
+- [Agent skill](#agent-skill)
 - [How to use](#how-to-use)
 - [Recommended tmux Settings](#recommended-tmux-settings)
 
@@ -298,6 +299,25 @@ set ssession $(sesh l -t -T -d -H | walker -d -f -k -p "Sesh sessions"); sesh cn
 ssession=$(sesh l -t -T -d -H | walker -d -f -k -p "Sesh sessions"); sesh cn --switch $ssession
 
 ##### For dmenu launchers replace walker -dfk with dmenu or rofi)
+
+## Agent skill
+
+Sesh ships an [agent skill](https://agentskills.io) that teaches coding agents to start work through sesh instead of shelling out to `tmux new-session`, `tmux new-window`, and `tmux send-keys`. An agent that has it will pick a session or a window depending on whether the work belongs to something already open, resolve names and directories across tmux, zoxide, config, and tmuxinator, reuse what's already running instead of duplicating it, and leave you where you are when the work is a background step.
+
+Install it with the [`skills`](https://github.com/vercel-labs/skills) CLI:
+
+```sh
+# globally, for every project
+npx skills add joshmedeski/sesh -g
+
+# or into the current project only
+npx skills add joshmedeski/sesh
+```
+
+It works with Claude Code, Codex, Cursor, OpenCode, and [dozens of other agents](https://github.com/vercel-labs/skills#supported-agents) — `skills add` will ask which ones to install to, or take `-a claude-code` to pick.
+
+The skill lives at [`skills/sesh/SKILL.md`](skills/sesh/SKILL.md) and is versioned with the CLI, so `npx skills update sesh` picks up changes. To install it by hand instead, copy or symlink that file to `~/.claude/skills/sesh/SKILL.md` (or your agent's equivalent skills directory).
+
 
 ### How to use
 

--- a/skills/sesh/SKILL.md
+++ b/skills/sesh/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: sesh
+description: Use when starting work in a terminal session — opening a project or directory, connecting to a session by name, cloning a repo to work in, or running a command or coding agent somewhere other than the current shell. Sesh resolves names and directories to sessions across tmux, zoxide, config, and tmuxinator. Use instead of `tmux new-session`, `tmux new-window`, `tmux attach`, or `tmux send-keys`.
+---
+
+# Starting work with sesh
+
+When work needs to start somewhere other than the shell you're in, call `sesh`, not `tmux`.
+
+Reaching for `tmux new-session -s <name>` or `tmux new-window -t <session>` throws away what the
+user set sesh up to do: resolve a rough name or a directory to the right session, start it from
+its configured root with its startup commands, reuse what's already running instead of duplicating
+it, and decide whether to move the user or leave them where they are.
+
+If `sesh` is not on `PATH`, fall back to raw tmux. Otherwise use the commands below.
+
+## Session or window?
+
+This is the first decision, and the one most worth getting right.
+
+**A session per unit of work.** That's the model — a project, a repo, a directory. If the work has
+its own directory, it wants its own session:
+
+```bash
+sesh connect ~/c/sesh
+sesh connect sesh          # a name works too; sesh resolves it
+```
+
+**A window when it belongs inside a context that already exists.** Reach for a window when the
+work is *part of* a session that's already running rather than a thing of its own:
+
+```bash
+sesh window connect claude -t 'second brain' -c 'claude "<prompt>"'
+```
+
+Good reasons to add a window instead of a session:
+
+- The user named a session to put it in ("in my dotfiles session", "next to what I'm working on")
+- The work is a second track in the same project — tests, logs, an agent, a dev server — and the
+  session for that project is already open
+- You're already inside the right session and just need another place to run something
+
+If neither applies, use a session. Don't create a window in an unrelated session just because
+that session happens to be attached.
+
+Either way, both commands **select-or-create**: they reuse what's there and only create on a miss,
+so it's safe to run them without checking first.
+
+## Sessions
+
+```bash
+sesh connect <name|directory>
+```
+
+Connects to the session, creating it if it isn't running. The argument can be a path, a session
+name, a zoxide result, a configured session, or a tmuxinator config — sesh resolves across all of
+them, which is the main reason to call it instead of tmux.
+
+```bash
+sesh connect ~/c/sesh              # by path
+sesh connect sesh                  # by rough name
+sesh connect 'second brain' -s     # names with spaces need quoting
+sesh connect ~/c/api -c 'npm run dev'
+```
+
+| Flag | Meaning |
+|---|---|
+| `-s`, `--switch` | Switch the client rather than attach. Use when triggering sesh from outside the terminal — a hotkey, a script, another app. |
+| `-c`, `--command` | Startup command. **Only runs on a cold start** — silently ignored if the session already exists. |
+| `-T`, `--tmuxinator` | Start via tmuxinator if the session isn't running. |
+
+That `-c` caveat is the sharp edge: if the user might already have the session open, `sesh connect
+-c` may do nothing at all. To run a command in a session that may already be running, add a window
+(next section).
+
+Two related entry points, for when the directory doesn't exist yet:
+
+```bash
+sesh mkdir ~/c/new-project -c '<command>'   # create the directory, then connect to it
+sesh clone <repo>                           # clone a git repo and connect to it
+```
+
+Use `sesh mkdir` rather than `mkdir && sesh connect` — it's one step and doesn't wait on zoxide.
+
+## Windows
+
+```bash
+sesh window connect <name|directory> -t <session> -c '<command>'
+```
+
+Selects the window called `<name>` in `<session>`, creating it if it isn't there. Prints the
+window's `session:index` target.
+
+```bash
+sesh window connect tests -c 'npm test -- --watch'   # in the current session
+sesh window connect ~/c/sesh -t dotfiles             # window "sesh", rooted at that path
+```
+
+A directory argument is named after its basename and rooted there, so running it twice selects the
+window the first run created rather than duplicating it.
+
+### `--command` means different things on create and reuse
+
+Identity is the window name:
+
+- **Created** window — the command becomes the window's process. The window closes when it exits.
+- **Existing** window — the command is typed in as keystrokes, into whatever is already running.
+  If that's a shell, it runs. If it's a long-running process, you just typed at that process.
+
+So launching an agent twice with the same window name starts one agent, then types the second
+prompt into the first agent's input. When each invocation must get its own window, pass `--new`:
+
+```bash
+sesh window connect claude -t 'second brain' --new -c 'claude "<prompt>"'
+```
+
+`--new` always creates, letting windows share a name; a later connect without it reuses the
+lowest-indexed one. Omitting the name also always creates — there's nothing to match on.
+
+### Targeting
+
+`-t <session>` resolves the same way `sesh connect` does and **starts the session if it isn't
+running**, without moving the user's client. So you don't have to check whether the session is up,
+and cold and warm targets take the same command.
+
+With no `-t`, the target is the attached session. Outside tmux that fails with
+`Not inside a tmux session, use --target to specify one.` — pass `-t`.
+
+## Focus: don't yank the user out of their work
+
+Both commands move the user to what they connected to. That's right when they asked for it and
+wrong when it's a background step.
+
+| Situation | Flag |
+|---|---|
+| The user asked for this and wants to land there | *(default)* |
+| Background work; leave them where they are | `-b` (windows only) |
+| Triggered from outside tmux — hotkey, script, another app | `-s` |
+
+`-b` / `--background` creates the window without selecting it or moving the client. Prefer it for
+anything the user didn't explicitly ask to be taken to. Sessions have no `-b`; a window connect
+with `-t` is the way to set something up without moving.
+
+## Finding the right target
+
+Don't guess a session name and don't invent one:
+
+```bash
+sesh list -j                       # every source: tmux, zoxide, config, tmuxinator
+sesh list -t                       # running tmux sessions only
+sesh window list -t <session>      # windows in a session (-j for json)
+```
+
+When the user names a project or directory, pass what they said — sesh resolves it. Session names
+contain spaces (`second brain`) more often than you'd expect, so quote arguments.
+
+## Do not
+
+- **Do not** use `tmux new-session`, `tmux attach`, `tmux new-window`, or `tmux split-window` to
+  start work. Use `sesh connect` or `sesh window connect`.
+- **Do not** use `tmux send-keys` to run a command. Use `-c`, which knows whether the target is
+  new or already running.
+- **Do not** create a second session for a directory or name that already has one — both commands
+  already select-or-create.
+- **Do not** put unrelated work in a window of whatever session happens to be attached. New work
+  with its own directory gets its own session.
+- **Do not** guess session names. Run `sesh list`.
+- **Do not** move the user for background work. Use `-b`.
+
+Panes are outside sesh's scope; `tmux split-window` and `tmux send-keys` remain correct there.
+
+## Command reference
+
+```
+sesh connect <name|directory>          Connect to a session, creating it if it doesn't exist
+  -s, --switch             Switch the client rather than attach
+  -c, --command <cmd>      Startup command; ignored if the session already exists
+  -T, --tmuxinator         Start via tmuxinator if the session isn't running
+
+sesh mkdir <path>                      Create a directory and connect to it as a session
+  -c, --command <cmd>      Startup command
+  -s, --switch             Switch rather than attach
+
+sesh clone <repo>                      Clone a git repo and connect to it as a session
+  -d, --dir <name>         Directory git creates
+  -c, --cmdDir <dir>       Directory to run git in
+
+sesh window connect [name|directory]   Select a window, creating it if it doesn't exist
+  -t, --target <session>   Target session (default: current attached session)
+  -c, --command <cmd>      Command to run in the target
+  -p, --path <dir>         Start directory (default: the target session's root)
+  -b, --background         Create without selecting it or moving the client
+  -s, --switch             Switch the client rather than attach
+      --new                Always create, even when the name matches an existing window
+
+sesh window list                       List the windows of a session
+  -t, --target <session>   Target session (default: current attached session)
+  -j, --json               Output as json
+
+sesh list                              List sessions from all sources
+  -j, --json               Output as json
+  -t, --tmux               tmux sessions only
+  -z, --zoxide             zoxide results only
+
+sesh last                              Connect to the last tmux session
+sesh root                              Print the root directory of the active session
+```


### PR DESCRIPTION
Ships the first user-facing agent skill, distributed through the [skills.sh](https://www.skills.sh) ecosystem.

Closes #457

## Why

An agent asked to "open my API project" or "start claude in my dotfiles session" reaches for `tmux new-session` / `tmux new-window`, because that's what's in its training data. Those calls give up name resolution across tmux/zoxide/config/tmuxinator, the session root, startup commands, and the switch-vs-attach handling — the whole reason sesh exists. #452 gave agents the missing primitive but didn't change the default, since an agent only reaches for a tool it knows the shape of.

## The skill

`skills/sesh/SKILL.md` leads with the decision agents get wrong first: **session or window**. A unit of work with its own directory gets a session; a window is for work belonging to a context already open — the user named a session, the project's session is already running, or the agent is already inside it. Sessions come first and windows are the special case, not the other way around.

Two quiet behaviours get called out because they fail silently rather than loudly:

- `sesh connect -c` is ignored when the session already exists — which is exactly what makes a window the answer for a session that may be up.
- `--command` becomes the window's process on create but arrives as keystrokes on reuse, so launching an agent twice under one window name types the second prompt into the first agent's input instead of starting a second one. `--new` is the way out.

## Install

`skills/<name>/SKILL.md` is a layout the skills CLI discovers, so it installs straight from GitHub:

```bash
npx skills add joshmedeski/sesh -g
npx skills update sesh
```

This is why there's no `sesh skill install` subcommand, no `go:embed`, and no GoReleaser change — and it works for people who installed sesh from a package manager rather than from source. Works with Claude Code, Codex, Cursor, OpenCode and ~70 other agents.

## The other three commits

Each stands on its own:

- **`docs:`** — the README's window section still documented the pre-#452 interface (`sesh window <name>`, `-s <session>`). Every example in it either failed or, for `-s`, silently meant something else. Rewritten around `list` / `connect`, with a note mapping the old forms to the new ones for anyone arriving from a broken keybinding.
- **`fix:`** — the `sesh` line in `.gitignore` (the built binary) has no slash, so it matched at every level and silently ignored `skills/sesh/`. Files added there don't show in `git status` and don't make it into the commit. Anchored to `/sesh`.
- **`chore:`** — `.claude/skills/` is one of the directories the skills CLI scans, so `npx skills add joshmedeski/sesh` was offering the internal `config-schema-sync` skill to end users. `metadata.internal: true` hides it from discovery; Claude Code ignores the field and still loads it here.

## Verification

Every claim in the skill was executed against an isolated tmux server (`TMUX_TMPDIR`, torn down after — no real sessions touched):

- create → `testsess:2`; same name again → `testsess:2` (reuse); `--new` → `testsess:3`
- directory arg `/tmp` → window named `tmp`, rooted there
- `-c 'sleep 300'` on create → pane process is `sleep`, not a shell
- `-c 'echo ...'` on reuse → text lands in the existing pane (send-keys)
- `-t /tmp/coldproj` on a session that wasn't running → started it, client never moved
- no `-t` outside tmux → exit 1, `Not inside a tmux session, use --target to specify one.`

Skill discovery verified with `npx skills add . --list`: `Found 1 skill` (2 with `INSTALL_INTERNAL_SKILLS=1`).

## Still open

Testing against a real agent — given "open my API project" does it call `sesh connect`, and given "run the tests next to what I'm working on" does it call `sesh window connect -t`? Worth doing before merge, since the session-vs-window routing is the part most likely to need tuning.
