### PR TITLE
feat(picker): remove a zoxide entry with ctrl+x

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,12 +619,13 @@ Sesh uses [zoxide](https://github.com/ajeetdsouza/zoxide) as its default frecenc
 list_command  = "fasd -d -l -R"  # list all tracked entries
 query_command = "fasd -d {}"     # resolve one input to a path
 add_command   = "fasd -A {}"     # record a path after connecting
+remove_command = "fasd -D {}"    # remove a path (picker ctrl+x)
 ```
 
-- The `{}` placeholder is replaced with the query string (`query_command`) or the path (`add_command`), the same substitution used by `preview_command`.
+- The `{}` placeholder is replaced with the query string (`query_command`) or the path (`add_command`, `remove_command`), the same substitution used by `preview_command`.
 - `list_command` output is parsed one path per line, most-frecent first. A leading numeric score is detected automatically when present (as with zoxide's `--score`); otherwise the score is `0`.
 - Any command runs as a single binary (no shell), so pipes/redirects aren't supported.
-- Any field you omit falls back to its zoxide default (`zoxide query --list --score`, `zoxide query {}`, `zoxide add {}`), so an absent `[frecency]` table leaves behavior unchanged.
+- Any field you omit falls back to its zoxide default (`zoxide query --list --score`, `zoxide query {}`, `zoxide add {}`, `zoxide remove {}`), so an absent `[frecency]` table leaves behavior unchanged.
 - The source label in `sesh list` output stays `zoxide`, so existing integrations that read the `--json` output keep working.
 
 ### Schema (Editor Autocomplete)
@@ -925,6 +926,28 @@ Pressing <kbd>3</kbd> connects to `my-project` immediately. Only `1`–`9` jump,
 The numbers follow the visible list, so anything typed after the sigil narrows it first and renumbers what's left — `#a` then <kbd>2</kbd> jumps to the second match for `a`. A digit with no row at that position does nothing rather than filtering.
 
 Only a leading `#` counts, so `feat#123` filters normally. If you configure `alias_filter_prefix = "#"`, alias mode wins and this mode is unreachable.
+
+#### Removing a zoxide entry
+
+A directory you deleted or renamed keeps showing up in the picker until zoxide is told about it. <kbd>ctrl+x</kbd> on a zoxide row prunes it where you noticed it, behind a confirmation:
+
+```
+╭────────────────────────────────────────────────────────╮
+│                                                        │
+│    Do you want to remove this directory from zoxide?   │
+│                                                        │
+│                    ~/c/some-old-project                │
+│                                                        │
+│                      Yes      No                       │
+│                                                        │
+╰────────────────────────────────────────────────────────╯
+```
+
+<kbd>y</kbd> or <kbd>enter</kbd> removes it, <kbd>n</kbd>, <kbd>q</kbd>, or <kbd>esc</kbd> cancels, and <kbd>←</kbd>/<kbd>→</kbd> or <kbd>tab</kbd> move between the buttons. Nothing typed while the dialog is open reaches the filter, so the list is exactly as you left it either way.
+
+Only zoxide rows can be removed — a tmux session, a `[[session]]` block, or a tmuxinator config is not zoxide's to forget, so <kbd>ctrl+x</kbd> says so and does nothing. The row disappears only once the removal actually succeeded; a backend that refuses it reports the error and leaves the row in place.
+
+The removal runs `zoxide remove {}` by default, or whatever `remove_command` you set — see [Custom Frecency Backend](#custom-frecency-backend-fasd-autojump-etc). With `cache = true`, the cache is rewritten behind the removal so the next launch doesn't list the directory again.
 
 #### Preview pane
 

--- a/lister/bench_test.go
+++ b/lister/bench_test.go
@@ -56,6 +56,7 @@ type benchZoxide struct {
 func (z *benchZoxide) ListResults() ([]*model.ZoxideResult, error) { return z.results, nil }
 func (z *benchZoxide) Add(string) error                            { return nil }
 func (z *benchZoxide) Query(string) (*model.ZoxideResult, error)   { return nil, nil }
+func (z *benchZoxide) Remove(string) error                         { return nil }
 
 type benchTmuxinator struct {
 	configs []*model.TmuxinatorConfig

--- a/model/config.go
+++ b/model/config.go
@@ -93,6 +93,9 @@ type (
 		// AddCommand records a path to bump its frecency after connecting.
 		// The `{}` placeholder is replaced with the path.
 		AddCommand string `toml:"add_command"`
+		// RemoveCommand drops a path from the backend, used by the picker's
+		// ctrl+x binding. The `{}` placeholder is replaced with the path.
+		RemoveCommand string `toml:"remove_command"`
 	}
 
 	// NameSubstitution rewrites the path a session name is derived from before

--- a/picker/confirm.go
+++ b/picker/confirm.go
@@ -1,0 +1,219 @@
+package picker
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+// zoxideSrc is the source name the frecency backend lists sessions under. It is
+// the only source whose rows can be removed from the picker: everything else is
+// a live tmux session or a config entry, neither of which ctrl+x owns.
+const zoxideSrc = "zoxide"
+
+// RemoveFunc drops a path from the frecency backend. Nil means removal is
+// unavailable and ctrl+x is inert.
+type RemoveFunc func(path string) error
+
+// confirmState is the removal confirmation dialog: the row it was opened on,
+// and which of the two buttons is focused. It is nil whenever the dialog is
+// closed, so its presence is the mode.
+type confirmState struct {
+	name string
+	path string
+	// yes is the focused button. The dialog opens on Yes, so enter alone
+	// confirms — the row was already chosen by pressing ctrl+x on it.
+	yes bool
+}
+
+// entryRemovedMsg carries the result of a removal back to Update. The row is
+// dropped from the list only once this arrives without an error, so a backend
+// that refuses the removal leaves the list telling the truth.
+type entryRemovedMsg struct {
+	name string
+	path string
+	err  error
+}
+
+// startRemove handles ctrl+x: it opens the confirmation dialog for the
+// highlighted row, or explains why it can't. Removal is unavailable while the
+// list is still loading — there is nothing highlighted to remove — and on any
+// row that didn't come from the frecency backend.
+func (m Model) startRemove() (tea.Model, tea.Cmd) {
+	if m.loading || m.removeFunc == nil {
+		return m, nil
+	}
+	if m.cursor < 0 || m.cursor >= len(m.filtered) {
+		return m, nil
+	}
+	item := m.filtered[m.cursor].item
+	if item.src != zoxideSrc {
+		m.status = "Only zoxide entries can be removed"
+		return m, nil
+	}
+	m.confirm = &confirmState{name: item.name, path: item.session.Path, yes: true}
+	return m, nil
+}
+
+// updateConfirm handles a keypress while the dialog is open. It swallows every
+// key: the filter input keeps its value but sees nothing typed, so the list is
+// exactly as it was when the dialog closes either way.
+func (m Model) updateConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c":
+		// ctrl+c means "get me out of here" everywhere else in the picker, and
+		// a dialog is a poor place to start making it mean something narrower.
+		m.confirm = nil
+		m.quit = true
+		return m, tea.Quit
+	case "y", "Y":
+		return m.applyConfirm(true)
+	case "n", "N", "q", "esc":
+		return m.applyConfirm(false)
+	case "enter":
+		return m.applyConfirm(m.confirm.yes)
+	case "left", "right", "tab", "shift+tab", "h", "l":
+		m.confirm = &confirmState{name: m.confirm.name, path: m.confirm.path, yes: !m.confirm.yes}
+		return m, nil
+	}
+	return m, nil
+}
+
+// applyConfirm closes the dialog, starting the removal when it was confirmed.
+func (m Model) applyConfirm(confirmed bool) (tea.Model, tea.Cmd) {
+	target := *m.confirm
+	m.confirm = nil
+	if !confirmed {
+		return m, nil
+	}
+	return m, m.removeEntry(target.name, target.path)
+}
+
+// removeEntry runs the backend removal off the event loop: it shells out, and
+// blocking Update on it would freeze the picker for as long as the command
+// takes.
+func (m Model) removeEntry(name, path string) tea.Cmd {
+	removeFunc := m.removeFunc
+	return func() tea.Msg {
+		return entryRemovedMsg{name: name, path: path, err: removeFunc(path)}
+	}
+}
+
+// dropItem removes a frecency entry from the loaded list and refilters, keeping
+// the cursor where it was — pulled back by one when it sat on the last row, so
+// it never points past the end.
+//
+// The row is matched on source and path rather than name: a zoxide directory
+// and a live tmux session can share a name, and the one that was removed from
+// the backend is the zoxide one.
+func (m *Model) dropItem(name, path string) {
+	for i, item := range m.allItems {
+		if item.src == zoxideSrc && item.name == name && item.session.Path == path {
+			m.allItems = append(m.allItems[:i], m.allItems[i+1:]...)
+			break
+		}
+	}
+	m.applyFilter()
+	if m.cursor >= len(m.filtered) {
+		m.cursor = max(len(m.filtered)-1, 0)
+	}
+	// The list lost a line, so the viewport is re-derived from the cursor in
+	// row space rather than nudged: a group separator may have gone with it.
+	m.scrollToCursor()
+}
+
+const (
+	// confirmMinWidth keeps a short prompt from rendering as a cramped box,
+	// and confirmMaxWidth keeps a long path from pushing the dialog wider than
+	// the list it sits over.
+	confirmMinWidth = 40
+	confirmMaxWidth = 60
+)
+
+// confirmView renders the dialog itself, sized to fit within the frame.
+func (m Model) confirmView() string {
+	c := m.confirm
+
+	inner := confirmMaxWidth
+	if m.width > 0 && m.width-6 < inner {
+		inner = m.width - 6
+	}
+	if inner < confirmMinWidth {
+		inner = confirmMinWidth
+	}
+
+	center := lipgloss.NewStyle().Width(inner).MaxWidth(inner).Align(lipgloss.Center)
+	faint := center.Faint(true)
+
+	lines := []string{
+		center.Render("Do you want to remove this directory from zoxide?"),
+		"",
+		center.Bold(true).Render(truncate(c.name, inner)),
+	}
+	// The path is what actually gets removed. It is only worth a line of its
+	// own when the row is displayed under some other name.
+	if c.path != "" && c.path != c.name {
+		lines = append(lines, faint.Render(truncate(c.path, inner)))
+	}
+	lines = append(lines, "", center.Render(confirmButtons(c.yes)))
+
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.ANSIColor(4)).
+		Padding(1, 2).
+		Render(strings.Join(lines, "\n"))
+}
+
+// confirmButtons renders the Yes/No pair with the focused one filled in.
+func confirmButtons(yes bool) string {
+	focused := lipgloss.NewStyle().Reverse(true).Bold(true)
+	blurred := lipgloss.NewStyle().Faint(true)
+	yesStyle, noStyle := blurred, focused
+	if yes {
+		yesStyle, noStyle = focused, blurred
+	}
+	return yesStyle.Render(" Yes ") + "   " + noStyle.Render(" No ")
+}
+
+// truncate cuts a string to width columns, marking the cut with an ellipsis so
+// a clipped path doesn't read as a shorter one that also exists.
+func truncate(s string, width int) string {
+	if width < 2 || lipgloss.Width(s) <= width {
+		return s
+	}
+	runes := []rune(s)
+	for len(runes) > 0 && lipgloss.Width(string(runes))+1 > width {
+		runes = runes[:len(runes)-1]
+	}
+	return string(runes) + "…"
+}
+
+// overlayCentered composes the dialog over the frame, centered. The frame is
+// left visible around it: the dialog is about a row in the list, and hiding the
+// list to ask about it would take away the context the question needs.
+//
+// A frame too small to hold the dialog — or one rendered before the terminal
+// size is known — gets the dialog on its own instead of a clipped overlay.
+func overlayCentered(base, dialog string, width, height int) string {
+	dw, dh := lipgloss.Width(dialog), lipgloss.Height(dialog)
+	if width < dw || height < dh {
+		return dialog
+	}
+	// The layers go through a compositor rather than being composed onto the
+	// canvas one at a time: a layer drawn directly fills the whole canvas, and
+	// only the compositor honors its x/y offset.
+	canvas := lipgloss.NewCanvas(width, height)
+	canvas.Compose(lipgloss.NewCompositor(
+		lipgloss.NewLayer(base),
+		lipgloss.NewLayer(dialog).X((width-dw)/2).Y((height-dh)/2).Z(1),
+	))
+	return canvas.Render()
+}
+
+// removalFailed is the status shown when the backend refuses a removal. The row
+// stays in the list, so the message has to say why it is still there.
+func removalFailed(err error) string {
+	return fmt.Sprintf("Couldn't remove entry: %v", err)
+}

--- a/picker/confirm_test.go
+++ b/picker/confirm_test.go
@@ -1,0 +1,378 @@
+package picker
+
+import (
+	"errors"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/zoxide"
+)
+
+// ctrlX is the removal binding as the terminal delivers it.
+var ctrlX = tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl}
+
+// newRemovableModel loads the test sessions with a removal func that records
+// the paths it was asked to remove, and returns that record alongside the
+// model.
+func newRemovableModel(err error) (Model, *[]string) {
+	removed := &[]string{}
+	sessions := testSessions()
+	opts := testOptionsWith(func(o *Options) {
+		o.Remove = func(path string) error {
+			*removed = append(*removed, path)
+			return err
+		}
+	})
+	m := New(testFetchFunc(sessions), opts)
+	result, _ := m.Update(sessionsLoadedMsg{sessions: sessions})
+	return result.(Model), removed
+}
+
+// cursorOnZoxide moves the cursor to the zoxide row of testSessions.
+func cursorOnZoxide(t *testing.T, m Model) Model {
+	t.Helper()
+	for i, item := range m.filtered {
+		if item.item.src == zoxideSrc {
+			m.cursor = i
+			return m
+		}
+	}
+	t.Fatal("no zoxide row in the test sessions")
+	return m
+}
+
+func press(m Model, msg tea.Msg) Model {
+	result, _ := m.Update(msg)
+	return result.(Model)
+}
+
+func TestCtrlX_OpensDialogOnZoxideRow(t *testing.T) {
+	m, _ := newRemovableModel(nil)
+	m = cursorOnZoxide(t, m)
+
+	m = press(m, ctrlX)
+
+	require.NotNil(t, m.confirm, "ctrl+x on a zoxide row should open the dialog")
+	assert.Equal(t, "~/code/app", m.confirm.name)
+	assert.Equal(t, "/home/user/code/app", m.confirm.path)
+	assert.True(t, m.confirm.yes, "the dialog should open with Yes focused")
+}
+
+func TestCtrlX_InertOnNonZoxideRows(t *testing.T) {
+	for _, src := range []string{"tmux", "config", "tmuxinator"} {
+		t.Run(src, func(t *testing.T) {
+			m, _ := newRemovableModel(nil)
+			for i, item := range m.filtered {
+				if item.item.src == src {
+					m.cursor = i
+					break
+				}
+			}
+			m = press(m, ctrlX)
+
+			assert.Nil(t, m.confirm, "ctrl+x should not open the dialog on a %s row", src)
+			assert.Contains(t, m.status, "Only zoxide entries")
+		})
+	}
+}
+
+func TestCtrlX_InertWhileLoading(t *testing.T) {
+	opts := testOptionsWith(func(o *Options) {
+		o.Remove = func(string) error { return nil }
+	})
+	m := New(testFetchFunc(testSessions()), opts)
+	require.True(t, m.loading)
+
+	m = press(m, ctrlX)
+
+	assert.Nil(t, m.confirm)
+	assert.Empty(t, m.status)
+}
+
+func TestCtrlX_InertWithoutRemoveFunc(t *testing.T) {
+	m := newTestModel()
+	m = cursorOnZoxide(t, m)
+
+	m = press(m, ctrlX)
+
+	assert.Nil(t, m.confirm)
+}
+
+func TestCtrlX_DoesNotTypeIntoTheFilter(t *testing.T) {
+	m, _ := newRemovableModel(nil)
+	m = cursorOnZoxide(t, m)
+
+	m = press(m, ctrlX)
+
+	assert.Equal(t, "", m.filterInput.Value())
+}
+
+func TestConfirm_SwallowsKeysWhileOpen(t *testing.T) {
+	m, _ := newRemovableModel(nil)
+	m = cursorOnZoxide(t, m)
+	m = press(m, ctrlX)
+
+	m = press(m, tea.KeyPressMsg{Code: 'a'})
+
+	assert.Equal(t, "", m.filterInput.Value(), "the dialog should swallow typing")
+	assert.NotNil(t, m.confirm, "an unrelated key should leave the dialog open")
+}
+
+func TestConfirm_YesRemovesTheEntry(t *testing.T) {
+	m, removed := newRemovableModel(nil)
+	m = cursorOnZoxide(t, m)
+	m = press(m, ctrlX)
+
+	result, cmd := m.Update(tea.KeyPressMsg{Code: 'y'})
+	m = result.(Model)
+	assert.Nil(t, m.confirm, "confirming should close the dialog")
+	require.NotNil(t, cmd, "confirming should start the removal")
+
+	msg := cmd()
+	assert.Equal(t, []string{"/home/user/code/app"}, *removed)
+
+	m = press(m, msg)
+	assert.Len(t, m.allItems, 4)
+	for _, item := range m.allItems {
+		assert.NotEqual(t, "~/code/app", item.name)
+	}
+}
+
+func TestConfirm_EnterConfirmsByDefault(t *testing.T) {
+	m, removed := newRemovableModel(nil)
+	m = cursorOnZoxide(t, m)
+	m = press(m, ctrlX)
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.NotNil(t, cmd)
+	cmd()
+
+	assert.Equal(t, []string{"/home/user/code/app"}, *removed)
+}
+
+func TestConfirm_EnterOnNoCancels(t *testing.T) {
+	m, removed := newRemovableModel(nil)
+	m = cursorOnZoxide(t, m)
+	m = press(m, ctrlX)
+
+	m = press(m, tea.KeyPressMsg{Code: tea.KeyRight})
+	require.NotNil(t, m.confirm)
+	assert.False(t, m.confirm.yes, "right should move focus to No")
+
+	result, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = result.(Model)
+	assert.Nil(t, m.confirm)
+	assert.Nil(t, cmd)
+	assert.Empty(t, *removed)
+	assert.Len(t, m.allItems, 5)
+}
+
+func TestConfirm_CancelKeys(t *testing.T) {
+	cancels := map[string]tea.KeyPressMsg{
+		"n":   {Code: 'n'},
+		"q":   {Code: 'q'},
+		"esc": {Code: tea.KeyEscape},
+	}
+	for name, key := range cancels {
+		t.Run(name, func(t *testing.T) {
+			m, removed := newRemovableModel(nil)
+			m = cursorOnZoxide(t, m)
+			m = press(m, ctrlX)
+
+			result, cmd := m.Update(key)
+			m = result.(Model)
+
+			assert.Nil(t, m.confirm, "%s should close the dialog", name)
+			assert.Nil(t, cmd, "%s should not start a removal", name)
+			assert.Empty(t, *removed)
+			assert.Len(t, m.allItems, 5)
+		})
+	}
+}
+
+func TestConfirm_EscDoesNotQuitThePicker(t *testing.T) {
+	m, _ := newRemovableModel(nil)
+	m = cursorOnZoxide(t, m)
+	m = press(m, ctrlX)
+
+	m = press(m, tea.KeyPressMsg{Code: tea.KeyEscape})
+
+	assert.False(t, m.quit, "esc should close the dialog, not the picker")
+}
+
+func TestConfirm_TabMovesBetweenButtons(t *testing.T) {
+	m, _ := newRemovableModel(nil)
+	m = cursorOnZoxide(t, m)
+	m = press(m, ctrlX)
+
+	m = press(m, tea.KeyPressMsg{Code: tea.KeyTab})
+	require.NotNil(t, m.confirm)
+	assert.False(t, m.confirm.yes)
+
+	m = press(m, tea.KeyPressMsg{Code: tea.KeyTab})
+	require.NotNil(t, m.confirm)
+	assert.True(t, m.confirm.yes)
+}
+
+func TestRemoval_FailureKeepsTheRow(t *testing.T) {
+	m, _ := newRemovableModel(errors.New("exit status 1"))
+	m = cursorOnZoxide(t, m)
+	m = press(m, ctrlX)
+
+	result, cmd := m.Update(tea.KeyPressMsg{Code: 'y'})
+	m = press(result.(Model), cmd())
+
+	assert.Len(t, m.allItems, 5, "a failed removal must not drop the row")
+	assert.Contains(t, m.status, "Couldn't remove entry")
+	assert.Contains(t, m.status, "exit status 1")
+}
+
+func TestRemoval_PreservesTheFilter(t *testing.T) {
+	m, _ := newRemovableModel(nil)
+	m.filterInput.SetValue("code/app")
+	m.applyFilter()
+	require.Len(t, m.filtered, 1)
+
+	m = press(m, ctrlX)
+	require.NotNil(t, m.confirm)
+
+	result, cmd := m.Update(tea.KeyPressMsg{Code: 'y'})
+	m = press(result.(Model), cmd())
+
+	assert.Equal(t, "code/app", m.filterInput.Value())
+	assert.Empty(t, m.filtered)
+	assert.Equal(t, 0, m.cursor)
+}
+
+func TestRemoval_PullsTheCursorBackFromTheLastRow(t *testing.T) {
+	sessions := model.SeshSessions{
+		OrderedIndex: []string{"s1", "s2"},
+		Directory: model.SeshSessionMap{
+			"s1": {Name: "one", Src: "tmux", Path: "/one"},
+			"s2": {Name: "~/two", Src: zoxideSrc, Path: "/two"},
+		},
+	}
+	opts := testOptionsWith(func(o *Options) {
+		o.Remove = func(string) error { return nil }
+	})
+	result, _ := New(testFetchFunc(sessions), opts).Update(sessionsLoadedMsg{sessions: sessions})
+	m := result.(Model)
+	m.cursor = 1
+
+	m = press(m, ctrlX)
+	confirmed, cmd := m.Update(tea.KeyPressMsg{Code: 'y'})
+	m = press(confirmed.(Model), cmd())
+
+	assert.Len(t, m.filtered, 1)
+	assert.Equal(t, 0, m.cursor, "the cursor should be pulled back onto the new last row")
+}
+
+func TestStatus_ClearedByTheNextKeypress(t *testing.T) {
+	m, _ := newRemovableModel(nil)
+	m.cursor = 0 // a tmux row
+	m = press(m, ctrlX)
+	require.NotEmpty(t, m.status)
+
+	m = press(m, tea.KeyPressMsg{Code: tea.KeyDown})
+
+	assert.Empty(t, m.status)
+}
+
+func TestConfirmView_ShowsThePromptAndButtons(t *testing.T) {
+	m, _ := newRemovableModel(nil)
+	m = press(m, tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = cursorOnZoxide(t, m)
+	m = press(m, ctrlX)
+
+	out := ansi.Strip(m.View().Content)
+
+	assert.Contains(t, out, "Do you want to remove this directory from zoxide?")
+	assert.Contains(t, out, "~/code/app")
+	assert.Contains(t, out, "Yes")
+	assert.Contains(t, out, "No")
+}
+
+func TestConfirmView_KeepsTheListVisibleBehindIt(t *testing.T) {
+	m, _ := newRemovableModel(nil)
+	m = press(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+	m = cursorOnZoxide(t, m)
+	m = press(m, ctrlX)
+
+	out := ansi.Strip(m.View().Content)
+
+	assert.Contains(t, out, "my-project", "the dialog overlays the list rather than replacing it")
+}
+
+func TestTruncate(t *testing.T) {
+	assert.Equal(t, "short", truncate("short", 10))
+	assert.Equal(t, "abcd…", truncate("abcdefgh", 5))
+}
+
+func TestConfirm_CtrlCQuitsThePicker(t *testing.T) {
+	m, removed := newRemovableModel(nil)
+	m = cursorOnZoxide(t, m)
+	m = press(m, ctrlX)
+
+	m = press(m, tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+
+	assert.True(t, m.quit, "ctrl+c should quit the picker, dialog or not")
+	assert.Nil(t, m.confirm)
+	assert.Empty(t, *removed)
+}
+
+func TestRemoval_DropsTheZoxideRowNotItsNamesake(t *testing.T) {
+	sessions := model.SeshSessions{
+		OrderedIndex: []string{"t", "z"},
+		Directory: model.SeshSessionMap{
+			"t": {Name: "app", Src: "tmux", Path: "/live/app"},
+			"z": {Name: "app", Src: zoxideSrc, Path: "/stale/app"},
+		},
+	}
+	opts := testOptionsWith(func(o *Options) {
+		o.Remove = func(string) error { return nil }
+	})
+	result, _ := New(testFetchFunc(sessions), opts).Update(sessionsLoadedMsg{sessions: sessions})
+	m := cursorOnZoxide(t, result.(Model))
+
+	m = press(m, ctrlX)
+	confirmed, cmd := m.Update(tea.KeyPressMsg{Code: 'y'})
+	m = press(confirmed.(Model), cmd())
+
+	require.Len(t, m.allItems, 1)
+	assert.Equal(t, "tmux", m.allItems[0].src, "the live session must survive its zoxide namesake")
+}
+
+func TestRealPicker_RemoveEntry(t *testing.T) {
+	t.Run("refreshes the cache after a successful removal", func(t *testing.T) {
+		mockZoxide := new(zoxide.MockZoxide)
+		mockZoxide.EXPECT().Remove("/stale/app").Return(nil)
+		refreshed := 0
+		p := &RealPicker{zoxide: mockZoxide, refreshCache: func() { refreshed++ }}
+
+		assert.NoError(t, p.removeEntry("/stale/app"))
+		assert.Equal(t, 1, refreshed)
+	})
+
+	t.Run("leaves the cache alone when the removal failed", func(t *testing.T) {
+		mockZoxide := new(zoxide.MockZoxide)
+		mockZoxide.EXPECT().Remove("/stale/app").Return(errors.New("exit status 1"))
+		refreshed := 0
+		p := &RealPicker{zoxide: mockZoxide, refreshCache: func() { refreshed++ }}
+
+		assert.Error(t, p.removeEntry("/stale/app"))
+		assert.Zero(t, refreshed)
+	})
+
+	t.Run("removes without a cache to refresh", func(t *testing.T) {
+		mockZoxide := new(zoxide.MockZoxide)
+		mockZoxide.EXPECT().Remove("/stale/app").Return(nil)
+		p := &RealPicker{zoxide: mockZoxide}
+
+		assert.NoError(t, p.removeEntry("/stale/app"))
+	})
+}

--- a/picker/picker.go
+++ b/picker/picker.go
@@ -11,6 +11,7 @@ import (
 	"github.com/joshmedeski/sesh/v2/home"
 	"github.com/joshmedeski/sesh/v2/model"
 	"github.com/joshmedeski/sesh/v2/previewer"
+	"github.com/joshmedeski/sesh/v2/zoxide"
 )
 
 const (
@@ -56,10 +57,43 @@ type RealPicker struct {
 	// wildcards matches a session path to a [[wildcard]] block, for icons
 	// declared on a pattern rather than a single session.
 	wildcards WildcardFinder
+	// zoxide is the frecency backend, reached only to remove an entry the user
+	// confirmed removing from the picker.
+	zoxide zoxide.Zoxide
+	// refreshCache refetches the session list into the cache after a removal.
+	// Nil when caching is off, which is also when there is nothing to refresh.
+	refreshCache CacheRefreshFunc
 }
 
-func NewPicker(config model.Config, previewer previewer.Previewer, home home.Home, wildcards WildcardFinder) Picker {
-	return &RealPicker{config: config, previewer: previewer, home: home, wildcards: wildcards}
+// CacheRefreshFunc rewrites the session cache from live data. The picker calls
+// it after removing an entry: the cache is what the next launch reads, and
+// without this it would list a directory the frecency backend has already
+// forgotten until the entry aged out on its own.
+type CacheRefreshFunc func()
+
+func NewPicker(config model.Config, previewer previewer.Previewer, home home.Home, wildcards WildcardFinder, zoxide zoxide.Zoxide, refreshCache CacheRefreshFunc) Picker {
+	return &RealPicker{
+		config:       config,
+		previewer:    previewer,
+		home:         home,
+		wildcards:    wildcards,
+		zoxide:       zoxide,
+		refreshCache: refreshCache,
+	}
+}
+
+// removeEntry drops a path from the frecency backend and refreshes the cache
+// behind it. The refresh is deliberately not part of the error: the entry is
+// gone either way, and a cache that is briefly out of date is not a failed
+// removal.
+func (p *RealPicker) removeEntry(path string) error {
+	if err := p.zoxide.Remove(path); err != nil {
+		return err
+	}
+	if p.refreshCache != nil {
+		p.refreshCache()
+	}
+	return nil
 }
 
 // buildAliases collects the aliases defined on [[session]] blocks, keyed by
@@ -191,6 +225,14 @@ func (p *RealPicker) Pick(fetchFunc FetchFunc, opts PickerOptions) (string, erro
 		previewFunc = p.previewer.Preview
 	}
 
+	// Removal reaches the backend the same way, so the TUI never learns what
+	// the frecency backend is. A picker built without one leaves ctrl+x inert
+	// rather than opening a dialog it can't act on.
+	var removeFunc RemoveFunc
+	if p.zoxide != nil {
+		removeFunc = p.removeEntry
+	}
+
 	m := New(fetchFunc, Options{
 		ShowIcons:               showIcons,
 		ShowWindows:             showWindows,
@@ -210,6 +252,7 @@ func (p *RealPicker) Pick(fetchFunc FetchFunc, opts PickerOptions) (string, erro
 		PreviewBorder:           p.config.TUI.PreviewBorder,
 		PreviewFunc:             previewFunc,
 		GroupSeparator:          p.config.TUI.GroupSeparator,
+		Remove:                  removeFunc,
 	})
 	prog := tea.NewProgram(m)
 	result, err := prog.Run()

--- a/picker/tui.go
+++ b/picker/tui.go
@@ -150,6 +150,9 @@ type Options struct {
 	// suppressed while the list is filtered, where the groups no longer occupy
 	// contiguous ranges.
 	GroupSeparator bool
+	// Remove drops an entry from the frecency backend. Nil leaves ctrl+x
+	// inert.
+	Remove RemoveFunc
 }
 
 type Model struct {
@@ -193,6 +196,14 @@ type Model struct {
 	// aliasSeq increments on every filter change so a pending auto-connect
 	// tick can tell whether it is stale.
 	aliasSeq int
+
+	// removeFunc drops an entry from the frecency backend, and confirm is the
+	// dialog guarding it — non-nil only while it is open, so its presence is
+	// the mode. status is a one-line message under the filter input,
+	// cleared by the next keypress.
+	removeFunc RemoveFunc
+	confirm    *confirmState
+	status     string
 
 	previewFunc     PreviewFunc
 	previewOn       bool
@@ -400,6 +411,7 @@ func New(fetchFunc FetchFunc, opts Options) Model {
 		aliasFilterPrefix:       opts.AliasFilterPrefix,
 		aliasAutoConnectDelay:   opts.AliasAutoConnectDelay,
 		disableAliasAutoConnect: opts.DisableAliasAutoConnect,
+		removeFunc:              opts.Remove,
 		previewFunc:             opts.PreviewFunc,
 		previewOn:               opts.Preview,
 		previewWidthPct:         previewWidth(opts.PreviewWidth),
@@ -517,6 +529,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.applyFilter()
 		return m, m.schedulePreview()
 
+	case entryRemovedMsg:
+		if msg.err != nil {
+			// The row is still in the list, and saying nothing would read as a
+			// removal that worked.
+			m.status = removalFailed(msg.err)
+			return m, nil
+		}
+		m.dropItem(msg.name, msg.path)
+		return m, m.schedulePreview()
+
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
@@ -524,6 +546,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyPressMsg:
+		// The dialog owns every key while it is open, so nothing reaches the
+		// filter input behind it.
+		if m.confirm != nil {
+			return m.updateConfirm(msg)
+		}
+		// A status message answers the previous keypress, so the next one
+		// retires it.
+		m.status = ""
+
 		switch msg.String() {
 		case "enter":
 			if m.loading {
@@ -554,6 +585,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+d":
 			m.cursorDown(m.visibleCount() / 2)
 			return m, m.schedulePreview()
+
+		case "ctrl+x":
+			return m.startRemove()
 
 		case "ctrl+o":
 			// Toggling stays allowed on a narrow terminal: the pane is gated on
@@ -1048,7 +1082,13 @@ func (m Model) View() tea.View {
 
 	// Filter input
 	b.WriteString("  " + m.filterInput.View())
-	b.WriteString("\n\n")
+	b.WriteString("\n")
+	// The status shares the blank line under the filter, so showing one never
+	// moves the list.
+	if m.status != "" {
+		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(3)).Render("  " + m.status))
+	}
+	b.WriteString("\n")
 
 	visible := m.visibleCount()
 
@@ -1138,6 +1178,10 @@ func (m Model) View() tea.View {
 			MaxWidth(m.contentWidth()).
 			Render(content)
 		content = lipgloss.JoinHorizontal(lipgloss.Top, list, m.previewView(cols, visible))
+	}
+
+	if m.confirm != nil {
+		content = overlayCentered(content, m.confirmView(), m.width, m.height)
 	}
 
 	v := tea.NewView(content)

--- a/sesh.schema.json
+++ b/sesh.schema.json
@@ -138,6 +138,11 @@
           "type": "string",
           "description": "Command that records a path to bump its frecency after connecting. The {} placeholder is replaced with the path.",
           "default": "zoxide add {}"
+        },
+        "remove_command": {
+          "type": "string",
+          "description": "Command that removes a path from the backend, used by the picker's ctrl+x binding. The {} placeholder is replaced with the path.",
+          "default": "zoxide remove {}"
         }
       },
       "additionalProperties": false

--- a/seshcli/deps.go
+++ b/seshcli/deps.go
@@ -148,7 +148,14 @@ func (b *BaseDeps) BuildAll(configPath string) (*Deps, error) {
 		worktree.IssueCacheName, worktree.IssueCacheVersion, worktree.IssueCacheTTL,
 	).WithMissingTTL(worktree.IssueCacheMissingTTL)
 	wt := worktree.NewWorktree(config, b.Git, b.Github, c, br, b.Home, b.Os, b.Path, issueCache)
-	pk := picker.NewPicker(config, p, b.Home, usedLister)
+	// Removing an entry from the picker has to be written through to the cache,
+	// or the next launch reads back the directory that was just removed. Nil
+	// when caching is off: the picker refetches every time anyway.
+	var refreshCache picker.CacheRefreshFunc
+	if cachedLi != nil {
+		refreshCache = func() { cachedLi.RefreshCache(lister.ListOptions{}) }
+	}
+	pk := picker.NewPicker(config, p, b.Home, usedLister, b.Zoxide, refreshCache)
 	mk := mkdirer.NewMkdirer(b.Os, b.Home, c)
 
 	return &Deps{

--- a/zoxide/remove.go
+++ b/zoxide/remove.go
@@ -1,0 +1,15 @@
+package zoxide
+
+// Remove drops a path from the frecency backend. Nothing else in sesh writes
+// to the backend destructively, so the caller is expected to have confirmed
+// the removal with the user first.
+func (z *RealZoxide) Remove(path string) error {
+	parts, err := z.shell.PrepareCmd(z.removeCommand, map[string]string{"{}": path})
+	if err != nil {
+		return err
+	}
+	if _, err := z.shell.Cmd(parts[0], parts[1:]...); err != nil {
+		return err
+	}
+	return nil
+}

--- a/zoxide/remove_test.go
+++ b/zoxide/remove_test.go
@@ -1,0 +1,49 @@
+package zoxide
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/joshmedeski/sesh/v2/model"
+	"github.com/joshmedeski/sesh/v2/shell"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemove(t *testing.T) {
+	t.Run("substitutes the path into the default zoxide command", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		zoxide := NewZoxide(mockShell, model.FrecencyConfig{})
+		mockShell.EXPECT().
+			PrepareCmd("zoxide remove {}", map[string]string{"{}": "/Users/joshmedeski/c/sesh/v2"}).
+			Return([]string{"zoxide", "remove", "/Users/joshmedeski/c/sesh/v2"}, nil)
+		mockShell.EXPECT().Cmd("zoxide", "remove", "/Users/joshmedeski/c/sesh/v2").Return("", nil)
+		err := zoxide.Remove("/Users/joshmedeski/c/sesh/v2")
+		assert.Nil(t, err)
+	})
+
+	t.Run("substitutes the path into a custom command", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		zoxide := NewZoxide(mockShell, model.FrecencyConfig{
+			RemoveCommand: "fasd -D {}",
+		})
+		mockShell.EXPECT().
+			PrepareCmd("fasd -D {}", map[string]string{"{}": "/Users/joshmedeski/c/sesh/v2"}).
+			Return([]string{"fasd", "-D", "/Users/joshmedeski/c/sesh/v2"}, nil)
+		mockShell.EXPECT().Cmd("fasd", "-D", "/Users/joshmedeski/c/sesh/v2").Return("", nil)
+		err := zoxide.Remove("/Users/joshmedeski/c/sesh/v2")
+		assert.Nil(t, err)
+	})
+
+	t.Run("returns the error when the command fails", func(t *testing.T) {
+		mockShell := new(shell.MockShell)
+		zoxide := NewZoxide(mockShell, model.FrecencyConfig{})
+		mockShell.EXPECT().
+			PrepareCmd("zoxide remove {}", map[string]string{"{}": "/tmp/gone"}).
+			Return([]string{"zoxide", "remove", "/tmp/gone"}, nil)
+		mockShell.EXPECT().
+			Cmd("zoxide", "remove", "/tmp/gone").
+			Return("", errors.New("exit status 1"))
+		err := zoxide.Remove("/tmp/gone")
+		assert.Error(t, err)
+	})
+}

--- a/zoxide/zoxide.go
+++ b/zoxide/zoxide.go
@@ -9,31 +9,35 @@ type Zoxide interface {
 	ListResults() ([]*model.ZoxideResult, error)
 	Add(path string) error
 	Query(path string) (*model.ZoxideResult, error)
+	Remove(path string) error
 }
 
 // Default commands reproduce zoxide's behavior exactly, so an empty
 // [frecency] config leaves the backend byte-identical to prior versions.
 const (
-	defaultListCommand  = "zoxide query --list --score"
-	defaultQueryCommand = "zoxide query {}"
-	defaultAddCommand   = "zoxide add {}"
+	defaultListCommand   = "zoxide query --list --score"
+	defaultQueryCommand  = "zoxide query {}"
+	defaultAddCommand    = "zoxide add {}"
+	defaultRemoveCommand = "zoxide remove {}"
 )
 
 type RealZoxide struct {
-	shell        shell.Shell
-	listCommand  string
-	queryCommand string
-	addCommand   string
+	shell         shell.Shell
+	listCommand   string
+	queryCommand  string
+	addCommand    string
+	removeCommand string
 }
 
 // NewZoxide builds the frecency backend, falling back to the zoxide
 // defaults for any command the frecency config leaves empty.
 func NewZoxide(shell shell.Shell, frecency model.FrecencyConfig) Zoxide {
 	return &RealZoxide{
-		shell:        shell,
-		listCommand:  orDefault(frecency.ListCommand, defaultListCommand),
-		queryCommand: orDefault(frecency.QueryCommand, defaultQueryCommand),
-		addCommand:   orDefault(frecency.AddCommand, defaultAddCommand),
+		shell:         shell,
+		listCommand:   orDefault(frecency.ListCommand, defaultListCommand),
+		queryCommand:  orDefault(frecency.QueryCommand, defaultQueryCommand),
+		addCommand:    orDefault(frecency.AddCommand, defaultAddCommand),
+		removeCommand: orDefault(frecency.RemoveCommand, defaultRemoveCommand),
 	}
 }
 


### PR DESCRIPTION
Closes #466

A directory you deleted or renamed keeps showing up in the picker until zoxide is told about it, and the only way to prune it was to drop to a shell and run `zoxide remove <path>`. <kbd>ctrl+x</kbd> does it where you actually notice the bad row, behind a confirmation.

```
  my-pr╭────────────────────────────────────────────────────────────────╮
  dotfi│                                                                │
> ~/cod│       Do you want to remove this directory from zoxide?        │
  rails│                                                                │
  notes│                           ~/code/app                           │
       │                      /home/user/code/app                       │
       │                                                                │
       │                          [ Yes ]   [ No ]                      │
       │                                                                │
       ╰────────────────────────────────────────────────────────────────╯
```

## Behavior

- <kbd>y</kbd>/<kbd>enter</kbd> confirm, <kbd>n</kbd>/<kbd>q</kbd>/<kbd>esc</kbd> cancel, <kbd>←</kbd>/<kbd>→</kbd>/<kbd>tab</kbd> move between the buttons. <kbd>ctrl+c</kbd> still quits the picker outright — it means "get me out of here" everywhere else, and a dialog is a poor place to start making it mean something narrower.
- The dialog swallows every key, so nothing typed while it is open reaches the filter input. The list is exactly as you left it whichever way it closes.
- It is drawn as a layer over the frame rather than in place of it: the dialog is *about* a row in the list, and hiding the list to ask about it would take away the context the question needs.
- Inert on rows the frecency backend doesn't own — a live tmux session, a `[[session]]` block, a tmuxinator config. It says "Only zoxide entries can be removed" on the line under the filter instead of opening a dialog it couldn't act on. Also inert while the list is still loading.
- The row disappears only once the removal actually succeeded. A backend that refuses it reports `Couldn't remove entry: …` and leaves the row in place, rather than showing a list that lies.
- The cursor stays put (pulled back when it sat on the last row) and the filter is preserved.

## Implementation

**`Zoxide.Remove`** is new, driven by a `remove_command` on `[frecency]` (default `zoxide remove {}`), so the alternative backends that table already supports — fasd, autojump, memy — can be wired up the same way as `list`/`query`/`add`. `sesh.schema.json` has the matching field so TOML editors keep autocompleting.

**The dialog is a mode on the picker model**: a `*confirmState` that is non-nil only while it is open, so its presence *is* the mode. It short-circuits both the key switch and `View`, the way index mode owns the digits. It lives in a new `picker/confirm.go` rather than growing `tui.go`, which is already ~1200 lines.

**The removal runs as a `tea.Cmd`**, not inline in `Update` — it shells out, and blocking the event loop would freeze the picker for as long as the command takes.

**The dropped row is matched on source *and* path**, not name: a zoxide directory and a live tmux session can share a name, and the one that was removed from the backend is the zoxide one.

**Cache write-through**: with `cache = true`, the cache is what the next launch reads, so `RealPicker.removeEntry` refreshes it behind a successful removal — otherwise the picker would list a directory the backend has already forgotten. Nil when caching is off. The refresh is deliberately outside the error path: the entry is gone either way, and a briefly stale cache is not a failed removal. `sesh picker` already `defer`s `CachingLister.Wait()`, so the background rewrite completes before the process exits.

## Tests

21 new tests. `zoxide/remove_test.go` covers the default command, a custom `fasd -D {}`, and error passthrough. `picker/confirm_test.go` covers every key in the dialog, all three inert cases, failure handling, the src+path match, filter and cursor preservation, the rendered dialog, and the cache-refresh wiring.

## Notes

- `ctrl+x` is not rebindable. No other picker key is, so this matches the existing bindings rather than inventing a keymap table.
- The cache refresh is async, matching what `sesh connect` does. Two removals in quick succession could have their revalidations land out of order, leaving the cache stale for up to the 5s soft TTL — self-healing, and the same race `sesh connect` already lives with. Making it synchronous would hold the `tea.Cmd` open while it re-listed tmux and zoxide, visibly delaying the row disappearing.
- `main` is merged in. Its `group_separator` work moved `offset` into row space, so `dropItem` re-derives the viewport with `scrollToCursor()` instead of nudging `offset` directly — otherwise the scroll would be off by one whenever a separator sat above the removed row.
