### PR TITLE
fix: read the client list tmux actually prints outside tmux

### DIFF
--- a/tmux/client.go
+++ b/tmux/client.go
@@ -1,6 +1,7 @@
 package tmux
 
 import (
+	"fmt"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -19,7 +20,20 @@ const seshClientEnv = "SESH_CLIENT"
 // normal pane inherits it, and tmux resolves the client from it exactly.
 const tmuxPaneEnv = "TMUX_PANE"
 
-const clientFormat = "#{client_name}\t#{client_tty}\t#{session_id}\t#{client_activity}"
+// clientFormat uses the same "::" separator as every other listing rather than
+// a tab, because tmux does not deliver a tab intact to a command client that
+// isn't attached: it sanitizes the control character to "_", so the whole line
+// arrives as a single field. That is exactly the GUI-launcher case — Leader
+// Key, Raycast, an osascript binding — where every client silently dropped out
+// of the list and sesh concluded nothing was attached to switch.
+var clientFormat = strings.Join([]string{
+	"#{client_name}",
+	"#{client_tty}",
+	"#{session_id}",
+	"#{client_activity}",
+}, separator)
+
+const clientFieldCount = 4
 
 func (t *RealTmux) ListClients() ([]model.TmuxClient, error) {
 	lines, err := t.shell.ListCmd(t.bin, "list-clients", "-F", clientFormat)
@@ -27,9 +41,14 @@ func (t *RealTmux) ListClients() ([]model.TmuxClient, error) {
 		return nil, err
 	}
 	clients := make([]model.TmuxClient, 0, len(lines))
+	unparsed := make([]string, 0, len(lines))
 	for _, line := range lines {
-		fields := strings.Split(line, "\t")
-		if len(fields) != 4 || fields[0] == "" {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		fields := strings.Split(line, separator)
+		if len(fields) != clientFieldCount || fields[0] == "" {
+			unparsed = append(unparsed, line)
 			continue
 		}
 		activity, _ := strconv.ParseInt(fields[3], 10, 64)
@@ -39,6 +58,12 @@ func (t *RealTmux) ListClients() ([]model.TmuxClient, error) {
 			SessionID: fields[2],
 			Activity:  activity,
 		})
+	}
+	// Clients tmux listed but sesh couldn't read must not look like a server
+	// with nothing attached: callers treat that as "nothing to switch" and
+	// report success without moving anything.
+	if len(clients) == 0 && len(unparsed) > 0 {
+		return nil, fmt.Errorf("tmux listed %d client(s) in an unreadable format: %q", len(unparsed), unparsed)
 	}
 	return clients, nil
 }

--- a/tmux/client_test.go
+++ b/tmux/client_test.go
@@ -36,9 +36,9 @@ func clientLines(lines ...string) []string {
 
 func TestResolveClient(t *testing.T) {
 	const (
-		onSession1   = "/dev/ttys001\t/dev/ttys001\t$1\t100"
-		onSession2   = "/dev/ttys002\t/dev/ttys002\t$2\t200"
-		alsoSession1 = "/dev/ttys003\t/dev/ttys003\t$1\t300"
+		onSession1   = "/dev/ttys001::/dev/ttys001::$1::100"
+		onSession2   = "/dev/ttys002::/dev/ttys002::$2::200"
+		alsoSession1 = "/dev/ttys003::/dev/ttys003::$1::300"
 	)
 
 	tests := []struct {
@@ -146,8 +146,8 @@ func TestSwitchOrAttachNamesTheResolvedClient(t *testing.T) {
 	mockOs.EXPECT().Getenv("TMUX").Return("/tmp/default,3746,1")
 	mockShell.EXPECT().ListCmd("tmux", "list-clients", "-F", clientFormat).
 		Return([]string{
-			"/dev/ttys001\t/dev/ttys001\t$1\t100",
-			"/dev/ttys002\t/dev/ttys002\t$2\t200",
+			"/dev/ttys001::/dev/ttys001::$1::100",
+			"/dev/ttys002::/dev/ttys002::$2::200",
 		}, nil)
 	mockShell.EXPECT().Cmd("tmux", "switch-client", "-c", "/dev/ttys001", "-t", "dotfiles").
 		Return("", nil)

--- a/tmux/tmux_test.go
+++ b/tmux/tmux_test.go
@@ -16,8 +16,8 @@ func TestListClients(t *testing.T) {
 	// an empty entry and has to be dropped.
 	s.EXPECT().ListCmd("tmux", "list-clients", "-F", clientFormat).
 		Return([]string{
-			"/dev/ttys001\t/dev/ttys001\t$1\t1788188899",
-			"/dev/ttys002\t/dev/ttys002\t$2\t1788188999",
+			"/dev/ttys001::/dev/ttys001::$1::1788188899",
+			"/dev/ttys002::/dev/ttys002::$2::1788188999",
 			"",
 		}, nil)
 	os := oswrap.NewMockOs(t)
@@ -28,6 +28,32 @@ func TestListClients(t *testing.T) {
 		{Name: "/dev/ttys001", TTY: "/dev/ttys001", SessionID: "$1", Activity: 1788188899},
 		{Name: "/dev/ttys002", TTY: "/dev/ttys002", SessionID: "$2", Activity: 1788188999},
 	}, clients)
+}
+
+// A client sesh cannot read is not a server with nothing attached. Reporting
+// it as no clients is how a GUI launcher ended up creating a session, focusing
+// the terminal, and never switching to it.
+func TestListClientsRejectsUnreadableLines(t *testing.T) {
+	s := shell.NewMockShell(t)
+	s.EXPECT().ListCmd("tmux", "list-clients", "-F", clientFormat).
+		Return([]string{"/dev/ttys001_/dev/ttys001_$1_1788188899", ""}, nil)
+	os := oswrap.NewMockOs(t)
+	tm := NewTmux(os, s, "")
+	_, err := tm.ListClients()
+	require.ErrorContains(t, err, "unreadable format")
+}
+
+// No clients at all is a real, readable answer: the server is up with nothing
+// attached.
+func TestListClientsWithNoClientsAttached(t *testing.T) {
+	s := shell.NewMockShell(t)
+	s.EXPECT().ListCmd("tmux", "list-clients", "-F", clientFormat).
+		Return([]string{""}, nil)
+	os := oswrap.NewMockOs(t)
+	tm := NewTmux(os, s, "")
+	clients, err := tm.ListClients()
+	require.NoError(t, err)
+	assert.Empty(t, clients)
 }
 
 func TestSwitchClientTarget(t *testing.T) {


### PR DESCRIPTION
## The bug

`sesh connect --switch` from a GUI launcher (Leader Key, Raycast, an osascript binding) created the session, brought the terminal forward, and exited 0 — but the client never moved.

`clientFormat` separated its fields with a tab, and tmux does not deliver a tab intact to a command client that isn't attached: it sanitizes the control character to `_`.

```
inside a pane:  /dev/ttys000\t/dev/ttys000\t$30\t1788537534
outside tmux:   /dev/ttys000_/dev/ttys000_$30_1788537534
```

So every line failed `ListClients`' four-field check and an empty slice came back **with no error**. `connectDetached` read that as a server with nothing attached and took the branch that only focuses the terminal.

Confirmed with an instrumented build, run with Leader Key's exact environment:

```
dbg: focusSession     session=sesh/w/468 doSwitch=true isAttached=false
dbg: ListClients raw  lines=["/dev/ttys000_/dev/ttys000_$30_1788537534",""] err=null
dbg: connectDetached  clients=[] err=null
```

This is the same symptom f4b8f61 set out to fix. Its new error path could not fire, because nothing had failed — the parse had simply dropped everyone.

## The fix

- `clientFormat` joins on the package's existing `"::"` separator, which every other listing (`list-sessions`, `list-windows`, `list-panes`) already uses. The tab was the outlier.
- `ListClients` stops swallowing lines it cannot parse. Blank lines are still skipped, but clients tmux listed and sesh could not read are now an error rather than an empty list — so a format mismatch can never again be indistinguishable from a server with no clients attached.

## Testing

- `just test` passes across all packages.
- New: `TestListClientsRejectsUnreadableLines` (mangled separator → error) and `TestListClientsWithNoClientsAttached` (empty output stays a legitimate empty list).
- Verified live from a bare environment matching Leader Key's PATH: client switched from `quill` to `sesh` and back.

Refs #451
