### PR TITLE
fix: stop a switch that never happened from looking like success

### DIFF
--- a/connector/connect_window_test.go
+++ b/connector/connect_window_test.go
@@ -194,6 +194,9 @@ func TestConnectWindow(t *testing.T) {
 			TargetSession: "second-brain",
 			Command:       "claude",
 		}).Return("second-brain:2", nil)
+		mTmux.EXPECT().ListClients().Return([]model.TmuxClient{
+			{Name: "/dev/ttys002", TTY: "/dev/ttys002", SessionID: "$2"},
+		}, nil)
 		mTmux.EXPECT().ResolveClient().Return("/dev/ttys002")
 		mTmux.EXPECT().SwitchClientTarget("/dev/ttys002", "second-brain").Return("", nil)
 

--- a/connector/tmux.go
+++ b/connector/tmux.go
@@ -2,6 +2,7 @@ package connector
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/joshmedeski/sesh/v2/model"
 )
@@ -21,7 +22,12 @@ func tmuxStrategy(c *RealConnector, name string) (model.Connection, error) {
 
 func connectToTmux(c *RealConnector, connection model.Connection, opts model.ConnectOpts) (string, error) {
 	if connection.New {
-		c.tmux.NewSession(connection.Session.Name, connection.Session.Path)
+		// Everything below assumes the session now exists, so a failure here
+		// makes the rest meaningless — and it is how "tmux isn't on the PATH"
+		// first shows up when sesh is launched from a GUI app.
+		if _, err := c.tmux.NewSession(connection.Session.Name, connection.Session.Path); err != nil {
+			return "", fmt.Errorf("failed to create tmux session %q: %w", connection.Session.Name, err)
+		}
 		if opts.Command != "" {
 			c.tmux.SendKeys(connection.Session.Name, opts.Command)
 		} else {
@@ -33,13 +39,39 @@ func connectToTmux(c *RealConnector, connection model.Connection, opts model.Con
 }
 
 func (c *RealConnector) connectDetached(sessionName string) (string, error) {
+	// Reaching tmux is checked separately from picking a client, because the two
+	// failures need opposite handling and look identical from ResolveClient. A
+	// GUI launcher (Leader Key, Raycast, an osascript binding) runs sesh with a
+	// bare PATH that Homebrew isn't on, so every tmux call fails while
+	// Activate's osascript still works — sesh brings the terminal forward and
+	// silently changes nothing, which is indistinguishable from success.
+	clients, err := c.tmux.ListClients()
+	if err != nil {
+		return "", fmt.Errorf("couldn't reach tmux to switch to '%s': %w", sessionName, err)
+	}
+
+	// Nothing attached, so there is no client to move. Bringing the terminal
+	// forward is still the useful thing to do: the user lands where they can
+	// attach.
+	if len(clients) == 0 {
+		c.focuser.Activate(c.config.Terminal)
+		return fmt.Sprintf("connected to tmux session: %s", sessionName), nil
+	}
+
 	client := c.tmux.ResolveClient()
 	if client != "" {
-		c.tmux.SwitchClientTarget(client, sessionName)
+		_, err = c.tmux.SwitchClientTarget(client, sessionName)
+	} else {
+		_, err = c.tmux.SwitchClient(sessionName)
 	}
+
+	// Worth focusing either way: on failure the user at least lands on the tmux
+	// they need to sort out.
 	c.focuser.Activate(c.config.Terminal)
-	if client != "" {
-		return fmt.Sprintf("switching to tmux session: %s", sessionName), nil
+
+	if err != nil {
+		slog.Error("failed to switch client", "client", client, "session", sessionName, "error", err)
+		return "", fmt.Errorf("failed to switch to tmux session '%s': %w", sessionName, err)
 	}
-	return fmt.Sprintf("connected to tmux session: %s", sessionName), nil
+	return fmt.Sprintf("switching to tmux session: %s", sessionName), nil
 }

--- a/connector/tmux_test.go
+++ b/connector/tmux_test.go
@@ -1,6 +1,7 @@
 package connector
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/joshmedeski/sesh/v2/dir"
@@ -78,6 +79,9 @@ func TestConnectToTmuxDetachedSwitchesClientAndFocuses(t *testing.T) {
 
 	// Detached: not attached, --switch set
 	mTmux.EXPECT().IsAttached().Return(false)
+	mTmux.EXPECT().ListClients().Return([]model.TmuxClient{
+		{Name: "/dev/ttys002", TTY: "/dev/ttys002", SessionID: "$2"},
+	}, nil)
 	mTmux.EXPECT().ResolveClient().Return("/dev/ttys002")
 	mTmux.EXPECT().SwitchClientTarget("/dev/ttys002", "nutiliti/2345").Return("", nil)
 	mFocuser.EXPECT().Activate("wezterm").Return(true, nil)
@@ -101,7 +105,7 @@ func TestConnectToTmuxDetachedWithNoClientStillFocuses(t *testing.T) {
 
 	// Nothing is attached to the server, so there is no client to switch.
 	mTmux.EXPECT().IsAttached().Return(false)
-	mTmux.EXPECT().ResolveClient().Return("")
+	mTmux.EXPECT().ListClients().Return(nil, nil)
 	mFocuser.EXPECT().Activate("wezterm").Return(true, nil)
 
 	c := NewConnector(
@@ -116,4 +120,28 @@ func TestConnectToTmuxDetachedWithNoClientStillFocuses(t *testing.T) {
 	msg, err := connectToTmux(c, conn, model.ConnectOpts{Switch: true})
 	require.NoError(t, err)
 	assert.Equal(t, "connected to tmux session: nutiliti/2345", msg)
+}
+
+// A GUI launcher runs sesh with a bare PATH, so tmux isn't reachable while
+// Activate's osascript still is. That used to focus the terminal, change
+// nothing, and report success.
+func TestConnectToTmuxDetachedReportsUnreachableTmux(t *testing.T) {
+	mTmux := tmux.NewMockTmux(t)
+	mFocuser := focuser.NewMockFocuser(t)
+
+	mTmux.EXPECT().IsAttached().Return(false)
+	mTmux.EXPECT().ListClients().
+		Return(nil, errors.New(`exec: "tmux": executable file not found in $PATH`))
+
+	c := NewConnector(
+		model.Config{Terminal: "wezterm"},
+		nil, nil, nil, nil, nil, mTmux, nil, nil, mFocuser,
+	).(*RealConnector)
+
+	conn := model.Connection{
+		Found: true, New: false,
+		Session: model.SeshSession{Src: "tmux", Name: "nutiliti/2345", Path: "/repo/w/2345"},
+	}
+	_, err := connectToTmux(c, conn, model.ConnectOpts{Switch: true})
+	require.ErrorContains(t, err, "couldn't reach tmux to switch to 'nutiliti/2345'")
 }

--- a/tmux/client.go
+++ b/tmux/client.go
@@ -1,6 +1,7 @@
 package tmux
 
 import (
+	"log/slog"
 	"strconv"
 	"strings"
 
@@ -13,6 +14,10 @@ import (
 //
 //	bind-key s run-shell 'SESH_CLIENT=#{client_name} sesh connect foo'
 const seshClientEnv = "SESH_CLIENT"
+
+// tmuxPaneEnv is tmux's own answer to "who is asking". Any command run from a
+// normal pane inherits it, and tmux resolves the client from it exactly.
+const tmuxPaneEnv = "TMUX_PANE"
 
 const clientFormat = "#{client_name}\t#{client_tty}\t#{session_id}\t#{client_activity}"
 
@@ -51,18 +56,46 @@ func (t *RealTmux) ListClients() ([]model.TmuxClient, error) {
 // which is no worse than not resolving at all.
 func (t *RealTmux) ResolveClient() string {
 	if client := t.os.Getenv(seshClientEnv); client != "" {
+		slog.Debug("tmux: client named by env", "client", client, "env", seshClientEnv)
 		return client
 	}
-	clients, err := t.ListClients()
-	if err != nil || len(clients) == 0 {
+	tmuxEnv := t.os.Getenv("TMUX")
+	// A pane inside tmux carries $TMUX_PANE, so tmux can resolve the calling
+	// client from the pane itself — exactly, not by guessing. Naming a client
+	// here would replace that certainty with the heuristic below, which is only
+	// ever a fallback for callers that have no pane identity. Popups are the
+	// case this whole resolver exists for, and they get no $TMUX_PANE.
+	//
+	// $TMUX has to be set for the pane to mean anything: a GUI launcher can
+	// inherit a stale $TMUX_PANE from whatever started it, and tmux has no
+	// caller to resolve from outside a session anyway.
+	if pane := t.os.Getenv(tmuxPaneEnv); pane != "" && tmuxEnv != "" {
+		slog.Debug("tmux: leaving client resolution to tmux", "pane", pane)
 		return ""
 	}
-	if sessionID := currentSessionID(t.os.Getenv("TMUX")); sessionID != "" {
+	clients, err := t.ListClients()
+	if err != nil {
+		// Almost always the tmux binary being unreachable — a GUI launcher
+		// hands sesh a bare PATH that Homebrew isn't on. Nothing downstream can
+		// work, and every caller degrades to doing nothing visible, so this
+		// cannot be a debug line.
+		slog.Error("tmux: could not list clients", "error", err, "tmuxCommand", t.bin)
+		return ""
+	}
+	if len(clients) == 0 {
+		slog.Debug("tmux: no clients attached")
+		return ""
+	}
+	sessionID := currentSessionID(tmuxEnv)
+	if sessionID != "" {
 		if client := mostRecent(clients, sessionID); client != "" {
+			slog.Debug("tmux: resolved client from calling session", "client", client, "session", sessionID)
 			return client
 		}
 	}
-	return mostRecent(clients, "")
+	client := mostRecent(clients, "")
+	slog.Debug("tmux: resolved most recently active client", "client", client, "callingSession", sessionID, "clients", clients)
+	return client
 }
 
 // switchClient moves the resolved client, falling back to letting tmux pick

--- a/tmux/client_test.go
+++ b/tmux/client_test.go
@@ -44,6 +44,7 @@ func TestResolveClient(t *testing.T) {
 	tests := []struct {
 		name       string
 		seshClient string
+		tmuxPane   string
 		tmuxEnv    string
 		clients    []string
 		clientsErr error
@@ -52,9 +53,20 @@ func TestResolveClient(t *testing.T) {
 		{
 			name:       "SESH_CLIENT wins outright",
 			seshClient: "/dev/ttys009",
+			tmuxPane:   "%3",
 			tmuxEnv:    "/tmp/default,3746,1",
 			clients:    clientLines(onSession1),
 			expected:   "/dev/ttys009",
+		},
+		{
+			// From a pane tmux resolves the client from $TMUX_PANE exactly.
+			// Guessing over the top of that is how sesh ended up moving a
+			// terminal the user wasn't looking at.
+			name:     "defers to tmux when the caller has a pane",
+			tmuxPane: "%3",
+			tmuxEnv:  "/tmp/default,3746,1",
+			clients:  clientLines(onSession1, onSession2),
+			expected: "",
 		},
 		{
 			// The popup case: tmux would guess ttys002 as most recently
@@ -83,6 +95,16 @@ func TestResolveClient(t *testing.T) {
 			expected: "/dev/ttys002",
 		},
 		{
+			// A GUI launcher can inherit a stale $TMUX_PANE from whatever
+			// started it. Outside tmux there is no caller for tmux to resolve
+			// from, so the pane must not short-circuit resolution.
+			name:     "ignores a stale pane when outside tmux",
+			tmuxPane: "%3",
+			tmuxEnv:  "",
+			clients:  clientLines(onSession1, onSession2),
+			expected: "/dev/ttys002",
+		},
+		{
 			name:     "no clients attached",
 			tmuxEnv:  "/tmp/default,3746,1",
 			clients:  clientLines(),
@@ -102,9 +124,13 @@ func TestResolveClient(t *testing.T) {
 			mockShell := shell.NewMockShell(t)
 			mockOs.EXPECT().Getenv("SESH_CLIENT").Return(tt.seshClient)
 			if tt.seshClient == "" {
+				mockOs.EXPECT().Getenv("TMUX").Return(tt.tmuxEnv)
+				mockOs.EXPECT().Getenv("TMUX_PANE").Return(tt.tmuxPane)
+			}
+			// A pane only short-circuits resolution from inside tmux.
+			if tt.seshClient == "" && !(tt.tmuxPane != "" && tt.tmuxEnv != "") {
 				mockShell.EXPECT().ListCmd("tmux", "list-clients", "-F", clientFormat).
 					Return(tt.clients, tt.clientsErr)
-				mockOs.EXPECT().Getenv("TMUX").Return(tt.tmuxEnv).Maybe()
 			}
 			tm := NewTmux(mockOs, mockShell, "")
 			assert.Equal(t, tt.expected, tm.ResolveClient())
@@ -116,6 +142,7 @@ func TestSwitchOrAttachNamesTheResolvedClient(t *testing.T) {
 	mockOs := oswrap.NewMockOs(t)
 	mockShell := shell.NewMockShell(t)
 	mockOs.EXPECT().Getenv("SESH_CLIENT").Return("")
+	mockOs.EXPECT().Getenv("TMUX_PANE").Return("")
 	mockOs.EXPECT().Getenv("TMUX").Return("/tmp/default,3746,1")
 	mockShell.EXPECT().ListCmd("tmux", "list-clients", "-F", clientFormat).
 		Return([]string{

--- a/tmux/switch_or_attach_test.go
+++ b/tmux/switch_or_attach_test.go
@@ -15,6 +15,8 @@ import (
 // to a bare `switch-client -t` and lets tmux pick the client itself.
 func stubNoClients(mockOs *oswrap.MockOs, mockShell *shell.MockShell, bin string) {
 	mockOs.On("Getenv", "SESH_CLIENT").Return("")
+	mockOs.On("Getenv", "TMUX_PANE").Return("")
+	mockOs.On("Getenv", "TMUX").Return("").Maybe()
 	mockShell.On("ListCmd", bin, "list-clients", "-F", clientFormat).Return([]string{""}, nil)
 }
 


### PR DESCRIPTION
## The bug

A GUI launcher — Leader Key, Raycast, an osascript binding — runs sesh with whatever PATH launchd handed the app, which on macOS is `/usr/bin:/bin:/usr/sbin:/sbin`. Homebrew isn't on it, and `tmux` lives at `/opt/homebrew/bin/tmux`. So every tmux call fails:

```
exec: "tmux": executable file not found in $PATH
```

while the focuser's `/usr/bin/osascript` still works. sesh brought the terminal forward, changed nothing, and reported success — indistinguishable from a switch that worked.

Nothing surfaced it. `connectToTmux` discarded `NewSession`'s error outright, and `ResolveClient` logged the `list-clients` failure at `Debug`, which the default log level doesn't write. `sesh list` kept answering from cache, so the setup looked healthy.

Reproduced against a live server with only PATH replaced:

```
$ env PATH=/usr/bin:/bin:/usr/sbin:/sbin sesh connect --switch update
# before: terminal focused, client unmoved, exit 0, nothing logged
# after:  Failed to create tmux session "update": exec: "tmux": executable file not found in $PATH
```

## What changed

- `connectToTmux` returns `NewSession`'s error instead of discarding it. Everything after it assumes the session exists.
- `connectDetached` checks that tmux is reachable separately from choosing a client. The two failures are indistinguishable through `ResolveClient`'s empty string but need opposite handling: an unreachable tmux is fatal, while a server with **no clients attached** has nothing to switch and is still worth focusing the terminal for. That second case is unchanged.
- `ResolveClient` logs a `list-clients` failure at `Error`. It's never a debug-level event — nothing downstream can work.
- Narrows the `$TMUX_PANE` short-circuit added in 3f2a3aa to also require `$TMUX`. A launcher can inherit a stale `$TMUX_PANE` from whatever started it, and outside a session there's no caller for tmux to resolve from, so the pane must not suppress resolution.

## Not a fix for the PATH itself

This makes the failure legible; it doesn't make Homebrew reachable. The launcher still needs a usable PATH:

```
/usr/bin/env PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin sesh worktree connect --browser --switch
```

Worth noting `tmux_command` in `sesh.toml` is *not* sufficient here — the worktree flow also shells out to `git` and `gh`, both in `/opt/homebrew/bin`.

## Tests

Updated expectations for the new `ListClients` call in `connectDetached`, plus new cases for unreachable tmux and for a stale `$TMUX_PANE` with no `$TMUX`. Full suite passes.

Refs #451
