### PR TITLE
feat: merge sources into one score-ordered picker group

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,6 +744,43 @@ sort_order = [
 ]
 ```
 
+#### Merging sources into one score-ordered group
+
+By default every source is its own block, so a config session you open daily
+still sits below zoxide paths you haven't touched in weeks. Nest sources in
+`sort_order` to merge them into a single block ordered by zoxide score, highest
+first:
+
+```toml
+sort_order = [
+  "tmux",                # live sessions stay pinned on top
+  ["config", "zoxide"],  # merged, ordered by zoxide score
+]
+```
+
+Sessions from a source that carries no score of its own — a `[[session]]` block,
+for instance — borrow the score zoxide has for their path, so they sort by how
+often that directory is actually visited. A path zoxide has never seen scores 0
+and trails the group.
+
+Groups still appear in the order they're listed, and a flat `sort_order` behaves
+exactly as it always has: merging is opt-in.
+
+#### Group separator
+
+Once sources are interleaved, the boundary between live tmux sessions and
+everywhere else stops being obvious from position alone. `group_separator` draws
+a faint rule between the `sort_order` groups in the picker:
+
+```toml
+[tui]
+group_separator = true
+```
+
+The rule is never selectable and the cursor steps straight over it. It is
+suppressed while you're filtering, where results are reordered by match quality
+and the groups no longer line up with contiguous ranges.
+
 ### Cache
 
 > [!WARNING]
@@ -784,6 +821,7 @@ prompt = "> "
 placeholder = "Filter sessions... "
 show_icons = false
 show_windows = false
+group_separator = false
 window_name_format = "#{window_name}"
 alias_auto_connect_delay = "150ms"
 alias_filter_prefix = "/"

--- a/configurator/configurator_test.go
+++ b/configurator/configurator_test.go
@@ -473,3 +473,38 @@ func TestValidateNameSubstitutions(t *testing.T) {
 		})
 	}
 }
+
+func TestGetConfig_SortOrderFlat(t *testing.T) {
+	config, err := configFromTOML(t, "sort_order = [\"tmux\", \"config\", \"zoxide\"]\n")
+	assert.NoError(t, err)
+	assert.Equal(t, []model.SortGroup{{"tmux"}, {"config"}, {"zoxide"}}, config.SortOrder.SortGroups())
+}
+
+func TestGetConfig_SortOrderNestedGroup(t *testing.T) {
+	config, err := configFromTOML(t, "sort_order = [\"tmux\", [\"config\", \"zoxide\"]]\n")
+	assert.NoError(t, err)
+	assert.Equal(t, []model.SortGroup{{"tmux"}, {"config", "zoxide"}}, config.SortOrder.SortGroups())
+}
+
+func TestGetConfig_SortOrderNestedGroupStrictMode(t *testing.T) {
+	config, err := configFromTOML(t, "strict_mode = true\nsort_order = [\"tmux\", [\"config\", \"zoxide\"]]\n")
+	assert.NoError(t, err)
+	assert.Equal(t, []model.SortGroup{{"tmux"}, {"config", "zoxide"}}, config.SortOrder.SortGroups())
+}
+
+func TestGetConfig_SortOrderIgnoresUnusableEntries(t *testing.T) {
+	config, err := configFromTOML(t, "sort_order = [\"tmux\", 7, [], [\"config\", 3]]\n")
+	assert.NoError(t, err)
+	assert.Equal(t, []model.SortGroup{{"tmux"}, {"config"}}, config.SortOrder.SortGroups(),
+		"a malformed sort_order costs the ordering it asked for, never the sessions")
+}
+
+func TestGetConfig_GroupSeparator(t *testing.T) {
+	config, err := configFromTOML(t, "")
+	assert.NoError(t, err)
+	assert.False(t, config.TUI.GroupSeparator, "opt-in")
+
+	config, err = configFromTOML(t, "[tui]\ngroup_separator = true\n")
+	assert.NoError(t, err)
+	assert.True(t, config.TUI.GroupSeparator)
+}

--- a/lister/list.go
+++ b/lister/list.go
@@ -1,6 +1,7 @@
 package lister
 
 import (
+	"cmp"
 	"slices"
 	"sync"
 
@@ -42,8 +43,8 @@ func (l *RealLister) List(opts ListOptions) (model.SeshSessions, error) {
 	fullDirectory := make(model.SeshSessionMap)
 	fullOrderedIndex := make([]string, 0)
 
-	srcsOrderedIndex := srcs(opts)
-	srcsOrderedIndex = sortSources(srcsOrderedIndex, l.config.SortOrder)
+	srcGroups := groupSources(srcs(opts), l.config.SortOrder)
+	srcsOrderedIndex := slices.Concat(srcGroups...)
 
 	resultsChan := make(chan strategyResult, len(srcsOrderedIndex))
 	var wg sync.WaitGroup
@@ -81,11 +82,22 @@ func (l *RealLister) List(opts ListOptions) (model.SeshSessions, error) {
 		resultsMap[res.source] = res.sessions
 	}
 
+	// The directory is filled first so a merged group can look a session up by
+	// key while it orders the group.
 	for _, src := range srcsOrderedIndex {
 		sessions := resultsMap[src]
-		fullOrderedIndex = append(fullOrderedIndex, sessions.OrderedIndex...)
 		for _, i := range sessions.OrderedIndex {
 			fullDirectory[i] = sessions.Directory[i]
+		}
+	}
+
+	scores := zoxideScores(resultsMap["zoxide"])
+	for group, sources := range srcGroups {
+		for _, key := range groupOrder(sources, resultsMap, fullDirectory, scores) {
+			session := fullDirectory[key]
+			session.Group = group
+			fullDirectory[key] = session
+			fullOrderedIndex = append(fullOrderedIndex, key)
 		}
 	}
 
@@ -134,4 +146,47 @@ func (l *RealLister) List(opts ListOptions) (model.SeshSessions, error) {
 	attachWindowNames(sessions, windowNames)
 
 	return sessions, nil
+}
+
+// groupOrder lays out one sort_order group's sessions. A group of one keeps the
+// order its source returned. A merged group is reordered by zoxide score,
+// highest first, so the block reads as "what am I working on right now" rather
+// than "which source did this come from".
+func groupOrder(sources []string, results map[string]model.SeshSessions, directory model.SeshSessionMap, scores map[string]float64) []string {
+	index := make([]string, 0)
+	for _, src := range sources {
+		index = append(index, results[src].OrderedIndex...)
+	}
+	if len(sources) < 2 {
+		return index
+	}
+	// Stable, so the sessions zoxide has never seen keep their source order
+	// behind the scored ones instead of being shuffled among themselves.
+	slices.SortStableFunc(index, func(a, b string) int {
+		return cmp.Compare(sessionScore(directory[b], scores), sessionScore(directory[a], scores))
+	})
+	return index
+}
+
+// zoxideScores indexes the scores already fetched for the zoxide source by
+// path, so scoring the other sources in a merged group costs no extra lookups.
+func zoxideScores(sessions model.SeshSessions) map[string]float64 {
+	scores := make(map[string]float64, len(sessions.OrderedIndex))
+	for _, key := range sessions.OrderedIndex {
+		session := sessions.Directory[key]
+		scores[session.Path] = session.Score
+	}
+	return scores
+}
+
+// sessionScore is the score a session sorts by inside a merged group: its own
+// when it came from zoxide, otherwise whatever zoxide has for its path. A path
+// zoxide has never seen scores 0 and trails the group, which is the point —
+// somewhere never actually visited doesn't belong at the top of a frecency
+// ordered list.
+func sessionScore(session model.SeshSession, scores map[string]float64) float64 {
+	if session.Score != 0 {
+		return session.Score
+	}
+	return scores[session.Path]
 }

--- a/lister/list_test.go
+++ b/lister/list_test.go
@@ -337,3 +337,82 @@ func TestList_ShowWindows(t *testing.T) {
 		mockTmux.AssertNotCalled(t, "ListAllWindowNames")
 	})
 }
+
+func TestMergedSortOrderGroup(t *testing.T) {
+	mockTmux := new(tmux.MockTmux)
+	mockZoxide := new(zoxide.MockZoxide)
+	mockHome := new(home.MockHome)
+	mockTmuxinator := new(tmuxinator.MockTmuxinator)
+
+	mockTmux.On("ListSessions").Return([]*model.TmuxSession{
+		{Name: "live", Path: "/live"},
+	}, nil)
+	mockZoxide.On("ListResults").Return([]*model.ZoxideResult{
+		{Path: "/hot", Score: 90},
+		{Path: "/notes", Score: 20},
+		{Path: "/cold", Score: 1},
+	}, nil)
+	for path, short := range map[string]string{"/hot": "hot", "/notes": "notes", "/cold": "cold"} {
+		mockHome.On("ShortenHome", path).Return(short, nil)
+	}
+	mockHome.On("ExpandPath", "/notes").Return("/notes", nil)
+	mockHome.On("ExpandPath", "/never").Return("/never", nil)
+
+	config := model.Config{
+		// "notes" is a config session zoxide also knows: it should sort by the
+		// score zoxide has for its path, not by coming from the config source.
+		SessionConfigs: []model.SessionConfig{
+			{Name: "notes-cfg", Path: "/notes"},
+			{Name: "never-cfg", Path: "/never"},
+		},
+		SortOrder: model.SortOrder{"tmux", []string{"config", "zoxide"}},
+	}
+	l := NewLister(config, mockHome, mockTmux, mockZoxide, mockTmuxinator)
+
+	result, err := l.List(ListOptions{Tmux: true, Config: true, Zoxide: true})
+	assert.NoError(t, err)
+
+	names := make([]string, 0, len(result.OrderedIndex))
+	groups := make([]int, 0, len(result.OrderedIndex))
+	for _, key := range result.OrderedIndex {
+		names = append(names, result.Directory[key].Name)
+		groups = append(groups, result.Directory[key].Group)
+	}
+
+	// tmux stays pinned in its own group; config and zoxide interleave by
+	// score, and the config session zoxide has never seen trails the group.
+	assert.Equal(t, []string{"live", "hot", "notes-cfg", "notes", "cold", "never-cfg"}, names)
+	assert.Equal(t, []int{0, 1, 1, 1, 1, 1}, groups)
+}
+
+func TestFlatSortOrderKeepsSourceBlocks(t *testing.T) {
+	mockTmux := new(tmux.MockTmux)
+	mockZoxide := new(zoxide.MockZoxide)
+	mockHome := new(home.MockHome)
+	mockTmuxinator := new(tmuxinator.MockTmuxinator)
+
+	mockZoxide.On("ListResults").Return([]*model.ZoxideResult{
+		{Path: "/hot", Score: 90},
+	}, nil)
+	mockHome.On("ShortenHome", "/hot").Return("hot", nil)
+	mockHome.On("ExpandPath", "/never").Return("/never", nil)
+
+	config := model.Config{
+		SessionConfigs: []model.SessionConfig{{Name: "never-cfg", Path: "/never"}},
+		SortOrder:      model.SortOrder{"config", "zoxide"},
+	}
+	l := NewLister(config, mockHome, mockTmux, mockZoxide, mockTmuxinator)
+
+	result, err := l.List(ListOptions{Config: true, Zoxide: true})
+	assert.NoError(t, err)
+
+	names := make([]string, 0, len(result.OrderedIndex))
+	groups := make([]int, 0, len(result.OrderedIndex))
+	for _, key := range result.OrderedIndex {
+		names = append(names, result.Directory[key].Name)
+		groups = append(groups, result.Directory[key].Group)
+	}
+	// Unmerged, the unscored config session still leads its own block.
+	assert.Equal(t, []string{"never-cfg", "hot"}, names)
+	assert.Equal(t, []int{0, 1}, groups)
+}

--- a/lister/srcs.go
+++ b/lister/srcs.go
@@ -5,29 +5,82 @@ import (
 	"math"
 	"slices"
 	"strings"
+
+	"github.com/joshmedeski/sesh/v2/model"
 )
 
 // returns a sorted list of sources based on the provided sort order.
-func sortSources(sources, sortOrder []string) []string {
-	if sortOrder == nil || len(sortOrder) == 0 {
-		return sources
+func sortSources(sources []string, sortOrder model.SortOrder) []string {
+	return slices.Concat(groupSources(sources, sortOrder)...)
+}
+
+// groupSources orders the active sources by sort_order and reports which of
+// them share a block. A nested sort_order entry puts its sources in one group,
+// whose sessions List merges and orders by score; every other source is a group
+// of one, listed on its own exactly as it always has been.
+//
+// Sources sort_order doesn't mention keep their relative order and trail the
+// ones it does, each as its own group.
+func groupSources(sources []string, sortOrder model.SortOrder) [][]string {
+	groups := sortOrder.SortGroups()
+	if len(groups) == 0 {
+		return singletonGroups(sources)
 	}
-	m := make(map[string]int)
-	for i, s := range sortOrder {
-		m[strings.ToLower(s)] = i
-	}
-	getOrder := func(s string) int {
-		if order, exists := m[strings.ToLower(s)]; exists {
-			return order
-		} else {
-			return math.MaxInt
+	// A source named more than once takes the last position it was given, so
+	// the group it ends up in is the last one that claimed it.
+	m := make(map[string]srcPos)
+	for i, group := range groups {
+		for j, src := range group {
+			m[strings.ToLower(src)] = srcPos{group: i, within: j}
 		}
+	}
+	unlisted := srcPos{group: math.MaxInt, within: math.MaxInt}
+	getOrder := func(s string) srcPos {
+		if pos, exists := m[strings.ToLower(s)]; exists {
+			return pos
+		}
+		return unlisted
 	}
 	result := slices.Clone(sources)
 	slices.SortStableFunc(result, func(a, b string) int {
-		return cmp.Compare(getOrder(a), getOrder(b))
+		pa, pb := getOrder(a), getOrder(b)
+		if pa.group != pb.group {
+			return cmp.Compare(pa.group, pb.group)
+		}
+		return cmp.Compare(pa.within, pb.within)
 	})
-	return result
+
+	grouped := make([][]string, 0, len(result))
+	prev := math.MaxInt
+	for _, src := range result {
+		group := getOrder(src).group
+		// MaxInt is "unlisted" rather than a shared position, so those sources
+		// never merge with each other.
+		if group != math.MaxInt && group == prev && len(grouped) > 0 {
+			last := len(grouped) - 1
+			grouped[last] = append(grouped[last], src)
+			continue
+		}
+		grouped = append(grouped, []string{src})
+		prev = group
+	}
+	return grouped
+}
+
+// srcPos is where sort_order puts a source: which group, and where inside it.
+// The position inside the group is what breaks ties between sessions a merged
+// group scores the same, so a group reads in the order it was written.
+type srcPos struct {
+	group  int
+	within int
+}
+
+func singletonGroups(sources []string) [][]string {
+	groups := make([][]string, len(sources))
+	for i, src := range sources {
+		groups[i] = []string{src}
+	}
+	return groups
 }
 
 func srcs(opts ListOptions) []string {

--- a/lister/srcs_test.go
+++ b/lister/srcs_test.go
@@ -4,36 +4,38 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/joshmedeski/sesh/v2/model"
 )
 
 func TestSortSources(t *testing.T) {
 	defaultSources := []string{"tmux", "config", "tmuxinator", "zoxide"}
 	tests := map[string]struct {
-		sortOrder []string
+		sortOrder model.SortOrder
 		expected  []string
 	}{
 		"a normal configuration": {
-			sortOrder: []string{"tmuxinator", "zoxide", "config", "tmux"},
+			sortOrder: model.SortOrder{"tmuxinator", "zoxide", "config", "tmux"},
 			expected:  []string{"tmuxinator", "zoxide", "config", "tmux"},
 		},
 		"empty configuration": {
-			sortOrder: []string{},
+			sortOrder: model.SortOrder{},
 			expected:  []string{"tmux", "config", "tmuxinator", "zoxide"},
 		},
 		"partial configuration": {
-			sortOrder: []string{"tmuxinator"},
+			sortOrder: model.SortOrder{"tmuxinator"},
 			expected:  []string{"tmuxinator", "tmux", "config", "zoxide"},
 		},
 		"superfluous elements": {
-			sortOrder: []string{"tmuxinator", "apple", "zoxide", "banana", "config", "chocolate", "tmux"},
+			sortOrder: model.SortOrder{"tmuxinator", "apple", "zoxide", "banana", "config", "chocolate", "tmux"},
 			expected:  []string{"tmuxinator", "zoxide", "config", "tmux"},
 		},
 		"configuration with capitalization": {
-			sortOrder: []string{"tMuxiNator", "Zoxide", "conFIg", "tmux"},
+			sortOrder: model.SortOrder{"tMuxiNator", "Zoxide", "conFIg", "tmux"},
 			expected:  []string{"tmuxinator", "zoxide", "config", "tmux"},
 		},
 		"configuration with duplicate elements": {
-			sortOrder: []string{"tmuxinator", "zoxide", "tmuxinator", "config", "tmuxinator", "tmux", "tmuxinator", "tmuxinator"},
+			sortOrder: model.SortOrder{"tmuxinator", "zoxide", "tmuxinator", "config", "tmuxinator", "tmux", "tmuxinator", "tmuxinator"},
 			expected:  []string{"zoxide", "config", "tmux", "tmuxinator"},
 		},
 	}
@@ -41,6 +43,48 @@ func TestSortSources(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			actual := sortSources(defaultSources, tt.sortOrder)
 			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestGroupSources(t *testing.T) {
+	defaultSources := []string{"tmux", "config", "tmuxinator", "zoxide"}
+	tests := map[string]struct {
+		sortOrder model.SortOrder
+		expected  [][]string
+	}{
+		"no sort order leaves every source on its own": {
+			sortOrder: nil,
+			expected:  [][]string{{"tmux"}, {"config"}, {"tmuxinator"}, {"zoxide"}},
+		},
+		"a flat sort order leaves every source on its own": {
+			sortOrder: model.SortOrder{"zoxide", "tmux", "config", "tmuxinator"},
+			expected:  [][]string{{"zoxide"}, {"tmux"}, {"config"}, {"tmuxinator"}},
+		},
+		"a nested entry merges its sources into one group": {
+			sortOrder: model.SortOrder{"tmux", []string{"config", "zoxide"}, "tmuxinator"},
+			expected:  [][]string{{"tmux"}, {"config", "zoxide"}, {"tmuxinator"}},
+		},
+		"a nested entry decoded from toml merges too": {
+			sortOrder: model.SortOrder{"tmux", []any{"config", "zoxide"}},
+			expected:  [][]string{{"tmux"}, {"config", "zoxide"}, {"tmuxinator"}},
+		},
+		"unlisted sources trail as groups of one": {
+			sortOrder: model.SortOrder{[]string{"zoxide", "tmux"}},
+			expected:  [][]string{{"zoxide", "tmux"}, {"config"}, {"tmuxinator"}},
+		},
+		"a source named twice joins the last group that claims it": {
+			sortOrder: model.SortOrder{[]string{"tmux", "zoxide"}, []string{"config", "zoxide"}},
+			expected:  [][]string{{"tmux"}, {"config", "zoxide"}, {"tmuxinator"}},
+		},
+		"a group naming only inactive sources is skipped": {
+			sortOrder: model.SortOrder{[]string{"apple", "banana"}, "zoxide"},
+			expected:  [][]string{{"zoxide"}, {"tmux"}, {"config"}, {"tmuxinator"}},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, groupSources(defaultSources, tt.sortOrder))
 		})
 	}
 }

--- a/model/config.go
+++ b/model/config.go
@@ -45,7 +45,7 @@ type (
 		DefaultSessionConfig    DefaultSessionConfig `toml:"default_session"`
 		Blacklist               []string             `toml:"blacklist"`
 		SessionConfigs          []SessionConfig      `toml:"session"`
-		SortOrder               []string             `toml:"sort_order"`
+		SortOrder               SortOrder            `toml:"sort_order"`
 		WindowConfigs           []WindowConfig       `toml:"window"`
 		WildcardConfigs         []WildcardConfig     `toml:"wildcard"`
 		WorktreeConfigs         []WorktreeConfig     `toml:"worktree"`
@@ -63,6 +63,19 @@ type (
 	Evaluation struct {
 		StrictMode bool `toml:"strict_mode"`
 	}
+
+	// SortOrder is `sort_order` as TOML hands it over: a list whose entries are
+	// either a source name or a nested list of source names. The nested form
+	// declares one merged group, whose sessions are ordered by zoxide score
+	// instead of source by source. A flat list is every source on its own,
+	// which is how the list has always been built.
+	//
+	// It is []any because the array is heterogeneous; SortGroups normalizes it.
+	SortOrder []any
+
+	// SortGroup is one block of the session list: a single source, or several
+	// sources merged and score-ordered.
+	SortGroup []string
 
 	// FrecencyConfig overrides the commands used to drive the frecency
 	// directory-jumping backend (zoxide by default). Each command may be
@@ -171,6 +184,12 @@ type (
 		// pane: "line" (default), "thick", "double", or "none" for no divider.
 		// Empty means unset.
 		PreviewBorder string `toml:"preview_border"`
+		// GroupSeparator draws a faint rule between the sort_order groups in
+		// the picker, so the boundary between live tmux sessions and everywhere
+		// else is visible once a merged group interleaves the sources. Opt-in:
+		// with a flat sort_order every source is its own group, and a rule
+		// between each of them is more lines than most lists want.
+		GroupSeparator bool `toml:"group_separator"`
 	}
 
 	WildcardConfig struct {
@@ -206,3 +225,31 @@ type (
 		URLCommand  string `toml:"url_command"` // AppleScript fragment; default "URL of active tab of front window"
 	}
 )
+
+// SortGroups normalizes the raw sort_order into the groups the list is built
+// from. Entries that are neither a source name nor a list of them are dropped:
+// a malformed sort_order costs the ordering it asked for, never the sessions.
+func (s SortOrder) SortGroups() []SortGroup {
+	groups := make([]SortGroup, 0, len(s))
+	for _, entry := range s {
+		switch v := entry.(type) {
+		case string:
+			groups = append(groups, SortGroup{v})
+		case []string:
+			if len(v) > 0 {
+				groups = append(groups, SortGroup(v))
+			}
+		case []any:
+			group := make(SortGroup, 0, len(v))
+			for _, name := range v {
+				if src, ok := name.(string); ok {
+					group = append(group, src)
+				}
+			}
+			if len(group) > 0 {
+				groups = append(groups, group)
+			}
+		}
+	}
+	return groups
+}

--- a/model/sesh_session.go
+++ b/model/sesh_session.go
@@ -25,6 +25,12 @@ type (
 		WindowConfigs         []WindowConfig // The windows used in session config
 		WindowNames           []string       // The names of the windows in session config
 		Score                 float64        // The score of the session (from Zoxide)
+
+		// Group is the index of the sort_order block this session was listed
+		// under. Sessions sharing one are contiguous in OrderedIndex, which is
+		// what the picker draws its group separator from. It is not part of
+		// `sesh list --json`: it describes the list, not the session.
+		Group int `json:"-"`
 	}
 
 	SeshSrcs struct {

--- a/picker/picker.go
+++ b/picker/picker.go
@@ -209,6 +209,7 @@ func (p *RealPicker) Pick(fetchFunc FetchFunc, opts PickerOptions) (string, erro
 		PreviewMinWidth:         previewMinWidth(p.config.TUI.PreviewMinWidth),
 		PreviewBorder:           p.config.TUI.PreviewBorder,
 		PreviewFunc:             previewFunc,
+		GroupSeparator:          p.config.TUI.GroupSeparator,
 	})
 	prog := tea.NewProgram(m)
 	result, err := prog.Run()

--- a/picker/picker_test.go
+++ b/picker/picker_test.go
@@ -2019,3 +2019,89 @@ func TestIndexGutter_RunsOutAfterNine(t *testing.T) {
 	assert.Equal(t, "  ", indexGutter(maxIndexJump, style),
 		"rows past the ninth are unreachable, and blanks keep the names aligned")
 }
+
+// groupedSessions is testSessions with the sources split across two sort_order
+// groups: tmux pinned on top, everything else merged below it.
+func groupedSessions() model.SeshSessions {
+	sessions := testSessions()
+	sessions.OrderedIndex = []string{"s1", "s5", "s2", "s3", "s4"}
+	for key, group := range map[string]int{"s1": 0, "s5": 0, "s2": 1, "s3": 1, "s4": 1} {
+		session := sessions.Directory[key]
+		session.Group = group
+		sessions.Directory[key] = session
+	}
+	return sessions
+}
+
+func newGroupedTestModel(separator bool) Model {
+	sessions := groupedSessions()
+	m := New(testFetchFunc(sessions), testOptionsWith(func(o *Options) {
+		o.GroupSeparator = separator
+	}))
+	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
+	m = result.(Model)
+	m.width = 60
+	m.height = 24
+	return m
+}
+
+func TestGroupSeparator_DrawnBetweenGroups(t *testing.T) {
+	m := newGroupedTestModel(true)
+
+	require.Len(t, m.rows, 6, "one rule laid in between the two groups")
+	assert.True(t, m.rows[2].separator)
+	assert.Equal(t, []int{0, 1, 3, 4, 5}, m.rowOf)
+
+	lines := strings.Split(ansi.Strip(m.View().Content), "\n")
+	assert.Contains(t, lines[3], "notes")
+	assert.Contains(t, lines[4], "─")
+	assert.Contains(t, lines[5], "dotfiles")
+}
+
+func TestGroupSeparator_OffByDefault(t *testing.T) {
+	m := newGroupedTestModel(false)
+
+	assert.Len(t, m.rows, 5)
+	assert.NotContains(t, ansi.Strip(m.View().Content), "─")
+}
+
+func TestGroupSeparator_SuppressedWhileFiltering(t *testing.T) {
+	m := newGroupedTestModel(true)
+
+	m.filterInput.SetValue("o")
+	m.applyFilter()
+
+	for _, row := range m.rows {
+		assert.False(t, row.separator, "no rule while the list is reordered by match quality")
+	}
+	assert.NotContains(t, ansi.Strip(m.View().Content), "─")
+}
+
+func TestGroupSeparator_CursorSkipsIt(t *testing.T) {
+	m := newGroupedTestModel(true)
+
+	// The cursor indexes sessions, so stepping over the boundary lands on the
+	// first session of the next group rather than on the rule.
+	m.cursor = 1
+	m.cursorDown(1)
+	assert.Equal(t, 2, m.cursor)
+	assert.Equal(t, "dotfiles", m.filtered[m.cursor].item.name)
+
+	m.cursorUp(1)
+	assert.Equal(t, 1, m.cursor)
+	assert.Equal(t, "notes", m.filtered[m.cursor].item.name)
+}
+
+func TestGroupSeparator_ScrollCountsTheRule(t *testing.T) {
+	m := newGroupedTestModel(true)
+	// Three visible lines: filter row, blank, and one session row short of the
+	// list, so the rule has to be paid for out of the same budget.
+	m.height = headerLines + 3
+
+	m.cursorDown(4)
+	assert.Equal(t, 4, m.cursor)
+	assert.Equal(t, 3, m.offset, "the rule occupies a line the viewport must scroll past")
+
+	lines := strings.Split(ansi.Strip(m.View().Content), "\n")
+	assert.Contains(t, lines[len(lines)-1], "rails-app")
+}

--- a/picker/picker_test.go
+++ b/picker/picker_test.go
@@ -1005,6 +1005,72 @@ func TestAliasChip_HighlightsMatchedPrefix(t *testing.T) {
 		"a match longer than the alias is clamped rather than panicking")
 }
 
+func TestAliasChip_HighlightsCaps(t *testing.T) {
+	m := newAliasModel(func(o *Options) { o.ShowIcons = true })
+
+	// The caps join the match block so the highlight is one shape: the left one
+	// as soon as anything matches, the right one only on a full match.
+	assert.NotEqual(t, m.aliasChip("my-project", 0), m.aliasChip("my-project", 1),
+		"the left cap must be highlighted once the alias starts matching")
+	partial, full := m.aliasChip("my-project", 1), m.aliasChip("my-project", 2)
+	assert.Equal(t, strings.Count(full, chipRightGlyph), 1)
+	assert.NotEqual(t, styleOf(partial, chipRightGlyph), styleOf(full, chipRightGlyph),
+		"the right cap is only highlighted once the whole alias matches")
+	assert.Equal(t, styleOf(partial, chipLeftGlyph), styleOf(full, chipLeftGlyph),
+		"the left cap stays highlighted for a partial and a full match alike")
+
+	plain := newAliasModel()
+	assert.Equal(t, "[wp] ", ansi.Strip(plain.aliasChip("my-project", 2)),
+		"highlighting the brackets must not change the text of the chip")
+	assert.NotEqual(t, styleOf(plain.aliasChip("my-project", 0), "]"),
+		styleOf(plain.aliasChip("my-project", 2), "]"),
+		"the bracket fallback highlights its caps too")
+}
+
+// styleOf returns the escape sequence rendered immediately before glyph, which
+// is the styling applied to it.
+func styleOf(s, glyph string) string {
+	before, _, found := strings.Cut(s, glyph)
+	if !found {
+		return ""
+	}
+	start := strings.LastIndex(before, "\x1b[")
+	if start < 0 {
+		return ""
+	}
+	return before[start:]
+}
+
+func TestFilter_HighlightsChipInNormalMode(t *testing.T) {
+	m := newAliasModel()
+
+	// Typing normally, with no sigil, still fills in the chip of any session
+	// whose alias the query prefixes.
+	m.filterInput.SetValue("do")
+	m.applyFilter()
+	require.Len(t, m.filtered, 1)
+	assert.Equal(t, "dotfiles", m.filtered[0].item.name)
+	assert.Equal(t, 2, m.filtered[0].chipMatchLen, "the typed prefix of the alias is highlighted")
+
+	// An exactly typed alias resolves to its target and fills the whole chip.
+	m.filterInput.SetValue("dot")
+	m.applyFilter()
+	require.Len(t, m.filtered, 1)
+	assert.Equal(t, 3, m.filtered[0].chipMatchLen)
+
+	// Aliases are matched case-insensitively, like the filter itself.
+	m.filterInput.SetValue("DO")
+	m.applyFilter()
+	require.Len(t, m.filtered, 1)
+	assert.Equal(t, 2, m.filtered[0].chipMatchLen)
+
+	// A query that matches the name but not the alias leaves the chip plain.
+	m.filterInput.SetValue("files")
+	m.applyFilter()
+	require.Len(t, m.filtered, 1)
+	assert.Equal(t, 0, m.filtered[0].chipMatchLen, "only alias prefixes highlight the chip")
+}
+
 func TestView_AliasChip(t *testing.T) {
 	m := newAliasModel()
 	out := ansi.Strip(fmt.Sprintf("%v", m.View()))

--- a/picker/tui.go
+++ b/picker/tui.go
@@ -284,38 +284,57 @@ const (
 // is always the terminal's background color on its foreground color, which
 // stays legible under any color scheme. The half circles are left unstyled for
 // the same reason: their default foreground is exactly the color the reversed
-// label fills with, so the chip reads as one shape.
+// label fills with, so the chip reads as one shape — and so coloring one paints
+// the same block the reversed label does.
 func (m Model) aliasChip(name string, matchLen int) string {
 	alias, ok := m.aliasByName[name]
 	if !ok {
 		return ""
 	}
 
+	runes := []rune(alias)
+	matchLen = max(min(matchLen, len(runes)), 0)
+
 	label := lipgloss.NewStyle().Reverse(true)
-	text := highlightChipPrefix(alias, matchLen, label)
+	var text string
+	if matchLen > 0 {
+		text = label.Foreground(aliasMatchColor).Render(string(runes[:matchLen]))
+	}
+	if matchLen < len(runes) {
+		text += label.Render(string(runes[matchLen:]))
+	}
+
+	leftCap, rightCap := chipLeftGlyph, chipRightGlyph
+	capStyle := lipgloss.NewStyle()
 	if !m.showIcons {
 		// Without nerd fonts the half circles render as tofu, so fall back to
-		// brackets that still read as a chip.
-		return label.Render("[") + text + label.Render("]") + " "
+		// brackets that still read as a chip. They are part of the label rather
+		// than a glyph beside it, so they are reversed along with it.
+		leftCap, rightCap = "[", "]"
+		capStyle = label
 	}
-	return chipLeftGlyph + text + chipRightGlyph + " "
+	// The caps belong to the match block whenever the letters beside them do:
+	// the left one as soon as anything matches, the right one only once the
+	// whole alias has, so a full match reads as one unbroken chip.
+	return chipCap(capStyle, leftCap, matchLen > 0) +
+		text +
+		chipCap(capStyle, rightCap, matchLen > 0 && matchLen == len(runes)) + " "
 }
 
-// highlightChipPrefix styles the first matchLen runes of a chip label as
-// matched. Reverse video is kept throughout so the chip stays one shape;
-// setting a foreground under it paints the matched runes as a colored block,
-// which is the same green used to highlight matches in session names.
-func highlightChipPrefix(alias string, matchLen int, label lipgloss.Style) string {
-	runes := []rune(alias)
-	if matchLen <= 0 {
-		return label.Render(alias)
+// chipCap renders one end of the chip, painted into the match block when
+// matched so the highlight carries into the rounded end instead of stopping
+// short at the first or last letter.
+func chipCap(capStyle lipgloss.Style, glyph string, matched bool) string {
+	if matched {
+		return capStyle.Foreground(aliasMatchColor).Render(glyph)
 	}
-	if matchLen > len(runes) {
-		matchLen = len(runes)
-	}
-	matched := label.Foreground(lipgloss.ANSIColor(2)).Render(string(runes[:matchLen]))
-	return matched + label.Render(string(runes[matchLen:]))
+	return capStyle.Render(glyph)
 }
+
+// aliasMatchColor is the color matched alias runes are painted in. It is the
+// same green the matches in session names are drawn in, and under the chip's
+// reverse video it fills as a block of background rather than colored text.
+var aliasMatchColor = lipgloss.ANSIColor(2)
 
 // indexFilterPrefix is the sigil that, typed first, enters index mode: the rows
 // are numbered and the next digit jumps straight to one of them.
@@ -821,9 +840,12 @@ func (m *Model) filterSessions(pattern string) []filteredItem {
 	}
 
 	if item, ok := m.aliasMatch(pattern); ok {
-		return []filteredItem{{item: item}}
+		return []filteredItem{{item: item, chipMatchLen: m.chipMatchLen(item.name, pattern)}}
 	}
 
+	// The chip is matched against what was typed, not the normalized form, for
+	// the same reason aliasMatch is: an alias is matched literally.
+	typed := pattern
 	if m.separatorAware {
 		pattern = normalizeSeparators(pattern)
 	}
@@ -831,12 +853,30 @@ func (m *Model) filterSessions(pattern string) []filteredItem {
 	matches := rankMatches(fuzzy.FindFromNoSort(pattern, m.allItems))
 	filtered := make([]filteredItem, len(matches))
 	for i, match := range matches {
+		item := m.allItems[match.Index]
 		filtered[i] = filteredItem{
-			item:           m.allItems[match.Index],
+			item:           item,
 			matchedIndexes: match.MatchedIndexes,
+			chipMatchLen:   m.chipMatchLen(item.name, typed),
 		}
 	}
 	return filtered
+}
+
+// chipMatchLen reports how many leading runes of a session's alias the query
+// prefixes, which is how much of its chip is highlighted. Aliases are matched
+// as a prefix rather than fuzzily so the chip fills in deterministically as the
+// alias is typed — the same rule alias-filter mode narrows by, applied here so
+// the chip lights up while filtering normally too.
+func (m *Model) chipMatchLen(name, query string) int {
+	alias, ok := m.aliasByName[name]
+	if !ok || query == "" {
+		return 0
+	}
+	if !strings.HasPrefix(strings.ToLower(alias), strings.ToLower(query)) {
+		return 0
+	}
+	return len([]rune(query))
 }
 
 // maxUnmatchedCharPenalty caps how much a name can be docked for the characters

--- a/picker/tui.go
+++ b/picker/tui.go
@@ -304,7 +304,7 @@ func (m Model) aliasChip(name string, matchLen int) string {
 // highlightChipPrefix styles the first matchLen runes of a chip label as
 // matched. Reverse video is kept throughout so the chip stays one shape;
 // setting a foreground under it paints the matched runes as a colored block,
-// which is the same red used to highlight matches in session names.
+// which is the same green used to highlight matches in session names.
 func highlightChipPrefix(alias string, matchLen int, label lipgloss.Style) string {
 	runes := []rune(alias)
 	if matchLen <= 0 {
@@ -313,7 +313,7 @@ func highlightChipPrefix(alias string, matchLen int, label lipgloss.Style) strin
 	if matchLen > len(runes) {
 		matchLen = len(runes)
 	}
-	matched := label.Foreground(lipgloss.ANSIColor(1)).Render(string(runes[:matchLen]))
+	matched := label.Foreground(lipgloss.ANSIColor(2)).Render(string(runes[:matchLen]))
 	return matched + label.Render(string(runes[matchLen:]))
 }
 
@@ -1036,7 +1036,7 @@ func (m Model) View() tea.View {
 		}
 
 		cursorStyle := lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(2)).Bold(true)
-		matchStyle := lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(1)).Bold(true)
+		matchStyle := lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(2)).Bold(true)
 		normalStyle := lipgloss.NewStyle()
 		windowStyle := lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(8)).Faint(true)
 		indexStyle := lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(4))

--- a/picker/tui.go
+++ b/picker/tui.go
@@ -38,6 +38,16 @@ type filteredItem struct {
 	chipMatchLen int
 }
 
+// displayRow is one line of the rendered list: either a session, or the rule
+// drawn where one sort_order group ends and the next begins. A separator exists
+// only here — the cursor indexes filtered, never rows, so it can neither land
+// on one nor select one.
+type displayRow struct {
+	// index is the position in filtered, or -1 for a separator.
+	index     int
+	separator bool
+}
+
 // FetchFunc loads sessions asynchronously. It is called in a goroutine by Init().
 type FetchFunc func() (model.SeshSessions, error)
 
@@ -136,14 +146,26 @@ type Options struct {
 	PreviewBorder string
 	// PreviewFunc renders previews. Nil disables the pane entirely.
 	PreviewFunc PreviewFunc
+	// GroupSeparator draws a faint rule between sort_order groups. It is
+	// suppressed while the list is filtered, where the groups no longer occupy
+	// contiguous ranges.
+	GroupSeparator bool
 }
 
 type Model struct {
-	allItems       sessionItems
-	filtered       []filteredItem
-	filterInput    textinput.Model
-	cursor         int
-	offset         int
+	allItems    sessionItems
+	filtered    []filteredItem
+	filterInput textinput.Model
+	// cursor indexes filtered; offset indexes rows, which is the same list with
+	// the group separators laid in, so scrolling counts the lines actually
+	// drawn.
+	cursor int
+	offset int
+	// rows is the rendered layout of filtered — see displayRow — and rowOf maps
+	// a filtered index back to the row that draws it.
+	rows           []displayRow
+	rowOf          []int
+	groupSeparator bool
 	width          int
 	height         int
 	chosen         string
@@ -364,6 +386,7 @@ func New(fetchFunc FetchFunc, opts Options) Model {
 		previewWidthPct:         previewWidth(opts.PreviewWidth),
 		previewMinWidth:         previewMinWidth(opts.PreviewMinWidth),
 		previewBorderName:       previewBorder(opts.PreviewBorder),
+		groupSeparator:          opts.GroupSeparator,
 	}
 	m.focusCmd = m.filterInput.Focus()
 	return m
@@ -748,18 +771,41 @@ func (m Model) indexJump(key string) (string, bool) {
 }
 
 func (m *Model) applyFilter() {
-	raw := m.filterInput.Value()
+	m.filtered = m.filterFor(m.filterInput.Value())
+	m.buildRows()
+}
+
+// filterFor narrows the loaded list for the raw input, dispatching on the sigil
+// it was typed with.
+func (m *Model) filterFor(raw string) []filteredItem {
 	if query, ok := m.aliasFilterQuery(raw); ok {
-		m.filtered = m.filterAliases(query)
-		return
+		return m.filterAliases(query)
 	}
 	// Index mode numbers whatever is displayed, so anything typed after the
 	// sigil filters exactly as it would on its own.
 	if query, ok := m.indexFilterQuery(raw); ok {
-		m.filtered = m.filterSessions(query)
-		return
+		return m.filterSessions(query)
 	}
-	m.filtered = m.filterSessions(raw)
+	return m.filterSessions(raw)
+}
+
+// buildRows lays the filtered sessions out as the lines the list renders,
+// inserting a rule wherever the sort_order group changes.
+//
+// Separators are suppressed as soon as anything is typed: a query reorders the
+// results by match quality, so the groups stop being contiguous ranges and a
+// rule would be drawing a boundary that isn't there.
+func (m *Model) buildRows() {
+	m.rows = make([]displayRow, 0, len(m.filtered))
+	m.rowOf = make([]int, len(m.filtered))
+	separate := m.groupSeparator && m.filterInput.Value() == ""
+	for i, item := range m.filtered {
+		if separate && i > 0 && item.item.session.Group != m.filtered[i-1].item.session.Group {
+			m.rows = append(m.rows, displayRow{index: -1, separator: true})
+		}
+		m.rowOf[i] = len(m.rows)
+		m.rows = append(m.rows, displayRow{index: i})
+	}
 }
 
 // filterSessions narrows the loaded list by pattern: everything when it's
@@ -835,9 +881,7 @@ func (m *Model) cursorUp(n int) {
 	if m.cursor < 0 {
 		m.cursor = 0
 	}
-	if m.cursor < m.offset {
-		m.offset = m.cursor
-	}
+	m.scrollToCursor()
 }
 
 func (m *Model) cursorDown(n int) {
@@ -849,9 +893,23 @@ func (m *Model) cursorDown(n int) {
 	if m.cursor > max {
 		m.cursor = max
 	}
-	visible := m.visibleCount()
-	if m.cursor >= m.offset+visible {
-		m.offset = m.cursor - visible + 1
+	m.scrollToCursor()
+}
+
+// scrollToCursor moves the viewport the least it can to keep the highlighted
+// session on screen. It works in row space so the separators between it and the
+// cursor are counted as the lines they are.
+func (m *Model) scrollToCursor() {
+	if m.cursor < 0 || m.cursor >= len(m.rowOf) {
+		m.offset = 0
+		return
+	}
+	row := m.rowOf[m.cursor]
+	if row < m.offset {
+		m.offset = row
+	}
+	if visible := m.visibleCount(); row >= m.offset+visible {
+		m.offset = row - visible + 1
 	}
 }
 
@@ -973,8 +1031,8 @@ func (m Model) View() tea.View {
 	} else {
 		// Session list
 		end := m.offset + visible
-		if end > len(m.filtered) {
-			end = len(m.filtered)
+		if end > len(m.rows) {
+			end = len(m.rows)
 		}
 
 		cursorStyle := lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(2)).Bold(true)
@@ -987,7 +1045,13 @@ func (m Model) View() tea.View {
 		// list instead of counted.
 		_, indexMode := m.indexFilterQuery(m.filterInput.Value())
 
-		for i := m.offset; i < end; i++ {
+		for r := m.offset; r < end; r++ {
+			if m.rows[r].separator {
+				b.WriteString(m.separatorRule())
+				b.WriteString("\n")
+				continue
+			}
+			i := m.rows[r].index
 			item := m.filtered[i]
 			prefix := "  "
 			if i == m.cursor {
@@ -1041,6 +1105,17 @@ func (m Model) View() tea.View {
 	// scrollback back untouched when it quits.
 	v.AltScreen = true
 	return v
+}
+
+// separatorRule draws the boundary between two sort_order groups: a faint rule
+// across the list column, so a glance says whether the row under the cursor is
+// a live tmux session or somewhere to go.
+func (m Model) separatorRule() string {
+	width := m.contentWidth() - 2
+	if width < 1 {
+		width = 1
+	}
+	return lipgloss.NewStyle().Faint(true).Render("  " + strings.Repeat("─", width))
 }
 
 // indexGutter renders the jump number for the row at position i, or blanks of

--- a/sesh.schema.json
+++ b/sesh.schema.json
@@ -31,9 +31,21 @@
     },
     "sort_order": {
       "type": "array",
-      "description": "Order in which session sources appear in the list",
+      "description": "Order in which session sources appear in the list. An entry may be a source name, listed as its own block, or a nested array of source names, merged into a single block ordered by zoxide score.",
       "items": {
-        "type": "string"
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "description": "Sources merged into one block, ordered by zoxide score. Sessions whose path zoxide has never seen score 0 and trail the block.",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1
+          }
+        ]
       }
     },
     "dir_length": {
@@ -184,7 +196,12 @@
           "default": 100,
           "minimum": 1
         },
-        "preview_border": {
+        "group_separator": {
+      "type": "boolean",
+      "description": "Draw a faint rule between the sort_order groups in the picker, so the boundary between live tmux sessions and everywhere else stays visible. Suppressed while the list is filtered.",
+      "default": false
+    },
+    "preview_border": {
           "type": "string",
           "description": "Divider drawn between the session list and the preview pane. Use \"none\" for no divider.",
           "enum": ["line", "thick", "double", "none"],


### PR DESCRIPTION
Closes #465

Two picker changes that both come out of sources being mixed together: an opt-in merged group ordered by zoxide score, and a set of highlight fixes so the merged list is still readable at a glance.

## Merge sources into one score-ordered group

`sort_order` now accepts nested arrays. A nested entry declares one merged group whose sessions are ordered by zoxide score instead of source by source:

```toml
sort_order = ["tmux", ["config", "zoxide"]]
```

That pins live tmux sessions on top and interleaves everything below them by how recently and often the directory is actually visited — which is closer to "what am I working on right now" than a source-first ordering is.

Sessions from a source that carries no score of its own borrow the score zoxide has for their path, looked up in the results already fetched for the zoxide source. A path zoxide has never seen scores 0 and trails the group. A flat `sort_order` behaves exactly as before, so merging is entirely opt-in.

## `[tui] group_separator`

A faint rule between groups, so the boundary between live tmux sessions and everywhere else stays visible once the sources interleave.

The picker now keeps a row layout alongside the filtered list: separators live only there, the cursor still indexes sessions and steps straight over them, and scrolling counts the rule as the line it is. The rule is suppressed while filtering, where results are reordered by match quality and the groups are no longer contiguous ranges.

## Match highlighting

- Matched runs in session names, and the matched prefix of an alias chip, are drawn in green instead of red.
- The alias chip's highlight now fills its rounded caps rather than stopping at the first and last letter: the left cap as soon as anything matches, the right cap once the whole alias does, so a full match reads as one unbroken chip.
- The chip lights up while filtering normally, not only in alias-filter mode. Aliases are still matched as a prefix, case-insensitively, so the chip fills in deterministically as it is typed.

## Notes for review

- Aliases are not part of the fuzzy corpus, so in normal mode a session only survives the filter on its name or an exactly-typed alias. With alias `wp` → `my-project`, typing `w` drops the row entirely and there is no chip left to highlight. Making partial aliases match in normal mode is a filtering change rather than a highlighting one, so it is not in this PR.
- The cursor style is also ANSI green, so on the selected row the matched characters no longer stand out from the rest of the row. Easy to change to bright green (`ANSIColor(10)`) if that reads badly in practice.
- `sesh.schema.json` is updated for the new `sort_order` shape and `group_separator`.

Full test suite passes.
